### PR TITLE
Add new parameters to export name and extratags information

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -226,8 +226,11 @@
 		function loadParamArray($aParams)
 		{
 			if (isset($aParams['addressdetails'])) $this->bIncludeAddressDetails = (bool)$aParams['addressdetails'];
-			if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool)$aParams['extratags'];
-			if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool)$aParams['namedetails'];
+			if ((float) CONST_Postgresql_Version > 9.2)
+			{
+				if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool)$aParams['extratags'];
+				if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool)$aParams['namedetails'];
+			}
 			if (isset($aParams['bounded'])) $this->bBoundedSearch = (bool)$aParams['bounded'];
 			if (isset($aParams['dedupe'])) $this->bDeDupe = (bool)$aParams['dedupe'];
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -5,11 +5,15 @@
 
 		protected $iPlaceID;
 
-		protected $bIsTiger = false;
+		protected $sType = false;
 
 		protected $aLangPrefOrder = array();
 
 		protected $bAddressDetails = false;
+
+		protected $bExtraTags = false;
+
+		protected $bNameDetails = false;
 
 		function PlaceLookup(&$oDB)
 		{
@@ -26,6 +30,22 @@
 			$this->bAddressDetails = $bAddressDetails;
 		}
 
+		function setIncludeExtraTags($bExtraTags = false)
+		{
+			if ((float) CONST_Postgresql_Version > 9.2)
+			{
+				$this->bExtraTags = $bExtraTags;
+			}
+		}
+
+		function setIncludeNameDetails($bNameDetails = false)
+		{
+			if ((float) CONST_Postgresql_Version > 9.2)
+			{
+				$this->bNameDetails = $bNameDetails;
+			}
+		}
+
 		function setPlaceID($iPlaceID)
 		{
 			$this->iPlaceID = $iPlaceID;
@@ -37,9 +57,16 @@
 			$this->iPlaceID = $this->oDB->getOne($sSQL);
 		}
 
-		function setIsTiger($b = false)
+		function lookupPlace($details)
 		{
-			$this->bIsTiger = $b;
+			if (isset($details['place_id'])) $this->iPlaceID = $details['place_id'];
+			if (isset($details['type'])) $this->sType = $details['type'];
+			if (isset($details['osm_type']) && isset($details['osm_id']))
+			{
+				$this->setOSMID($details['osm_type'], $details['osm_id']);
+			}
+
+			return $this->lookup();
 		}
 
 		function lookup()
@@ -48,27 +75,32 @@
 
 			$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
 
-			$sSQL = "select placex.place_id, partition, osm_type, osm_id, class, type, admin_level, housenumber, street, isin, postcode, country_code, extratags, parent_place_id, linked_place_id, rank_address, rank_search, ";
-			$sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
-			$sSQL .= " get_address_by_language(place_id, $sLanguagePrefArraySQL) as langaddress,";
-			$sSQL .= " get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
-			$sSQL .= " get_name_by_language(name, ARRAY['ref']) as ref,";
-			$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
-			$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
-			$sSQL .= " from placex where place_id = ".(int)$this->iPlaceID;
-
-
-			if ($this->bIsTiger)
+			if ($this->sType == 'tiger')
 			{
 				$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
-				$sSQL .= " 'us' as country_code, null as extratags, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
+				$sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
 				$sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
 				$sSQL .= " get_address_by_language(place_id, $sLanguagePrefArraySQL) as langaddress,";
 				$sSQL .= " null as placename,";
 				$sSQL .= " null as ref,";
+				if ($this->bExtraTags) $sSQL .= " null as extra,";
+				if ($this->bNameDetails) $sSQL .= " null as names,";
 				$sSQL .= " st_y(centroid) as lat,";
 				$sSQL .= " st_x(centroid) as lon";
 				$sSQL .= " from location_property_tiger where place_id = ".(int)$this->iPlaceID;
+			}
+			else
+			{
+				$sSQL = "select placex.place_id, partition, osm_type, osm_id, class, type, admin_level, housenumber, street, isin, postcode, country_code, parent_place_id, linked_place_id, rank_address, rank_search, ";
+				$sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
+				$sSQL .= " get_address_by_language(place_id, $sLanguagePrefArraySQL) as langaddress,";
+				$sSQL .= " get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
+				$sSQL .= " get_name_by_language(name, ARRAY['ref']) as ref,";
+				if ($this->bExtraTags) $sSQL .= " hstore_to_json(extratags) as extra,";
+				if ($this->bNameDetails) $sSQL .= " hstore_to_json(name) as names,";
+				$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
+				$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
+				$sSQL .= " from placex where place_id = ".(int)$this->iPlaceID;
 			}
 
 			$aPlace = $this->oDB->getRow($sSQL);
@@ -87,6 +119,29 @@
 				$aPlace['aAddress'] = $aAddress;
 			}
 
+			if ($this->bExtraTags)
+			{
+				if ($aPlace['extra'])
+				{
+					$aPlace['sExtraTags'] = json_decode($aPlace['extra']);
+				}
+				else
+				{
+					$aPlace['sExtraTags'] = array();
+				}
+			}
+
+			if ($this->bNameDetails)
+			{
+				if ($aPlace['names'])
+				{
+					$aPlace['sNameDetails'] = json_decode($aPlace['names']);
+				}
+				else
+				{
+					$aPlace['sNameDetails'] = array();
+				}
+			}
 
 			$aClassType = getClassTypes();
 			$sAddressType = '';
@@ -129,7 +184,7 @@
 
 		function getAddressNames()
 		{
-			$aAddressLines = $this->getAddressDetails(false);;
+			$aAddressLines = $this->getAddressDetails(false);
 
 			$aAddress = array();
 			$aFallback = array();

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -9,8 +9,6 @@
 
 		protected $aLangPrefOrder = array();
 
-		protected $bShowAddressDetails = true;
-
 		function ReverseGeocode(&$oDB)
 		{
 			$this->oDB =& $oDB;
@@ -19,11 +17,6 @@
 		function setLanguagePreference($aLangPref)
 		{
 			$this->aLangPrefOrder = $aLangPref;
-		}
-
-		function setIncludeAddressDetails($bAddressDetails = true)
-		{
-			$this->bAddressDetails = $bAddressDetails;
 		}
 
 		function setLatLon($fLat, $fLon)
@@ -171,13 +164,8 @@
 				}
 			}
 
-			$oPlaceLookup = new PlaceLookup($this->oDB);
-			$oPlaceLookup->setLanguagePreference($this->aLangPrefOrder);
-			$oPlaceLookup->setIncludeAddressDetails($this->bAddressDetails);
-			$oPlaceLookup->setPlaceId($iPlaceID);
-			$oPlaceLookup->setIsTiger($bPlaceIsTiger);
-
-			return $oPlaceLookup->lookup();
+			return array('place_id' => $iPlaceID,
+					     'type' => $bPlaceIsTiger ? 'tiger' : 'osm');
 		}
 	}
 ?>

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -39,6 +39,12 @@
 		exit;
 	}
 
+	function getParamBool($name, $default=false)
+	{
+		if (!isset($_GET[$name])) return $default;
+
+		return (bool) $_GET[$name];
+	}
 
 	function fail($sError, $sUserError = false)
 	{
@@ -668,12 +674,11 @@
 	}
 
 
-	function javascript_renderData($xVal)
+	function javascript_renderData($xVal, $iOptions = 0)
 	{
 		header("Access-Control-Allow-Origin: *");
-		$iOptions = 0;
 		if (defined('PHP_VERSION_ID') && PHP_VERSION_ID > 50400)
-			$iOptions = JSON_UNESCAPED_UNICODE;
+			$iOptions |= JSON_UNESCAPED_UNICODE;
 		$jsonout = json_encode($xVal, $iOptions);
 
 		if( ! isset($_GET['json_callback']))

--- a/lib/template/address-json.php
+++ b/lib/template/address-json.php
@@ -10,7 +10,7 @@
 	}
 	else
 	{
-		if ($aPlace['place_id']) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
+		if (isset($aPlace['place_id'])) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
 		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
                 if ($sOSMType)
@@ -21,8 +21,10 @@
                 if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
                 if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
 		$aFilteredPlaces['display_name'] = $aPlace['langaddress'];
-		if ($bShowAddressDetails) $aFilteredPlaces['address'] = $aPlace['aAddress'];
+		if (isset($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
+		if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];
+		if (isset($aPlace['sNameDetails'])) $aFilteredPlaces['namedetails'] = $aPlace['sNameDetails'];
 	}
 
-	javascript_renderData($aFilteredPlaces);
+	javascript_renderData($aFilteredPlaces, JSON_FORCE_OBJECT);
 

--- a/lib/template/address-jsonv2.php
+++ b/lib/template/address-jsonv2.php
@@ -23,16 +23,19 @@
 
 		$aFilteredPlaces['place_rank'] = $aPlace['rank_search'];
 
-                $aFilteredPlaces['category'] = $aPlace['class'];
-                $aFilteredPlaces['type'] = $aPlace['type'];
+		$aFilteredPlaces['category'] = $aPlace['class'];
+		$aFilteredPlaces['type'] = $aPlace['type'];
 
 		$aFilteredPlaces['importance'] = $aPlace['importance'];
 
-                $aFilteredPlaces['addresstype'] = strtolower($aPlace['addresstype']);
+		$aFilteredPlaces['addresstype'] = strtolower($aPlace['addresstype']);
 
 		$aFilteredPlaces['display_name'] = $aPlace['langaddress'];
-                $aFilteredPlaces['name'] = $aPlace['placename'];
-		if ($bShowAddressDetails && $aPlace['aAddress'] && sizeof($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
+		$aFilteredPlaces['name'] = $aPlace['placename'];
+
+		if (isset($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
+		if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];
+		if (isset($aPlace['sNameDetails'])) $aFilteredPlaces['namedetails'] = $aPlace['sNameDetails'];
 	}
 
-	javascript_renderData($aFilteredPlaces);
+	javascript_renderData($aFilteredPlaces, JSON_FORCE_OBJECT);

--- a/lib/template/address-xml.php
+++ b/lib/template/address-xml.php
@@ -29,7 +29,8 @@
 		if (isset($aPlace['lon'])) echo ' lon="'.htmlspecialchars($aPlace['lon']).'"';
 		echo ">".htmlspecialchars($aPlace['langaddress'])."</result>";
 
-		if ($bShowAddressDetails) {
+		if (isset($aPlace['aAddress']))
+		{
 			echo "<addressparts>";
 			foreach($aPlace['aAddress'] as $sKey => $sValue)
 			{
@@ -39,6 +40,30 @@
 				echo "</$sKey>";
 			}
 			echo "</addressparts>";
+		}
+
+		if (isset($aPlace['sExtraTags']))
+		{
+			echo "<extratags>";
+			foreach ($aPlace['sExtraTags'] as $sKey => $sValue)
+			{
+				echo '<tag key="'.htmlspecialchars($sKey).'">';
+				echo htmlspecialchars($sValue);
+				echo "</tag>";
+			}
+			echo "</extratags>";
+		}
+
+		if (isset($aPlace['sNameDetails']))
+		{
+			echo "<namedetails>";
+			foreach ($aPlace['sNameDetails'] as $sKey => $sValue)
+			{
+				echo '<name key="'.htmlspecialchars($sKey).'">';
+				echo htmlspecialchars($sValue);
+				echo "</name>";
+			}
+			echo "</namedetails>";
 		}
 	}
 

--- a/lib/template/address-xml.php
+++ b/lib/template/address-xml.php
@@ -47,9 +47,7 @@
 			echo "<extratags>";
 			foreach ($aPlace['sExtraTags'] as $sKey => $sValue)
 			{
-				echo '<tag key="'.htmlspecialchars($sKey).'">';
-				echo htmlspecialchars($sValue);
-				echo "</tag>";
+				echo '<tag key="'.htmlspecialchars($sKey).'" value="'.htmlspecialchars($sValue).'"/>';
 			}
 			echo "</extratags>";
 		}
@@ -59,7 +57,7 @@
 			echo "<namedetails>";
 			foreach ($aPlace['sNameDetails'] as $sKey => $sValue)
 			{
-				echo '<name key="'.htmlspecialchars($sKey).'">';
+				echo '<name desc="'.htmlspecialchars($sKey).'">';
 				echo htmlspecialchars($sValue);
 				echo "</name>";
 			}

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -74,6 +74,9 @@
 			$aPlace['geokml'] = $aPointDetails['askml'];
 		}
 
+		if (isset($aPointDetails['sExtraTags'])) $aPlace['extratags'] = $aPointDetails['sExtraTags'];
+		if (isset($aPointDetails['sNameDetails'])) $aPlace['namedetails'] = $aPointDetails['sNameDetails'];
+
 		$aFilteredPlaces[] = $aPlace;
 	}
 

--- a/lib/template/search-jsonv2.php
+++ b/lib/template/search-jsonv2.php
@@ -73,6 +73,9 @@
                         $aPlace['geokml'] = $aPointDetails['askml'];
                 }
 
+		if (isset($aPointDetails['sExtraTags'])) $aPlace['extratags'] = $aPointDetails['sExtraTags'];
+		if (isset($aPointDetails['sNameDetails'])) $aPlace['namedetails'] = $aPointDetails['sNameDetails'];
+
 		$aFilteredPlaces[] = $aPlace;
 	}
 

--- a/lib/template/search-xml.php
+++ b/lib/template/search-xml.php
@@ -88,20 +88,59 @@
 			echo " icon='".htmlspecialchars($aResult['icon'], ENT_QUOTES)."'";
 		}
 
-		if (isset($aResult['address']) || isset($aResult['askml']))
-		{
-			echo ">";
-		}
+		$bHasDelim = false;
 
 		if (isset($aResult['askml']))
 		{
+			if (!$bHasDelim)
+			{
+				$bHasDelim = true;
+				echo ">";
+			}
 			echo "\n<geokml>";
 			echo $aResult['askml'];
 			echo "</geokml>";
 		}
 
+		if (isset($aResult['sExtraTags']))
+		{
+			if (!$bHasDelim)
+			{
+				$bHasDelim = true;
+				echo ">";
+			}
+			echo "\n<extratags>";
+			foreach ($aResult['sExtraTags'] as $sKey => $sValue)
+			{
+				echo '<tag key="'.htmlspecialchars($sKey).'" value="'.htmlspecialchars($sValue).'"/>';
+			}
+			echo "</extratags>";
+		}
+
+		if (isset($aResult['sNameDetails']))
+		{
+			if (!$bHasDelim)
+			{
+				$bHasDelim = true;
+				echo ">";
+			}
+			echo "\n<namedetails>";
+			foreach ($aResult['sNameDetails'] as $sKey => $sValue)
+			{
+				echo '<name desc="'.htmlspecialchars($sKey).'">';
+				echo htmlspecialchars($sValue);
+				echo "</name>";
+			}
+			echo "</namedetails>";
+		}
+
 		if (isset($aResult['address']))
 		{
+			if (!$bHasDelim)
+			{
+				$bHasDelim = true;
+				echo ">";
+			}
 			echo "\n";
 			foreach($aResult['address'] as $sKey => $sValue)
 			{
@@ -112,7 +151,7 @@
 			}
 		}
 
-		if (isset($aResult['address']) || isset($aResult['askml']))
+		if ($bHasDelim)
 		{
 			echo "</place>";
 		}

--- a/tests/features/api/reverse.feature
+++ b/tests/features/api/reverse.feature
@@ -36,3 +36,28 @@ Feature: Reverse geocoding
           | 0  | Kings Estate Drive | 84128    | us
         And result 0 has attributes osm_id,osm_type
 
+   Scenario Outline: Reverse Geocoding with extratags
+        Given the request parameters
+          | extratags
+          | 1
+        When looking up <format> coordinates 48.86093,2.2978
+        Then result 0 has attributes extratags
+
+   Examples:
+        | format
+        | xml
+        | json
+        | jsonv2
+
+   Scenario Outline: Reverse Geocoding with namedetails
+        Given the request parameters
+          | namedetails
+          | 1
+        When looking up <format> coordinates 48.86093,2.2978
+        Then result 0 has attributes namedetails
+
+   Examples:
+        | format
+        | xml
+        | json
+        | jsonv2

--- a/tests/features/api/search_params.feature
+++ b/tests/features/api/search_params.feature
@@ -70,7 +70,7 @@ Feature: Search queries
         Then result addresses contain
           | ID | city
           | 0  | Chicago
-    
+
     Scenario: No POI search with unbounded viewbox
         Given the request parameters
           | viewbox
@@ -202,3 +202,31 @@ Feature: Search queries
         | 0.5
         | 999
         | nan
+
+    Scenario Outline: Search with extratags
+        Given the request parameters
+          | extratags
+          | 1
+        When sending <format> search query "Hauptstr"
+        Then result 0 has attributes extratags
+        And result 1 has attributes extratags
+
+    Examples:
+        | format
+        | xml
+        | json
+        | jsonv2
+
+    Scenario Outline: Search with namedetails
+        Given the request parameters
+          | namedetails
+          | 1
+        When sending <format> search query "Hauptstr"
+        Then result 0 has attributes namedetails
+        And result 1 has attributes namedetails
+
+    Examples:
+        | format
+        | xml
+        | json
+        | jsonv2

--- a/tests/features/api/search_simple.feature
+++ b/tests/features/api/search_simple.feature
@@ -51,6 +51,10 @@ Feature: Simple Tests
      | limit            | 1000
      | dedupe           | 1
      | dedupe           | 0
+     | extratags        | 1
+     | extratags        | 0
+     | namedetails      | 1
+     | namedetails      | 0
 
     Scenario: Search with invalid output format
         Given the request parameters

--- a/tests/steps/api_setup.py
+++ b/tests/steps/api_setup.py
@@ -10,6 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 def api_call(requesttype):
+    world.request_type = requesttype
     world.json_callback = None
     data = urllib.urlencode(world.params)
     url = "%s/%s?%s" % (world.config.base_url, requesttype, data)

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -27,10 +27,6 @@
 		$sOutputFormat = $_GET['format'];
 	}
 
-	// Show address breakdown
-	$bShowAddressDetails = true;
-	if (isset($_GET['addressdetails'])) $bShowAddressDetails = (bool)$_GET['addressdetails'];
-
 	// Preferred language
 	$aLangPrefOrder = getPreferredLanguages();
 
@@ -42,7 +38,9 @@
 	{
 		$oPlaceLookup = new PlaceLookup($oDB);
 		$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-		$oPlaceLookup->setIncludeAddressDetails($bShowAddressDetails);
+		$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
+		$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
+		$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 		
 		$aOsmIds = explode(',', $_GET['osm_ids']);
 		

--- a/website/search.php
+++ b/website/search.php
@@ -126,6 +126,8 @@
 	if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) $sMoreURL .= '&accept-language='.$_SERVER["HTTP_ACCEPT_LANGUAGE"];
 	if ($bShowPolygons) $sMoreURL .= '&polygon=1';
 	if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';
+	if ($oGeocode->getIncludeExtraTags()) $sMoreURL .= '&extratags=1';
+	if ($oGeocode->getIncludeNameDetails()) $sMoreURL .= '&namedetails=1';
 	if ($sViewBox) $sMoreURL .= '&viewbox='.urlencode($sViewBox);
 	if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float)$_GET['nearlat'].'&nearlon='.(float)$_GET['nearlon'];
 	$sMoreURL .= '&q='.urlencode($sQuery);


### PR DESCRIPTION
Adds two parameters `namedetails` and `extratags` are added to search, reverse and lookup. When set the name and extratags hstore content is added to the result. This works only for postgresql >= 9.3 because it uses hstore_to_json() for convenience.

Fixes #304.