### PR TITLE
fully evaluate reverse order of queries

### DIFF
--- a/lib/lib.php
+++ b/lib/lib.php
@@ -193,6 +193,26 @@
 		return $aResult;
 	}
 
+	function getInverseWordSets($aWords, $iDepth)
+	{
+		$aResult = array(array(join(' ',$aWords)));
+		$sFirstToken = '';
+		if ($iDepth < 8)
+		{
+			while(sizeof($aWords) > 1)
+			{
+				$sWord = array_pop($aWords);
+				$sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
+				$aRest = getInverseWordSets($aWords, $iDepth+1);
+				foreach($aRest as $aSet)
+				{
+					$aResult[] = array_merge(array($sFirstToken),$aSet);
+				}
+			}
+		}
+		return $aResult;
+	}
+
 
 	function getTokensFromSets($aSets)
 	{


### PR DESCRIPTION
Factors out computation of search group and calls the code once
for forward evaluation and once with reversed word order.

The existing tests pass but I'd like to have more tests that specifically tests reverse word order. Some performance evaluation would be good as well.