### PR TITLE
during reverse geocode lookup we also check the (optional) Tiger data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,6 @@ Nominatim was written by:
   Kurt Roeckx
   Rodolphe Quiédeville
   Marc Tobias Metten
+
+Reverse geocoding using Tiger data sponsored by
+  Linux training company, Guru Labs (https://www.gurulabs.com)

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,5 +16,4 @@ Nominatim was written by:
   Rodolphe Quiédeville
   Marc Tobias Metten
 
-Reverse geocoding using Tiger data sponsored by
-  Linux training company, Guru Labs (https://www.gurulabs.com)
+Reverse geocoding using Tiger data feature made possible with support from Guru Labs

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+ * reverse geocoding looking includes looking up Tiger data
+
+
 2.4
 
  * drop support for postgres 8.4

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -62,7 +62,7 @@
 			{
 				$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
 				$sSQL .= " 'us' as country_code, null as extratags, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
-				$sSQL .= " coalesce(0,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
+				$sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
 				$sSQL .= " get_address_by_language(place_id, $sLanguagePrefArraySQL) as langaddress,";
 				$sSQL .= " null as placename,";
 				$sSQL .= " null as ref,";

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -5,6 +5,8 @@
 
 		protected $iPlaceID;
 
+		protected $bIsTiger = false;
+
 		protected $aLangPrefOrder = array();
 
 		protected $bAddressDetails = false;
@@ -35,6 +37,11 @@
 			$this->iPlaceID = $this->oDB->getOne($sSQL);
 		}
 
+		function setIsTiger($b = false)
+		{
+			$this->bIsTiger = $b;
+		}
+
 		function lookup()
 		{
 			if (!$this->iPlaceID) return null;
@@ -49,12 +56,29 @@
 			$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
 			$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
 			$sSQL .= " from placex where place_id = ".(int)$this->iPlaceID;
+
+
+			if ($this->bIsTiger)
+			{
+				$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
+				$sSQL .= " 'us' as country_code, null as extratags, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
+				$sSQL .= " coalesce(0,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
+				$sSQL .= " get_address_by_language(place_id, $sLanguagePrefArraySQL) as langaddress,";
+				$sSQL .= " null as placename,";
+				$sSQL .= " null as ref,";
+				$sSQL .= " st_y(centroid) as lat,";
+				$sSQL .= " st_x(centroid) as lon";
+				$sSQL .= " from location_property_tiger where place_id = ".(int)$this->iPlaceID;
+			}
+
 			$aPlace = $this->oDB->getRow($sSQL);
+
 
 			if (PEAR::IsError($aPlace))
 			{
 				failInternalError("Could not lookup place.", $sSQL, $aPlace);
 			}
+
 			if (!$aPlace['place_id']) return null;
 
 			if ($this->bAddressDetails)
@@ -62,6 +86,7 @@
 				$aAddress = $this->getAddressNames();
 				$aPlace['aAddress'] = $aAddress;
 			}
+
 
 			$aClassType = getClassTypes();
 			$sAddressType = '';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -69,6 +69,7 @@
 		{
 			$sPointSQL = 'ST_SetSRID(ST_Point('.$this->fLon.','.$this->fLat.'),4326)';
 			$iMaxRank = $this->iMaxRank;
+			$iMaxRank_orig = $this->iMaxRank;
 
 			// Find the nearest point
 			$fSearchDiam = 0.0004;
@@ -112,9 +113,8 @@
 				$bIsInUnitedStates = ($aPlace['calculated_country_code'] == 'us');
 			}
 
-
 			// Only street found? If it's in the US we can check TIGER data for nearest housenumber
-			if ($bIsInUnitedStates && $iPlaceID && $aPlace['rank_search'] == 26) 
+			if ($bIsInUnitedStates && $iMaxRank_orig >= 28 && $iPlaceID && ($aPlace['rank_search'] == 26 || $aPlace['rank_search'] == 27 )) 
 			{
 				$fSearchDiam = 0.001;
 				$sSQL = 'SELECT place_id,parent_place_id,30 as rank_search ';

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -75,6 +75,8 @@
 			$iPlaceID = null;
 			$aArea = false;
 			$fMaxAreaDistance = 1;
+			$bIsInUnitedStates = false;
+			$bPlaceIsTiger = false;
 			while(!$iPlaceID && $fSearchDiam < $fMaxAreaDistance)
 			{
 				$fSearchDiam = $fSearchDiam * 2;
@@ -90,7 +92,7 @@
 				if ($fSearchDiam > 0.008 && $iMaxRank > 22) $iMaxRank = 22;
 				if ($fSearchDiam > 0.001 && $iMaxRank > 26) $iMaxRank = 26;
 
-				$sSQL = 'select place_id,parent_place_id,rank_search from placex';
+				$sSQL = 'select place_id,parent_place_id,rank_search,calculated_country_code from placex';
 				$sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
 				$sSQL .= ' and rank_search != 28 and rank_search >= '.$iMaxRank;
 				$sSQL .= ' and (name is not null or housenumber is not null)';
@@ -107,12 +109,53 @@
 				}
 				$iPlaceID = $aPlace['place_id'];
 				$iParentPlaceID = $aPlace['parent_place_id'];
+				$bIsInUnitedStates = ($aPlace['calculated_country_code'] == 'us');
+			}
+
+
+			// Only street found? If it's in the US we can check TIGER data for nearest housenumber
+			if ($bIsInUnitedStates && $iPlaceID && $aPlace['rank_search'] == 26) 
+			{
+				$fSearchDiam = 0.001;
+				$sSQL = 'SELECT place_id,parent_place_id,30 as rank_search ';
+				if (CONST_Debug) { $sSQL .= ', housenumber, ST_distance('.$sPointSQL.', centroid) as distance, st_y(centroid) as lat, st_x(centroid) as lon'; }
+				$sSQL .= ' FROM location_property_tiger WHERE parent_place_id = '.$iPlaceID;
+				$sSQL .= ' AND ST_DWithin('.$sPointSQL.', centroid, '.$fSearchDiam.')';
+				$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', centroid) ASC limit 1';
+
+
+				// print all house numbers in the parent (street)
+				if (CONST_Debug)
+				{
+					$sSQL = preg_replace('/limit 1/', 'limit 100', $sSQL);
+					var_dump($sSQL);
+
+					$aAllHouses = $this->oDB->getAll($sSQL);
+					foreach($aAllHouses as $i)
+					{
+						echo $i['housenumber'] . ' | ' . $i['distance'] * 1000 . ' | ' . $i['lat'] . ' | ' . $i['lon']. ' | '. "<br>\n";
+					}
+				}
+
+				$aPlaceTiger = $this->oDB->getRow($sSQL);
+				if (PEAR::IsError($aPlace))
+				{
+					failInternalError("Could not determine closest Tiger place.", $sSQL, $aPlaceTiger);
+				}
+				if ($aPlaceTiger)
+				{
+					if (CONST_Debug) var_dump('found Tiger place', $aPlaceTiger);
+					$bPlaceIsTiger = true;
+					$aPlace = $aPlaceTiger;
+					$iPlaceID = $aPlaceTiger['place_id'];
+					$iParentPlaceID = $aPlaceTiger['parent_place_id']; // the street
+				}
 			}
 
 			// The point we found might be too small - use the address to find what it is a child of
 			if ($iPlaceID && $iMaxRank < 28)
 			{
-				if ($aPlace['rank_search'] > 28 && $iParentPlaceID)
+				if ($aPlace['rank_search'] > 28 && $iParentPlaceID && !$bPlaceIsTiger)
 				{
 					$iPlaceID = $iParentPlaceID;
 				}
@@ -132,6 +175,7 @@
 			$oPlaceLookup->setLanguagePreference($this->aLangPrefOrder);
 			$oPlaceLookup->setIncludeAddressDetails($this->bAddressDetails);
 			$oPlaceLookup->setPlaceId($iPlaceID);
+			$oPlaceLookup->setIsTiger($bPlaceIsTiger);
 
 			return $oPlaceLookup->lookup();
 		}

--- a/tests/features/api/reverse.feature
+++ b/tests/features/api/reverse.feature
@@ -11,3 +11,23 @@ Feature: Reverse geocoding
          | ID | country
          | 0  | Deutschland
 
+    @Tiger
+    Scenario: TIGER house number
+        Given the request parameters
+          | addressdetails
+          | 1
+        When looking up jsonv2 coordinates 40.6863624710666,-112.060005720023
+        # Then exactly 1 result is returned
+        # Then result addresses contain
+        # | ID | house_number | road               | postcode | country_code
+        # | 0  | 7094         | Kings Estate Drive | 84128    | us
+        Then results contain
+          | type | house
+        And results contain
+          | addresstype | place
+        And results contain
+          | road | Kings Estate Drive
+        And results contain
+          | house_number | 7094
+        And results contain
+          | postcode | 84128

--- a/tests/features/api/reverse.feature
+++ b/tests/features/api/reverse.feature
@@ -16,18 +16,10 @@ Feature: Reverse geocoding
         Given the request parameters
           | addressdetails
           | 1
-        When looking up jsonv2 coordinates 40.6863624710666,-112.060005720023
-        # Then exactly 1 result is returned
-        # Then result addresses contain
-        # | ID | house_number | road               | postcode | country_code
-        # | 0  | 7094         | Kings Estate Drive | 84128    | us
-        Then results contain
-          | type | house
-        And results contain
-          | addresstype | place
-        And results contain
-          | road | Kings Estate Drive
-        And results contain
-          | house_number | 7094
-        And results contain
-          | postcode | 84128
+        When looking up coordinates 40.6863624710666,-112.060005720023
+        And exactly 1 result is returned
+        And result addresses contain
+          | ID | house_number | road               | postcode | country_code
+          | 0  | 7094         | Kings Estate Drive | 84128    | us
+        And result 0 has not attributes osm_id,osm_type
+


### PR DESCRIPTION
When we don't find a result with rank 30 (building name, house number etc) but find a road, then inside the US we also check the nearest Tiger house numbers who have the street as parent.

The `osm_type` is 'T' and the `osm_id` is the place_id. Not entirely sure if that makes sense but `Geocode.php` sets the same.

In `PlaceLookup.php` right after `if ($this->bIsTiger)` it would be possible to use a `UNION` to combine both SQL queries. But since it's a direct lookup by place_id and we already know the place is a Tiger place a single query is enough.

I've setup a server at http://46.101.149.108:9876/nominatim were you can test the results. For example http://46.101.149.108:9876/nominatim/reverse.php?format=xml&lat=40.6859534063625&lon=-112.055149368461 which will return `6882, Kings Estate Drive, West Valley City, Salt Lake County, 84128, United States of America`.

The server has only data loaded for the Salt Lake City, Utah area. See the bounding box on http://bboxfinder.com/#40.310949,-112.376404,41.391234,-111.549683 

This feature got sponsored/paid for by Guru Labs. Thanks a lot!