### PR TITLE
spaces-to-tabs for all *.php files

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -478,15 +478,15 @@
 		function getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases)
 		{
 			/*
-			   Calculate all searches using aValidTokens i.e.
-			   'Wodsworth Road, Sheffield' =>
+				 Calculate all searches using aValidTokens i.e.
+				 'Wodsworth Road, Sheffield' =>
 
-			   Phrase Wordset
-			   0      0       (wodsworth road)
-			   0      1       (wodsworth)(road)
-			   1      0       (sheffield)
+				 Phrase Wordset
+				 0      0       (wodsworth road)
+				 0      1       (wodsworth)(road)
+				 1      0       (sheffield)
 
-			   Score how good the search is so they can be ordered
+				 Score how good the search is so they can be ordered
 			 */
 			foreach($aPhrases as $iPhrase => $sPhrase)
 			{
@@ -755,32 +755,32 @@
 		/* Perform the actual query lookup.
 
 			Returns an ordered list of results, each with the following fields:
-			  osm_type: type of corresponding OSM object
+				osm_type: type of corresponding OSM object
 							N - node
 							W - way
 							R - relation
 							P - postcode (internally computed)
-			  osm_id: id of corresponding OSM object
-			  class: general object class (corresponds to tag key of primary OSM tag)
-			  type: subclass of object (corresponds to tag value of primary OSM tag)
-			  admin_level: see http://wiki.openstreetmap.org/wiki/Admin_level
-			  rank_search: rank in search hierarchy
+				osm_id: id of corresponding OSM object
+				class: general object class (corresponds to tag key of primary OSM tag)
+				type: subclass of object (corresponds to tag value of primary OSM tag)
+				admin_level: see http://wiki.openstreetmap.org/wiki/Admin_level
+				rank_search: rank in search hierarchy
 							(see also http://wiki.openstreetmap.org/wiki/Nominatim/Development_overview#Country_to_street_level)
-			  rank_address: rank in address hierarchy (determines orer in address)
-			  place_id: internal key (may differ between different instances)
-			  country_code: ISO country code
-			  langaddress: localized full address
-			  placename: localized name of object
-			  ref: content of ref tag (if available)
-			  lon: longitude
-			  lat: latitude
-			  importance: importance of place based on Wikipedia link count
-			  addressimportance: cumulated importance of address elements
-			  extra_place: type of place (for admin boundaries, if there is a place tag)
-			  aBoundingBox: bounding Box
-			  label: short description of the object class/type (English only) 
-			  name: full name (currently the same as langaddress)
-			  foundorder: secondary ordering for places with same importance
+				rank_address: rank in address hierarchy (determines orer in address)
+				place_id: internal key (may differ between different instances)
+				country_code: ISO country code
+				langaddress: localized full address
+				placename: localized name of object
+				ref: content of ref tag (if available)
+				lon: longitude
+				lat: latitude
+				importance: importance of place based on Wikipedia link count
+				addressimportance: cumulated importance of address elements
+				extra_place: type of place (for admin boundaries, if there is a place tag)
+				aBoundingBox: bounding Box
+				label: short description of the object class/type (English only) 
+				name: full name (currently the same as langaddress)
+				foundorder: secondary ordering for places with same importance
 		*/
 		function lookup()
 		{
@@ -863,8 +863,8 @@
 				// Start with a blank search
 				$aSearches = array(
 					array('iSearchRank' => 0, 'iNamePhrase' => -1, 'sCountryCode' => false, 'aName'=>array(), 'aAddress'=>array(), 'aFullNameAddress'=>array(),
-					      'aNameNonSearch'=>array(), 'aAddressNonSearch'=>array(),
-					      'sOperator'=>'', 'aFeatureName' => array(), 'sClass'=>'', 'sType'=>'', 'sHouseNumber'=>'', 'fLat'=>'', 'fLon'=>'', 'fRadius'=>'')
+								'aNameNonSearch'=>array(), 'aAddressNonSearch'=>array(),
+								'sOperator'=>'', 'aFeatureName' => array(), 'sClass'=>'', 'sType'=>'', 'sHouseNumber'=>'', 'fLat'=>'', 'fLon'=>'', 'fRadius'=>'')
 				);
 
 				// Do we have a radius search?
@@ -1194,8 +1194,8 @@
 								{
 									$sSQL = "select place_id from placex where calculated_country_code='".$aSearch['sCountryCode']."' and rank_search = 4";
 									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-                                    if ($bBoundingBoxSearch)
-                                        $sSQL .= " and _st_intersects($this->sViewboxSmallSQL, geometry)";
+									if ($bBoundingBoxSearch)
+										$sSQL .= " and _st_intersects($this->sViewboxSmallSQL, geometry)";
 									$sSQL .= " order by st_area(geometry) desc limit 1";
 									if (CONST_Debug) var_dump($sSQL);
 									$aPlaceIDs = $this->oDB->getCol($sSQL);
@@ -1615,7 +1615,7 @@
 				if (!preg_match('/\pL/', $sWord)) unset($aRecheckWords[$i]);
 			}
 
-            if (CONST_Debug) { echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords); }
+			if (CONST_Debug) { echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords); }
 
 			foreach($aSearchResults as $iResNum => $aResult)
 			{

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -13,7 +13,7 @@
 	if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') exit;
 
 	if (CONST_ClosedForIndexing && strpos(CONST_ClosedForIndexingExceptionIPs, ','.$_SERVER["REMOTE_ADDR"].',') === false)
- 	{
+	{
 		echo "Closed for re-indexing...";
 		exit;
 	}

--- a/lib/leakybucket.php
+++ b/lib/leakybucket.php
@@ -7,39 +7,39 @@
 		if (!CONST_ConnectionBucket_MemcacheServerAddress) return null;
 		if (!isset($m))
 		{
-		        $m = new Memcached();
-        		$m->addServer(CONST_ConnectionBucket_MemcacheServerAddress, CONST_ConnectionBucket_MemcacheServerPort);
+			$m = new Memcached();
+			$m->addServer(CONST_ConnectionBucket_MemcacheServerAddress, CONST_ConnectionBucket_MemcacheServerPort);
 		}
 		return $m;
 	}
 
 	function doBucket($asKey, $iRequestCost, $iLeakPerSecond, $iThreshold)
 	{
-	        $m = getBucketMemcache();
+		$m = getBucketMemcache();
 		if (!$m) return 0;
 
 		$iMaxVal = 0;
-	        $t = time();
+		$t = time();
 
 		foreach($asKey as $sKey)
 		{
-		        $aCurrentBlock = $m->get($sKey);
-	        	if (!$aCurrentBlock)
+			$aCurrentBlock = $m->get($sKey);
+			if (!$aCurrentBlock)
 			{
-		                $aCurrentBlock = array($iRequestCost, $t, false);
-        		}
+				$aCurrentBlock = array($iRequestCost, $t, false);
+			}
 			else
 			{
 				// add RequestCost
 				// remove leak * the time since the last request 
-	        		$aCurrentBlock[0] += $iRequestCost - ($t - $aCurrentBlock[1])*$iLeakPerSecond;
-		        	$aCurrentBlock[1] = $t;
+				$aCurrentBlock[0] += $iRequestCost - ($t - $aCurrentBlock[1])*$iLeakPerSecond;
+				$aCurrentBlock[1] = $t;
 			}
 
-	        	if ($aCurrentBlock[0] <= 0)
+			if ($aCurrentBlock[0] <= 0)
 			{
-                		$m->delete($sKey);
-		        }
+				$m->delete($sKey);
+			}
 			else
 			{
 				// If we have hit the threshold stop and record this to the block list
@@ -77,7 +77,7 @@
 					}
 				}
 				// Only keep in memcache until the time it would have expired (to avoid clutering memcache)
-	                	$m->set($sKey, $aCurrentBlock, $t + 1 + $aCurrentBlock[0]/$iLeakPerSecond);
+						$m->set($sKey, $aCurrentBlock, $t + 1 + $aCurrentBlock[0]/$iLeakPerSecond);
 			}
 
 			// Bucket result in the largest bucket we find
@@ -85,16 +85,16 @@
 		}
 
 		return $iMaxVal;
-        }
+	}
 
 	function isBucketSleeping($asKey)
 	{
-	        $m = getBucketMemcache();
+		$m = getBucketMemcache();
 		if (!$m) return false;
 
 		foreach($asKey as $sKey)
 		{
-		        $aCurrentBlock = $m->get($sKey);
+			$aCurrentBlock = $m->get($sKey);
 			if ($aCurrentBlock[2]) return true;
 		}
 		return false;
@@ -102,15 +102,15 @@
 
 	function setBucketSleeping($asKey, $bVal)
 	{
-	        $m = getBucketMemcache();
+		$m = getBucketMemcache();
 		if (!$m) return false;
 
 		$iMaxVal = 0;
-	        $t = time();
+		$t = time();
 
 		foreach($asKey as $sKey)
 		{
-		        $aCurrentBlock = $m->get($sKey);
+			$aCurrentBlock = $m->get($sKey);
 			$aCurrentBlock[2] = $bVal;
 			$m->set($sKey, $aCurrentBlock, $t + 1 + $aCurrentBlock[0]/CONST_ConnectionBucket_LeakRate);
 		}
@@ -137,9 +137,9 @@
 
 	function getBucketBlocks()
 	{
-	        $m = getBucketMemcache();
+		$m = getBucketMemcache();
 		if (!$m) return null;
-	        $t = time();
+		$t = time();
 		$aBlockedList = $m->get('blockedList', null, $hCasToken);
 		if (!$aBlockedList) $aBlockedList = array();
 		foreach($aBlockedList as $sKey => $aDetails)
@@ -161,7 +161,7 @@
 
 	function clearBucketBlocks()
 	{
-	        $m = getBucketMemcache();
+		$m = getBucketMemcache();
 		if (!$m) return false;
 		$m->delete('blockedList');
 		return true;

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -101,7 +101,7 @@
 	function bySearchRank($a, $b)
 	{
 		if ($a['iSearchRank'] == $b['iSearchRank'])
-            return strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']);
+			return strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']);
 		return ($a['iSearchRank'] < $b['iSearchRank']?-1:1);
 	}
 

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -1,129 +1,129 @@
 <?php
-  header("content-type: text/html; charset=UTF-8");
+	header("content-type: text/html; charset=UTF-8");
 ?>
 <?php include(CONST_BasePath.'/lib/template/includes/html-header.php'); ?>
-  <link href="css/common.css" rel="stylesheet" type="text/css" />
-  <link href="css/search.css" rel="stylesheet" type="text/css" />
+	<link href="css/common.css" rel="stylesheet" type="text/css" />
+	<link href="css/search.css" rel="stylesheet" type="text/css" />
 </head>
 
 <body id="reverse-page">
 
-  <?php include(CONST_BasePath.'/lib/template/includes/html-top-navigation.php'); ?>
+	<?php include(CONST_BasePath.'/lib/template/includes/html-top-navigation.php'); ?>
 
-  <form class="form-inline" role="search" accept-charset="UTF-8" action="<?php echo CONST_Website_BaseURL; ?>reverse.php">
-    <div class="form-group">
-      <input name="format" type="hidden" value="html">
-      <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars($_GET['lat']); ?>" >
-      <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars($_GET['lon']); ?>" >
-      max zoom
+	<form class="form-inline" role="search" accept-charset="UTF-8" action="<?php echo CONST_Website_BaseURL; ?>reverse.php">
+		<div class="form-group">
+			<input name="format" type="hidden" value="html">
+			<input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars($_GET['lat']); ?>" >
+			<input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars($_GET['lon']); ?>" >
+			max zoom
 
-      <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars($_GET['zoom']); ?>">
-        <option value="" <?php echo $_GET['zoom']==''?'selected':'' ?> >--</option>
-        <?php
+			<select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars($_GET['zoom']); ?>">
+				<option value="" <?php echo $_GET['zoom']==''?'selected':'' ?> >--</option>
+				<?php
 
-          $aZoomLevels = array(
-             0 => "Continent / Sea",
-             1 => "",
-             2 => "",
-             3 => "Country",
-             4 => "",
-             5 => "State",
-             6 => "Region",
-             7 => "",
-             8 => "County",
-             9 => "",
-            10 => "City",
-            11 => "",
-            12 => "Town / Village",
-            13 => "",
-            14 => "Suburb",
-            15 => "",
-            16 => "Street",
-            17 => "",
-            18 => "Building",
-            19 => "",
-            20 => "",
-            21 => "",
-          );
+					$aZoomLevels = array(
+						 0 => "Continent / Sea",
+						 1 => "",
+						 2 => "",
+						 3 => "Country",
+						 4 => "",
+						 5 => "State",
+						 6 => "Region",
+						 7 => "",
+						 8 => "County",
+						 9 => "",
+						10 => "City",
+						11 => "",
+						12 => "Town / Village",
+						13 => "",
+						14 => "Suburb",
+						15 => "",
+						16 => "Street",
+						17 => "",
+						18 => "Building",
+						19 => "",
+						20 => "",
+						21 => "",
+					);
 
-          foreach($aZoomLevels as $iZoomLevel => $sLabel)
-          {
-            $bSel = isset($_GET['zoom']) && ($_GET['zoom'] == (string)$iZoomLevel);
-            echo '<option value="'.$iZoomLevel.'"'.($bSel?'selected':'').'>'.$iZoomLevel.' '.$sLabel.'</option>'."\n";
-          }
-        ?>
-      </select>
-    </div>
-    <div class="form-group search-button-group">
-      <button type="submit" class="btn btn-primary btn-sm">Search</button>
-    </div>
-    <div class="search-type-link">
-      <a href="<?php echo CONST_Website_BaseURL; ?>search.php">forward search</a>
-    </div>
-  </form>
+					foreach($aZoomLevels as $iZoomLevel => $sLabel)
+					{
+						$bSel = isset($_GET['zoom']) && ($_GET['zoom'] == (string)$iZoomLevel);
+						echo '<option value="'.$iZoomLevel.'"'.($bSel?'selected':'').'>'.$iZoomLevel.' '.$sLabel.'</option>'."\n";
+					}
+				?>
+			</select>
+		</div>
+		<div class="form-group search-button-group">
+			<button type="submit" class="btn btn-primary btn-sm">Search</button>
+		</div>
+		<div class="search-type-link">
+			<a href="<?php echo CONST_Website_BaseURL; ?>search.php">forward search</a>
+		</div>
+	</form>
 
 
-  <div id="content">
+	<div id="content">
 
 <?php if ($aPlace) { ?>
 
-    <div id="searchresults" class="sidebar">
-    <?php
-      $aResult = $aPlace;
+		<div id="searchresults" class="sidebar">
+		<?php
+			$aResult = $aPlace;
 
-      echo '<div class="result" data-position="0">';
+			echo '<div class="result" data-position="0">';
 
-      echo (isset($aResult['icon'])?'<img alt="icon" src="'.$aResult['icon'].'"/>':'');
-      echo ' <span class="name">'.htmlspecialchars($aResult['langaddress']).'</span>';
-      if (isset($aResult['label']))
-        echo ' <span class="type">('.$aResult['label'].')</span>';
-      else if ($aResult['type'] == 'yes')
-        echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['class'])).')</span>';
-      else
-        echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['type'])).')</span>';
-      echo '<p>'.$aResult['lat'].','.$aResult['lon'].'</p>';
-      echo ' <a class="btn btn-default btn-xs details" href="details.php?place_id='.$aResult['place_id'].'">details</a>';
-      echo '</div>';
-    ?>
-    </div>
+			echo (isset($aResult['icon'])?'<img alt="icon" src="'.$aResult['icon'].'"/>':'');
+			echo ' <span class="name">'.htmlspecialchars($aResult['langaddress']).'</span>';
+			if (isset($aResult['label']))
+				echo ' <span class="type">('.$aResult['label'].')</span>';
+			else if ($aResult['type'] == 'yes')
+				echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['class'])).')</span>';
+			else
+				echo ' <span class="type">('.ucwords(str_replace('_',' ',$aResult['type'])).')</span>';
+			echo '<p>'.$aResult['lat'].','.$aResult['lon'].'</p>';
+			echo ' <a class="btn btn-default btn-xs details" href="details.php?place_id='.$aResult['place_id'].'">details</a>';
+			echo '</div>';
+		?>
+		</div>
 
 <?php } else { ?>
 
-    <div id="intro" class="sidebar">
-      Search for coordinates or click anywhere on the map.
-    </div>
+		<div id="intro" class="sidebar">
+			Search for coordinates or click anywhere on the map.
+		</div>
 
 <?php } ?>
 
-    <div id="map-wrapper">
-      <div id="map-position"></div>
-      <div id="map"></div>
-    </div>
+		<div id="map-wrapper">
+			<div id="map-position"></div>
+			<div id="map"></div>
+		</div>
 
-  </div> <!-- /content -->
-
-
+	</div> <!-- /content -->
 
 
 
 
 
-  <script type="text/javascript">
-  <?php
 
-    $aNominatimMapInit = [
-      'zoom' => isset($_GET['zoom']) ? htmlspecialchars($_GET['zoom']) : CONST_Default_Zoom,
-      'lat'  => isset($_GET['lat'] ) ? htmlspecialchars($_GET['lat'] ) : CONST_Default_Lat,
-      'lon'  => isset($_GET['lon'] ) ? htmlspecialchars($_GET['lon'] ) : CONST_Default_Lon,
-      'tile_url' => $sTileURL,
-      'tile_attribution' => $sTileAttribution
-    ];
-    echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 
-    echo 'var nominatim_results = ' . json_encode([$aPlace], JSON_PRETTY_PRINT) . ';'; 
-  ?>
-  </script>
-  <?php include(CONST_BasePath.'/lib/template/includes/html-footer.php'); ?>
+	<script type="text/javascript">
+	<?php
+
+		$aNominatimMapInit = [
+			'zoom' => isset($_GET['zoom']) ? htmlspecialchars($_GET['zoom']) : CONST_Default_Zoom,
+			'lat'  => isset($_GET['lat'] ) ? htmlspecialchars($_GET['lat'] ) : CONST_Default_Lat,
+			'lon'  => isset($_GET['lon'] ) ? htmlspecialchars($_GET['lon'] ) : CONST_Default_Lon,
+			'tile_url' => $sTileURL,
+			'tile_attribution' => $sTileAttribution
+		];
+		echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
+
+		echo 'var nominatim_results = ' . json_encode([$aPlace], JSON_PRETTY_PRINT) . ';'; 
+	?>
+	</script>
+	<?php include(CONST_BasePath.'/lib/template/includes/html-footer.php'); ?>
 
 </body>
 </html>

--- a/lib/template/address-json.php
+++ b/lib/template/address-json.php
@@ -13,13 +13,13 @@
 		if (isset($aPlace['place_id'])) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
 		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
-                if ($sOSMType)
-                {
-                        $aFilteredPlaces['osm_type'] = $sOSMType;
-                        $aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
-                }
-                if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
-                if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
+		if ($sOSMType)
+		{
+			$aFilteredPlaces['osm_type'] = $sOSMType;
+			$aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
+		}
+		if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
+		if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
 		$aFilteredPlaces['display_name'] = $aPlace['langaddress'];
 		if (isset($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
 		if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];

--- a/lib/template/address-jsonv2.php
+++ b/lib/template/address-jsonv2.php
@@ -13,11 +13,11 @@
 		if ($aPlace['place_id']) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
 		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
-                if ($sOSMType)
-                {
-                        $aFilteredPlaces['osm_type'] = $sOSMType;
-                        $aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
-                }
+		if ($sOSMType)
+		{
+			$aFilteredPlaces['osm_type'] = $sOSMType;
+			$aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
+		}
 		if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
 		if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
 

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -264,21 +264,21 @@
 	<script type="text/javascript">
 	<?php
 
-    $aNominatimMapInit = [
-      'tile_url' => $sTileURL,
-      'tile_attribution' => $sTileAttribution
-    ];
-    echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
+		$aNominatimMapInit = [
+		  'tile_url' => $sTileURL,
+		  'tile_attribution' => $sTileAttribution
+		];
+		echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 
-    $aPlace = [
-			'outlinestring' => $aPointDetails['outlinestring'],
-			'lon' => $aPointDetails['lon'],
-			'lat' => $aPointDetails['lat'],
-    ];
-	  echo 'var nominatim_result = ' . json_encode($aPlace, JSON_PRETTY_PRINT) . ';'; 
+		$aPlace = [
+				'outlinestring' => $aPointDetails['outlinestring'],
+				'lon' => $aPointDetails['lon'],
+				'lat' => $aPointDetails['lat'],
+		];
+		echo 'var nominatim_result = ' . json_encode($aPlace, JSON_PRETTY_PRINT) . ';'; 
 
 
-  ?>
+	?>
 	</script>
 
 

--- a/lib/template/includes/html-footer.php
+++ b/lib/template/includes/html-footer.php
@@ -1,10 +1,10 @@
 <footer>
-  <p class="disclaimer">
-    Addresses and postcodes are approximate
-  </p>
-  <p class="copyright">
-    &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-  </p>
+	<p class="disclaimer">
+		Addresses and postcodes are approximate
+	</p>
+	<p class="copyright">
+		&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
+	</p>
 </footer>
 
 <script src="js/jquery.min.js"></script>

--- a/lib/template/includes/html-top-navigation.php
+++ b/lib/template/includes/html-top-navigation.php
@@ -1,49 +1,49 @@
-  <header class="container-fluid">
-    <div class="row">
-      <div class="col-xs-4">
-        <div class="brand">
-          <a href="<?php echo CONST_Website_BaseURL;?>">
-          <img alt="logo" src="images/osm_logo.120px.png" width="30" height="30"/>
-          <h1>Nominatim</h1>
-          </a>
-        </div>
-      </div>
-      <div id="last-updated" class="col-xs-4 text-center">
-        <?php if ($sDataDate){ ?>
-          Data last updated:
-          <br>
-          <?php echo $sDataDate; ?>
-        <?php } ?>
-      </div>
-      <div class="col-xs-4 text-right">
-        <div class="btn-group">
-          <button class="dropdown-toggle btn btn-sm btn-default" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-            About &amp; Help <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li><a href="http://wiki.openstreetmap.org/wiki/Nominatim" target="_blank">Documentation</a></li>
-            <li><a href="http://wiki.openstreetmap.org/wiki/Nominatim/FAQ" target="_blank">FAQ</a></li>
-            <li role="separator" class="divider"></li>
-            <li><a href="#" class="" data-toggle="modal" data-target="#report-modal">Report problem with results</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </header>
+	<header class="container-fluid">
+		<div class="row">
+			<div class="col-xs-4">
+				<div class="brand">
+					<a href="<?php echo CONST_Website_BaseURL;?>">
+					<img alt="logo" src="images/osm_logo.120px.png" width="30" height="30"/>
+					<h1>Nominatim</h1>
+					</a>
+				</div>
+			</div>
+			<div id="last-updated" class="col-xs-4 text-center">
+				<?php if ($sDataDate){ ?>
+					Data last updated:
+					<br>
+					<?php echo $sDataDate; ?>
+				<?php } ?>
+			</div>
+			<div class="col-xs-4 text-right">
+				<div class="btn-group">
+					<button class="dropdown-toggle btn btn-sm btn-default" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+						About &amp; Help <span class="caret"></span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						<li><a href="http://wiki.openstreetmap.org/wiki/Nominatim" target="_blank">Documentation</a></li>
+						<li><a href="http://wiki.openstreetmap.org/wiki/Nominatim/FAQ" target="_blank">FAQ</a></li>
+						<li role="separator" class="divider"></li>
+						<li><a href="#" class="" data-toggle="modal" data-target="#report-modal">Report problem with results</a></li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</header>
 
-  <div class="modal fade" id="report-modal">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">Report a problem</h4>
-        </div>
-        <div class="modal-body">
-          <?php include(CONST_BasePath.'/lib/template/includes/report-errors.php'); ?>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">OK</button>
-        </div>
-      </div>
-    </div>
-  </div>
+	<div class="modal fade" id="report-modal">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<h4 class="modal-title">Report a problem</h4>
+				</div>
+				<div class="modal-body">
+					<?php include(CONST_BasePath.'/lib/template/includes/report-errors.php'); ?>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">OK</button>
+				</div>
+			</div>
+		</div>
+	</div>

--- a/lib/template/search-batch-json.php
+++ b/lib/template/search-batch-json.php
@@ -11,8 +11,8 @@
 		foreach($aSearchResults as $iResNum => $aPointDetails)
 		{
 			$aPlace = array(
-					'place_id'=>$aPointDetails['place_id'],
-				  );
+						'place_id'=>$aPointDetails['place_id'],
+					);
 
 			$sOSMType = ($aPointDetails['osm_type'] == 'N'?'node':($aPointDetails['osm_type'] == 'W'?'way':($aPointDetails['osm_type'] == 'R'?'relation':'')));
 			if ($sOSMType)
@@ -21,8 +21,8 @@
 				$aPlace['osm_id'] = $aPointDetails['osm_id'];
 			}
 
-        	        if (isset($aPointDetails['aBoundingBox']))
-                	{
+			if (isset($aPointDetails['aBoundingBox']))
+			{
 				$aPlace['boundingbox'] = array(
 					$aPointDetails['aBoundingBox'][0],
 					$aPointDetails['aBoundingBox'][1],
@@ -33,7 +33,7 @@
 				{
 					$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 				}
-	                }
+			}
 
 			if (isset($aPointDetails['zoom']))
 			{
@@ -58,27 +58,27 @@
 			if (isset($aPointDetails['address']) && sizeof($aPointDetails['address'])>0)
 			{
 				$aPlace['address'] = $aPointDetails['address'];
-        	        }
+			}
 
-	                if (isset($aPointDetails['asgeojson']))
-        	        {
+			if (isset($aPointDetails['asgeojson']))
+			{
 				$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-        	        }
+			}
 
-	                if (isset($aPointDetails['assvg']))
-        	        {
+			if (isset($aPointDetails['assvg']))
+			{
 				$aPlace['svg'] = $aPointDetails['assvg'];
-	                }
+			}
 
-	                if (isset($aPointDetails['astext']))
-        	        {
-                	        $aPlace['geotext'] = $aPointDetails['astext'];
-	                }
+			if (isset($aPointDetails['astext']))
+			{
+				$aPlace['geotext'] = $aPointDetails['astext'];
+			}
 
-        	        if (isset($aPointDetails['askml']))
-                	{
-                        	$aPlace['geokml'] = $aPointDetails['askml'];
-	                }
+			if (isset($aPointDetails['askml']))
+			{
+				$aPlace['geokml'] = $aPointDetails['askml'];
+			}
 
 			$aFilteredPlaces[] = $aPlace;
 		}

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -16,8 +16,8 @@
 			$aPlace['osm_id'] = $aPointDetails['osm_id'];
 		}
 
-                if (isset($aPointDetails['aBoundingBox']))
-                {
+		if (isset($aPointDetails['aBoundingBox']))
+		{
 			$aPlace['boundingbox'] = array(
 				$aPointDetails['aBoundingBox'][0],
 				$aPointDetails['aBoundingBox'][1],
@@ -28,7 +28,7 @@
 			{
 				$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 			}
-                }
+		}
 
 		if (isset($aPointDetails['zoom']))
 		{
@@ -52,22 +52,22 @@
 		if (isset($aPointDetails['address']))
 		{
 			$aPlace['address'] = $aPointDetails['address'];
-                }
+		}
 
-                if (isset($aPointDetails['asgeojson']))
-                {
-                        $aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-                }
+		if (isset($aPointDetails['asgeojson']))
+		{
+			$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
+		}
 
-                if (isset($aPointDetails['assvg']))
-                {
-                        $aPlace['svg'] = $aPointDetails['assvg'];
-                }
+		if (isset($aPointDetails['assvg']))
+		{
+			$aPlace['svg'] = $aPointDetails['assvg'];
+		}
 
-                if (isset($aPointDetails['astext']))
-                {
-                        $aPlace['geotext'] = $aPointDetails['astext'];
-                }
+		if (isset($aPointDetails['astext']))
+		{
+			$aPlace['geotext'] = $aPointDetails['astext'];
+		}
 
 		if (isset($aPointDetails['askml']))
 		{

--- a/lib/template/search-jsonv2.php
+++ b/lib/template/search-jsonv2.php
@@ -14,8 +14,8 @@
 			$aPlace['osm_id'] = $aPointDetails['osm_id'];
 		}
 
-                if (isset($aPointDetails['aBoundingBox']))
-                {
+		if (isset($aPointDetails['aBoundingBox']))
+		{
 			$aPlace['boundingbox'] = array(
 				$aPointDetails['aBoundingBox'][0],
 				$aPointDetails['aBoundingBox'][1],
@@ -26,7 +26,7 @@
 			{
 				$aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
 			}
-                }
+		}
 
 		if (isset($aPointDetails['zoom']))
 		{
@@ -51,27 +51,27 @@
 		if (isset($aPointDetails['address']) && sizeof($aPointDetails['address'])>0)
 		{
 			$aPlace['address'] = $aPointDetails['address'];
-                }
+		}
 
-                if (isset($aPointDetails['asgeojson']))
-                {
+		if (isset($aPointDetails['asgeojson']))
+		{
 			$aPlace['geojson'] = json_decode($aPointDetails['asgeojson']);
-                }
+		}
 
-                if (isset($aPointDetails['assvg']))
-                {
+		if (isset($aPointDetails['assvg']))
+		{
 			$aPlace['svg'] = $aPointDetails['assvg'];
-                }
+		}
 
-                if (isset($aPointDetails['astext']))
-                {
-                        $aPlace['geotext'] = $aPointDetails['astext'];
-                }
+		if (isset($aPointDetails['astext']))
+		{
+			$aPlace['geotext'] = $aPointDetails['astext'];
+		}
 
-                if (isset($aPointDetails['askml']))
-                {
-                        $aPlace['geokml'] = $aPointDetails['askml'];
-                }
+		if (isset($aPointDetails['askml']))
+		{
+			$aPlace['geokml'] = $aPointDetails['askml'];
+		}
 
 		if (isset($aPointDetails['sExtraTags'])) $aPlace['extratags'] = $aPointDetails['sExtraTags'];
 		if (isset($aPointDetails['sNameDetails'])) $aPlace['namedetails'] = $aPointDetails['sNameDetails'];

--- a/settings/phrase_settings.php
+++ b/settings/phrase_settings.php
@@ -38,14 +38,14 @@ $aLanguageIn = array(
 
 # class/type combinations to exclude
 $aTagsBlacklist = array(
-  'boundary' => array('administrative'),
-  'place' => array('house', 'houses'),
+	'boundary' => array('administrative'),
+	'place' => array('house', 'houses'),
 );
 # If a class is in the white list then all types will 
 # be ignored except the ones given in the list.
 # Also use this list to exclude an entire class from
 # special phrases.
 $aTagsWhitelist = array(
-  'highway' => array('bus_stop', 'rest_area', 'raceway'),
-  'building' => array(),
+	'highway' => array('bus_stop', 'rest_area', 'raceway'),
+	'building' => array(),
 );

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -1,6 +1,6 @@
 <?php
-        require_once(dirname(dirname(__FILE__)).'/lib/init-website.php');
-        require_once(CONST_BasePath.'/lib/log.php');
+	require_once(dirname(dirname(__FILE__)).'/lib/init-website.php');
+	require_once(CONST_BasePath.'/lib/log.php');
 
 	$sOutputFormat = 'html';
 	ini_set('memory_limit', '200M');
@@ -19,12 +19,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
-    
-    <title>Nominatim Deleted Data</title>
-    
-    <meta name="description" content="List of OSM data that has been deleted" lang="en-US" />
+	<meta charset="utf-8"/>
+	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+	
+	<title>Nominatim Deleted Data</title>
+	
+	<meta name="description" content="List of OSM data that has been deleted" lang="en-US" />
 
 </head>
 
@@ -79,16 +79,16 @@ table td {
 		{
 			switch($sCol)
 			{
-            case 'osm_id':
-                $sOSMType = ($aRow['osm_type'] == 'N'?'node':($aRow['osm_type'] == 'W'?'way':($aRow['osm_type'] == 'R'?'relation':'')));
-                echo '<td><a href="http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$sVal.'" target="_new">'.$sVal.'</a></td>';
-                                break;
-			case 'place_id':
-				echo '<td><a href="'.CONST_Website_BaseURL.'details?place_id='.$sVal.'">'.$sVal.'</a></td>';
-				break;
-			default:
-				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-				break;
+				case 'osm_id':
+					$sOSMType = ($aRow['osm_type'] == 'N'?'node':($aRow['osm_type'] == 'W'?'way':($aRow['osm_type'] == 'R'?'relation':'')));
+					echo '<td><a href="http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$sVal.'" target="_new">'.$sVal.'</a></td>';
+					break;
+				case 'place_id':
+					echo '<td><a href="'.CONST_Website_BaseURL.'details?place_id='.$sVal.'">'.$sVal.'</a></td>';
+					break;
+				default:
+					echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+					break;
 			}
 		}
 		echo "</tr>";

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -78,7 +78,7 @@
 		$aBreadcrums[] = array('placeId'=>$aPlace['place_id'], 'osmType'=>$aPlace['osm_type'], 'osmId'=>$aPlace['osm_id'], 'localName'=>$aPlace['localname']);
 		$sPlaceUrl = 'hierarchy.php?place_id='.$aPlace['place_id'];
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
-                $sOSMUrl = 'http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$aPlace['osm_id'];
+				$sOSMUrl = 'http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$aPlace['osm_id'];
 		if ($sOutputFormat == 'html') if ($i) echo " > ";
 		if ($sOutputFormat == 'html') echo '<a href="'.$sPlaceUrl.'">'.$aPlace['localname'].'</a> (<a href="'.$sOSMUrl.'">osm</a>)';
 	}
@@ -102,52 +102,52 @@
 	$sSQL .= " order by rank_address asc,rank_search asc,localname,class, type,housenumber";
 	$aParentOfLines = $oDB->getAll($sSQL);
 
-        if (sizeof($aParentOfLines))
-        {
-                echo '<h2>Parent Of:</h2>';
+	if (sizeof($aParentOfLines))
+	{
+		echo '<h2>Parent Of:</h2>';
 		$aClassType = getClassTypesWithImportance();
-                $aGroupedAddressLines = array();
-                foreach($aParentOfLines as $aAddressLine)
-                {
+		$aGroupedAddressLines = array();
+		foreach($aParentOfLines as $aAddressLine)
+		{
 			if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-                                              && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-                                {
-                                        $aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
-                                }
+			      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
+			{
+				$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
+			}
 			elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-                                              && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-                                {
-                                        $aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
-                                }
+			        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
+			{
+				$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
+			}
 			else $aAddressLine['label'] = ucwords($aAddressLine['type']);
 
-                        if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
-                        $aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
-                }
-                foreach($aGroupedAddressLines as $sGroupHeading => $aParentOfLines)
-                {
-                        echo "<h3>$sGroupHeading</h3>";
-                foreach($aParentOfLines as $aAddressLine)
-                {
-                        $aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
-                        $sOSMType = ($aAddressLine['osm_type'] == 'N'?'node':($aAddressLine['osm_type'] == 'W'?'way':($aAddressLine['osm_type'] == 'R'?'relation':'')));
+			if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
+				$aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
+			}
+			foreach($aGroupedAddressLines as $sGroupHeading => $aParentOfLines)
+			{
+				echo "<h3>$sGroupHeading</h3>";
+				foreach($aParentOfLines as $aAddressLine)
+				{
+					$aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
+					$sOSMType = ($aAddressLine['osm_type'] == 'N'?'node':($aAddressLine['osm_type'] == 'W'?'way':($aAddressLine['osm_type'] == 'R'?'relation':'')));
 
-                        echo '<div class="line">';
-                        echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
-                        echo ' (';
-                        echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
-                        if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' <a href="http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$aAddressLine['osm_id'].'">'.$aAddressLine['osm_id'].'</a></span>';
-                        echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
-                        echo ', '.$aAddressLine['area'];
-                        echo ')';
-                        echo '</div>';
-                }
-                }
-                if (sizeof($aParentOfLines) >= 500) {
-                        echo '<p>There are more child objects which are not shown.</p>';
-                }
-                echo '</div>';
-        }
+					echo '<div class="line">';
+					echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
+					echo ' (';
+					echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
+					if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' <a href="http://www.openstreetmap.org/browse/'.$sOSMType.'/'.$aAddressLine['osm_id'].'">'.$aAddressLine['osm_id'].'</a></span>';
+					echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
+					echo ', '.$aAddressLine['area'];
+					echo ')';
+					echo '</div>';
+				}
+			}
+			if (sizeof($aParentOfLines) >= 500) {
+				echo '<p>There are more child objects which are not shown.</p>';
+			}
+			echo '</div>';
+		}
 exit;
 
 

--- a/website/polygons.php
+++ b/website/polygons.php
@@ -39,12 +39,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
-    
-    <title>Nominatim Broken Polygon Data</title>
-    
-    <meta name="description" content="List of broken OSM polygon data by date" lang="en-US" />
+	<meta charset="utf-8"/>
+	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+	
+	<title>Nominatim Broken Polygon Data</title>
+	
+	<meta name="description" content="List of broken OSM polygon data by date" lang="en-US" />
 
 </head>
 


### PR DESCRIPTION
The majority (90%, just guessing) of PHP files are intended by tabs. This PR converts the remaining files to make it consistent, The largest difference is the new header and footer HTML files.

I tested using `grep -r '^  '  lib/ website/ settings/ tests-php/ | grep '.php'` (that's two spaces)

A `git diff --ignore-space-change --ignore-blank-line` shows there were no other changes.

Let me know if you prefer spaces though. For the *.sql files it's mostly 2 space indentation, for the python files I see 4 space indentation.