### PR TITLE
Handle external db servers

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -676,6 +676,7 @@
 
 	function pgsqlRunScriptFile($sFilename)
 	{
+		global $aCMDResult;
 		if (!file_exists($sFilename)) fail('unable to find '.$sFilename);
 
 		// Convert database DSN to psql parameters
@@ -691,6 +692,7 @@
 			2 => array('file', '/dev/null', 'a')
 		);
 		$ahPipes = null;
+		if ($aCMDResult['verbose']) echo "Running $sCMD\n";
 		$hProcess = proc_open($sCMD, $aDescriptors, $ahPipes);
 		if (!is_resource($hProcess)) fail('unable to start pgsql');
 
@@ -708,6 +710,7 @@
 
 	function pgsqlRunScript($sScript)
 	{
+		global $aCMDResult;
 		// Convert database DSN to psql parameters
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
@@ -720,6 +723,7 @@
 			2 => STDERR
 		);
 		$ahPipes = null;
+		if ($aCMDResult['verbose']) echo "Running $sCMD\n";
 		$hProcess = @proc_open($sCMD, $aDescriptors, $ahPipes);
 		if (!is_resource($hProcess)) fail('unable to start pgsql');
 
@@ -734,6 +738,7 @@
 
 	function pgsqlRunRestoreData($sDumpFile)
 	{
+		global $aCMDResult;
 		// Convert database DSN to psql parameters
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
@@ -747,6 +752,7 @@
 			2 => array('file', '/dev/null', 'a')
 		);
 		$ahPipes = null;
+		if ($aCMDResult['verbose']) echo "Running $sCMD\n";
 		$hProcess = proc_open($sCMD, $aDescriptors, $ahPipes);
 		if (!is_resource($hProcess)) fail('unable to start pg_restore');
 
@@ -764,6 +770,7 @@
 
 	function pgsqlRunDropAndRestore($sDumpFile)
 	{
+		global $aCMDResult;
 		// Convert database DSN to psql parameters
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
@@ -777,6 +784,7 @@
 			2 => array('file', '/dev/null', 'a')
 		);
 		$ahPipes = null;
+		if ($aCMDResult['verbose']) echo "Running $sCMD\n";
 		$hProcess = proc_open($sCMD, $aDescriptors, $ahPipes);
 		if (!is_resource($hProcess)) fail('unable to start pg_restore');
 

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -97,7 +97,10 @@
 		{
 			fail('database already exists ('.CONST_Database_DSN.')');
 		}
-		passthruCheckReturn('createdb -E UTF-8 -p '.$aDSNInfo['port'].' '.$aDSNInfo['database']);
+		$sCMD = 'createdb -E UTF-8 -p '.$aDSNInfo['port'].' '.$aDSNInfo['database'];
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
+		passthruCheckReturn($sCMD);
 	}
 
 	if ($aCMDResult['setup-db'] || $aCMDResult['all'])
@@ -115,8 +118,10 @@
 			echo "ERROR: PostgreSQL version is not correct.  Expected ".CONST_Postgresql_Version." found ".$aMatches[1].'.'.$aMatches[2]."\n";
 			exit;
 		}
-
-		passthru('createlang plpgsql -p '.$aDSNInfo['port'].' '.$aDSNInfo['database']);
+		$sCMD = 'createlang plpgsql -p '.$aDSNInfo['port'].' '.$aDSNInfo['database'];
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
+		passthru($sCMD);
 		$pgver = (float) CONST_Postgresql_Version;
 		if ($pgver < 9.1) {
 			pgsqlRunScriptFile(CONST_Path_Postgresql_Contrib.'/hstore.sql');

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -176,6 +176,8 @@
 		}
 		$osm2pgsql .= ' -lsc -O gazetteer --hstore';
 		$osm2pgsql .= ' -C '.$iCacheMemory;
+		if (isset($aDSNInfo['hostspec'])) $osm2pgsql .= ' -H '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $osm2pgsql .= ' -U '.$aDSNInfo['username'];
 		$osm2pgsql .= ' -P '.$aDSNInfo['port'];
 		$osm2pgsql .= ' -d '.$aDSNInfo['database'].' '.$aCMDResult['osm-file'];
 		passthruCheckReturn($osm2pgsql);
@@ -600,6 +602,8 @@
 		$sOutputFile = '';
 		if (isset($aCMDResult['index-output'])) $sOutputFile = ' -F '.$aCMDResult['index-output'];
 		$sBaseCmd = CONST_BasePath.'/nominatim/nominatim -i -d '.$aDSNInfo['database'].' -P '.$aDSNInfo['port'].' -t '.$iInstances.$sOutputFile;
+		if (isset($aDSNInfo['hostspec'])) $sBaseCmd .= ' -H '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sBaseCmd .= ' -U '.$aDSNInfo['username'];
 		passthruCheckReturn($sBaseCmd.' -R 4');
 		if (!$aCMDResult['index-noanalyse']) pgsqlRunScript('ANALYSE');
 		passthruCheckReturn($sBaseCmd.' -r 5 -R 25');
@@ -678,6 +682,8 @@
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
 		$sCMD = 'psql -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'].' -f '.$sFilename;
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
 
 		$aDescriptors = array(
 			0 => array('pipe', 'r'),
@@ -706,6 +712,8 @@
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
 		$sCMD = 'psql -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'];
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
 		$aDescriptors = array(
 			0 => array('pipe', 'r'),
 			1 => STDOUT, 
@@ -730,6 +738,8 @@
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
 		$sCMD = 'pg_restore -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'].' -Fc -a '.$sDumpFile;
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
 
 		$aDescriptors = array(
 			0 => array('pipe', 'r'),
@@ -758,6 +768,8 @@
 		$aDSNInfo = DB::parseDSN(CONST_Database_DSN);
 		if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
 		$sCMD = 'pg_restore -p '.$aDSNInfo['port'].' -d '.$aDSNInfo['database'].' -Fc --clean '.$sDumpFile;
+		if (isset($aDSNInfo['hostspec'])) $sCMD .= ' -h '.$aDSNInfo['hostspec'];
+		if (isset($aDSNInfo['username'])) $sCMD .= ' -U '.$aDSNInfo['username'];
 
 		$aDescriptors = array(
 			0 => array('pipe', 'r'),


### PR DESCRIPTION
This adds what I think is everything needed to work with an external database server.

It doesn't handle the installation of `nominatim.so`, and in fact, I'm trying to deploy to Amazon RDS, so there's no way to load a C extension and I've dummied the two functions in my attempts.

It should however do everything else needed.

Password prompts happen. Use `.pgpass`. 