### PR TITLE
Add polygon simplification

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1618,7 +1618,16 @@
 					if ($this->bIncludePolygonAsKML) $sSQL .= ",ST_AsKML(geometry) as askml";
 					if ($this->bIncludePolygonAsSVG) $sSQL .= ",ST_AsSVG(geometry) as assvg";
 					if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ",ST_AsText(geometry) as astext";
-					$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry from placex where place_id = ".$aResult['place_id'].") as plx";
+					$sFrom = " from placex where place_id = ".$aResult['place_id'];
+					if ($this->fPolygonSimplificationThreshold > 0)
+					{
+						$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry".$sFrom.") as plx";
+					}
+					else
+					{
+						$sSQL .= $sFrom;
+					}
+
 					$aPointPolygon = $this->oDB->getRow($sSQL);
 					if (PEAR::IsError($aPointPolygon))
 					{

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -12,6 +12,7 @@
 		protected $bIncludePolygonAsGeoJSON = false;
 		protected $bIncludePolygonAsKML = false;
 		protected $bIncludePolygonAsSVG = false;
+		protected $fPolygonSimplificationThreshold = 0.0;
 
 		protected $aExcludePlaceIDs = array();
 		protected $bDeDupe = true;
@@ -100,6 +101,11 @@
 		function setIncludePolygonAsSVG($b = true)
 		{
 			$this->bIncludePolygonAsSVG = $b;
+		}
+
+		function setPolygonSimplificationThreshold($f)
+		{
+			$this->fPolygonSimplificationThreshold = $f;
 		}
 
 		function setDeDupe($bDeDupe = true)
@@ -1612,7 +1618,7 @@
 					if ($this->bIncludePolygonAsKML) $sSQL .= ",ST_AsKML(geometry) as askml";
 					if ($this->bIncludePolygonAsSVG) $sSQL .= ",ST_AsSVG(geometry) as assvg";
 					if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ",ST_AsText(geometry) as astext";
-					$sSQL .= " from placex where place_id = ".$aResult['place_id'];
+					$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry from placex where place_id = ".$aResult['place_id'].") as plx";
 					$aPointPolygon = $this->oDB->getRow($sSQL);
 					if (PEAR::IsError($aPointPolygon))
 					{

--- a/website/search.php
+++ b/website/search.php
@@ -44,6 +44,8 @@
 		$bAsKML = (boolean)isset($_GET['polygon_kml']) && $_GET['polygon_kml'];
 		$bAsSVG = (boolean)isset($_GET['polygon_svg']) && $_GET['polygon_svg'];
 		$bAsText = (boolean)isset($_GET['polygon_text']) && $_GET['polygon_text'];
+		$fThreshold = 0.0;
+		if (isset($_GET['polygon_threshold'])) $fThreshold = (float)$_GET['polygon_threshold'];
 		if ( ( ($bAsGeoJSON?1:0)
 		     + ($bAsKML?1:0)
 		     + ($bAsSVG?1:0)
@@ -66,6 +68,7 @@
 		$oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
 		$oGeocode->setIncludePolygonAsKML($bAsKML);
 		$oGeocode->setIncludePolygonAsSVG($bAsSVG);
+		$oGeocode->setPolygonSimplificationThreshold($fThreshold);
 	}
 
 	$oGeocode->loadParamArray($_GET);

--- a/website/search.php
+++ b/website/search.php
@@ -44,8 +44,6 @@
 		$bAsKML = (boolean)isset($_GET['polygon_kml']) && $_GET['polygon_kml'];
 		$bAsSVG = (boolean)isset($_GET['polygon_svg']) && $_GET['polygon_svg'];
 		$bAsText = (boolean)isset($_GET['polygon_text']) && $_GET['polygon_text'];
-		$fThreshold = 0.0;
-		if (isset($_GET['polygon_threshold'])) $fThreshold = (float)$_GET['polygon_threshold'];
 		if ( ( ($bAsGeoJSON?1:0)
 		     + ($bAsKML?1:0)
 		     + ($bAsSVG?1:0)
@@ -68,8 +66,12 @@
 		$oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
 		$oGeocode->setIncludePolygonAsKML($bAsKML);
 		$oGeocode->setIncludePolygonAsSVG($bAsSVG);
-		$oGeocode->setPolygonSimplificationThreshold($fThreshold);
 	}
+
+	// Polygon simplification threshold (optional)
+	$fThreshold = 0.0;
+	if (isset($_GET['polygon_threshold'])) $fThreshold = (float)$_GET['polygon_threshold'];
+	$oGeocode->setPolygonSimplificationThreshold($fThreshold);
 
 	$oGeocode->loadParamArray($_GET);
 


### PR DESCRIPTION
New query string parameter polygon_threshold=<0.0..1> is introduced.
The float value of this parameter (defaults to 0) is passed to
ST_SimplifyPreserveTopology() on geometry we're about to output in
one (or many) requested formats such as GeoJSON, KML, etc.

This is useful when getting border polygons for whole countries, but
rendering them at large scale, when most of the high resolution details
cannot be seen anyway.  For example, the unsimplified polygon data for
Germany in GeoJSON format currently makes for about 3 MB response body.
With use of this new parameter, the application can greatly reduce the
amount of downloaded data and server response time while providing its
users with the same picture.  On a typical laptop screen resolution,
zooming out to fit the whole country borders on screen, only 1/100 amount
of details could be well enough.