### PR TITLE
fix for PHP7, added test setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure("2") do |config|
       sub.vm.box = "ubuntu/trusty64"
       sub.vm.provision :shell, :path => "vagrant/ubuntu-trusty-provision.sh"
   end
+  config.vm.define "ubuntu-php7" do |sub|
+      sub.vm.box = "ubuntu/trusty64"
+      sub.vm.provision :shell, :path => "vagrant/ubuntu-trusty-php7-provision.sh"
+  end
   config.vm.define "centos" do |sub|
       sub.vm.box = "bento/centos-7.2"
       sub.vm.provision :shell, :path => "vagrant/centos-7-provision.sh"

--- a/vagrant/ubuntu-trusty-php7-provision.sh
+++ b/vagrant/ubuntu-trusty-php7-provision.sh
@@ -67,12 +67,15 @@ sudo -u postgres createuser -s $USERNAME
 ###
 ### PHP for frontend
 ###
-sudo apt-get install -y php5 php5-pgsql php-pear php-db
+sudo LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
+sudo apt-get update -qq
+sudo apt-get install -y apache2
+sudo apt-get install -y php7.0 php7.0-pgsql php7.0-fpm libapache2-mod-php7.0 php-pear php-db
 
 
 # get rid of some warning
 # where is the ini file? 'php --ini'
-echo "date.timezone = 'Etc/UTC'" | sudo tee /etc/php5/cli/conf.d/99-timezone.ini > /dev/null
+echo "date.timezone = 'Etc/UTC'" | sudo tee /etc/php/7.0/cli/conf.d/99-timezone.ini > /dev/null
 
 
 
@@ -165,10 +168,13 @@ sudo -u $USERNAME ./utils/setup.php --create-website /var/www/nominatim
 ##
 apt-get install -y python-dev python-pip python-Levenshtein python-shapely \
                         python-psycopg2 tidy python-nose python-tidylib
+pip install certifi # deals with "SNI extension to TLS is not available" warning
 pip install lettuce==0.2.18 six==1.7 haversine
+pip install --upgrade pip setuptools
 
 ## Test suite (PHP)
 ## https://github.com/twain47/Nominatim/tree/master/tests-php
-apt-get install -y phpunit
-
+wget --quiet https://phar.phpunit.de/phpunit.phar
+chmod +x phpunit.phar
+mv phpunit.phar /usr/local/bin/phpunit
 

--- a/website/search.php
+++ b/website/search.php
@@ -14,7 +14,7 @@
 	$fLon = CONST_Default_Lon;
 	$iZoom = CONST_Default_Zoom;
 
-	$oGeocode =& new Geocode($oDB);
+	$oGeocode = new Geocode($oDB);
 
 	$aLangPrefOrder = getPreferredLanguages();
 	$oGeocode->setLanguagePreference($aLangPrefOrder);


### PR DESCRIPTION
This fixes an issue with PHP7 as reported in https://github.com/twain47/Nominatim/issues/394

I created a Vagrant test setup and diff between the Ubuntu Vagrant files shows what's needed to get a clean Nominatim with PHP7 running. PHP and python test suite run fine, running an index for a small country is also good.