### PR TITLE
query the last updated timestamp only if output format is HTML

### DIFF
--- a/lib/template/includes/html-top-navigation.php
+++ b/lib/template/includes/html-top-navigation.php
@@ -9,7 +9,7 @@
 				</div>
 			</div>
 			<div id="last-updated" class="col-xs-4 text-center">
-				<?php if ($sDataDate){ ?>
+				<?php if (isset($sDataDate)){ ?>
 					Data last updated:
 					<br>
 					<?php echo $sDataDate; ?>

--- a/website/details.php
+++ b/website/details.php
@@ -159,7 +159,12 @@
 
 	logEnd($oDB, $hLog, 1);
 
-	$sTileURL = CONST_Map_Tile_URL;
-	$sTileAttribution = CONST_Map_Tile_Attribution;
+	if ($sOutputFormat=='html')
+	{
+		$sDataDate = $oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1");
+		$sTileURL = CONST_Map_Tile_URL;
+		$sTileAttribution = CONST_Map_Tile_Attribution;
+	}
+
 	
 	include(CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php');

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -76,6 +76,10 @@
 		exit;
 	}
 
-	$sTileURL = CONST_Map_Tile_URL;
-	$sTileAttribution = CONST_Map_Tile_Attribution;
+	if ($sOutputFormat=='html')
+	{
+		$sDataDate = $oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1");
+		$sTileURL = CONST_Map_Tile_URL;
+		$sTileAttribution = CONST_Map_Tile_Attribution;
+	}
 	include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');

--- a/website/search.php
+++ b/website/search.php
@@ -13,8 +13,6 @@
 	$fLat = CONST_Default_Lat;
 	$fLon = CONST_Default_Lon;
 	$iZoom = CONST_Default_Zoom;
-	$sTileURL = CONST_Map_Tile_URL;
-	$sTileAttribution = CONST_Map_Tile_Attribution;
 
 	$oGeocode =& new Geocode($oDB);
 
@@ -99,17 +97,17 @@
 	{
 		if (!(isset($_GET['q']) && $_GET['q']) && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
 		{
-				$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
+			$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
 
-				// reverse order of '/' separated string
-				$aPhrases = explode('/', $sQuery);
-				$aPhrases = array_reverse($aPhrases);
-				$sQuery = join(', ',$aPhrases);
-				$oGeocode->setQuery($sQuery);
+			// reverse order of '/' separated string
+			$aPhrases = explode('/', $sQuery);
+			$aPhrases = array_reverse($aPhrases);
+			$sQuery = join(', ',$aPhrases);
+			$oGeocode->setQuery($sQuery);
 		}
 		else
 		{
-				$oGeocode->setQueryFromParams($_GET);
+			$oGeocode->setQueryFromParams($_GET);
 		}
 	}
 
@@ -118,8 +116,12 @@
 	$aSearchResults = $oGeocode->lookup();
 	if ($aSearchResults === false) $aSearchResults = array();
 
-	$sDataDate = $oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1");
-
+	if ($sOutputFormat=='html')
+	{
+		$sDataDate = $oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1");
+		$sTileURL = CONST_Map_Tile_URL;
+		$sTileAttribution = CONST_Map_Tile_Attribution;
+	}
 	logEnd($oDB, $hLog, sizeof($aSearchResults));
 
 	$bAsText = $oGeocode->getIncludePolygonAsText();


### PR DESCRIPTION
Also the timestamp is printed in the `html-top-navigation.php` template and that caused `undefined` warnings in the error log.