### PR TITLE
make map tile layer configurable

### DIFF
--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -112,9 +112,11 @@
   <?php
 
     $aNominatimMapInit = [
-      'zoom' => isset($_GET['zoom'])?htmlspecialchars($_GET['zoom']):NULL,
-      'lat'  => isset($_GET['lat'] )?htmlspecialchars($_GET['lat']):NULL,
-      'lon'  => isset($_GET['lon'] )?htmlspecialchars($_GET['lon']):NULL
+      'zoom' => isset($_GET['zoom']) ? htmlspecialchars($_GET['zoom']) : CONST_Default_Zoom,
+      'lat'  => isset($_GET['lat'] ) ? htmlspecialchars($_GET['lat'] ) : CONST_Default_Lat,
+      'lon'  => isset($_GET['lon'] ) ? htmlspecialchars($_GET['lon'] ) : CONST_Default_Lon,
+      'tile_url' => $sTileURL,
+      'tile_attribution' => $sTileAttribution
     ];
     echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -6,7 +6,6 @@
 	<link href="css/details.css" rel="stylesheet" type="text/css" />
 </head>
 
-<?php include(CONST_BasePath.'/lib/template/includes/html-top-navigation.php'); ?>
 
 
 <?php
@@ -114,6 +113,7 @@
 
 
 <body id="details-page">
+	<?php include(CONST_BasePath.'/lib/template/includes/html-top-navigation.php'); ?>
 	<div class="container">
 		<div class="row">
 			<div class="col-sm-10">
@@ -261,13 +261,23 @@
 	</div>
 
 	<script type="text/javascript">
+	<?php
 
-		var nominatim_result = {
-			outlinestring: '<?php echo $aPointDetails['outlinestring'];?>',
-			lon: <?php echo $aPointDetails['lon'];?>,
-			lat: <?php echo $aPointDetails['lat'];?>,
-		};
+    $aNominatimMapInit = [
+      'tile_url' => $sTileURL,
+      'tile_attribution' => $sTileAttribution
+    ];
+    echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 
+    $aPlace = [
+			'outlinestring' => $aPointDetails['outlinestring'],
+			'lon' => $aPointDetails['lon'],
+			'lat' => $aPointDetails['lat'],
+    ];
+	  echo 'var nominatim_result = ' . json_encode($aPlace, JSON_PRETTY_PRINT) . ';'; 
+
+
+  ?>
 	</script>
 
 

--- a/lib/template/search-html.php
+++ b/lib/template/search-html.php
@@ -99,7 +99,9 @@
 		$aNominatimMapInit = [
 			'zoom' => $iZoom,
 			'lat' => $fLat,
-			'lon' => $fLon
+			'lon' => $fLon,
+			'tile_url' => $sTileURL,
+			'tile_attribution' => $sTileAttribution
 		];
 		echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -91,6 +91,8 @@
 	@define('CONST_Default_Lat', 20.0);
 	@define('CONST_Default_Lon', 0.0);
 	@define('CONST_Default_Zoom', 2);
+	@define('CONST_Map_Tile_URL', 'http://{s}.tile.osm.org/{z}/{x}/{y}.png');
+	@define('CONST_Map_Tile_Attribution', ''); // Set if tile source isn't osm.org
 
 	@define('CONST_Search_AreaPolygons_Enabled', true);
 	@define('CONST_Search_AreaPolygons', true);
@@ -114,3 +116,5 @@
 	@define('CONST_Log_File_Format', 'TODO'); // Currently hard coded
 	@define('CONST_Log_File_SearchLog', '');
 	@define('CONST_Log_File_ReverseLog', '');
+
+

--- a/website/details.php
+++ b/website/details.php
@@ -127,4 +127,7 @@
 
 	logEnd($oDB, $hLog, 1);
 
+	$sTileURL = CONST_Map_Tile_URL;
+	$sTileAttribution = CONST_Map_Tile_Attribution;
+	
 	include(CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php');

--- a/website/js/nominatim-ui.js
+++ b/website/js/nominatim-ui.js
@@ -10,30 +10,23 @@ jQuery(document).on('ready', function(){
 	$('#q').focus();
 
 	map = new L.map('map', {
-				attributionControl: false, // moved to page footer
+				attributionControl: (nominatim_map_init.tile_attribution && nominatim_map_init.tile_attribution.length),
 				scrollWheelZoom:    !L.Browser.touch,
 				touchZoom:          false
 			});
 
-
-
-	L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-		noWrap: true // otherwise we end up with click coordinates like latitude -728
+	L.tileLayer(nominatim_map_init.tile_url, {
+		noWrap: true, // otherwise we end up with click coordinates like latitude -728
 		// moved to footer
-		// attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+		attribution: (nominatim_map_init.tile_attribution || null ) //'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 
-	if ( nominatim_map_init.lat ){
-		map.setView([nominatim_map_init.lat || 0, nominatim_map_init.lon], nominatim_map_init.zoom);
+	map.setView([nominatim_map_init.lat, nominatim_map_init.lon], nominatim_map_init.zoom);
 
-		if ( is_reverse_search ){
-			// not really a market, but the .circle changes radius once you zoom in/out
-			var cm = L.circleMarker([nominatim_map_init.lat,nominatim_map_init.lon], { radius: 5, weight: 2, fillColor: '#ff7800', color: 'red', opacity: 0.75, clickable: false});
-			cm.addTo(map);
-		}
-
-	} else {
-		map.setView([0,0],2);
+	if ( is_reverse_search ){
+		// We don't need a marker, but an L.circle instance changes radius once you zoom in/out
+		var cm = L.circleMarker([nominatim_map_init.lat,nominatim_map_init.lon], { radius: 5, weight: 2, fillColor: '#ff7800', color: 'red', opacity: 0.75, clickable: false});
+		cm.addTo(map);
 	}
 
 
@@ -188,15 +181,17 @@ jQuery(document).on('ready', function(){
 		map = new L.map('map', {
 					// center: [nominatim_map_init.lat, nominatim_map_init.lon],
 					// zoom:   nominatim_map_init.zoom,
-					attributionControl: false,
+					attributionControl: (nominatim_map_init.tile_attribution && nominatim_map_init.tile_attribution.length),
 					scrollWheelZoom:    false,
 					touchZoom:          false,
 				});
 
-		L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+
+		L.tileLayer(nominatim_map_init.tile_url, {
 			// moved to footer
-			// attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+			attribution: (nominatim_map_init.tile_attribution || null ) //'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 		}).addTo(map);
+
 
 		var layerGroup = new L.layerGroup().addTo(map);
 

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -76,4 +76,6 @@
 		exit;
 	}
 
+	$sTileURL = CONST_Map_Tile_URL;
+	$sTileAttribution = CONST_Map_Tile_Attribution;
 	include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');

--- a/website/search.php
+++ b/website/search.php
@@ -13,6 +13,8 @@
 	$fLat = CONST_Default_Lat;
 	$fLon = CONST_Default_Lon;
 	$iZoom = CONST_Default_Zoom;
+	$sTileURL = CONST_Map_Tile_URL;
+	$sTileAttribution = CONST_Map_Tile_Attribution;
 
 	$oGeocode =& new Geocode($oDB);
 


### PR DESCRIPTION
* adds two new settings for tile URL and tile attribution
* makes sure the existing default lat/lon are observed (they weren't)
* fixes a HTML syntax issue (navigation printed when <body> tag wasn't open yet)

I believe this issue https://github.com/twain47/Nominatim/issues/65 can be closed.

During testing I added these lines to my `settings/local.php` file

    @define('CONST_Default_Lat', 52.52); // Berlin
    @define('CONST_Default_Lon', 13.40);
    @define('CONST_Default_Zoom', 9);
    @define('CONST_Map_Tile_URL', 'https://{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png');
    @define('CONST_Map_Tile_Attribution', 'Map tiles © <a href="http://www.thunderforest.com">Thunderforest</a>');