### PR TITLE
second argument of array_merge can be empty

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1647,8 +1647,11 @@
 				$oPlaceLookup->setPolygonSimplificationThreshold($this->fPolygonSimplificationThreshold);
 
 				$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter/2);
-				$aResult = array_merge($aResult, $aOutlineResult);
-
+				if ($aOutlineResult)
+				{
+					$aResult = array_merge($aResult, $aOutlineResult);
+				}
+				
 				if ($aResult['extra_place'] == 'city')
 				{
 					$aResult['class'] = 'place';

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -102,9 +102,12 @@
 		$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
 
 		$fRadius = $fDiameter = getResultDiameter($aPlace);
-		$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'],$aPlace['lon'],$aPlace['lat'],$fRadius);
+		$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'], $aPlace['lon'], $aPlace['lat'], $fRadius);
 
-		$aPlace = array_merge($aPlace, $aOutlineResult);
+		if ($aOutlineResult)
+		{
+			$aPlace = array_merge($aPlace, $aOutlineResult);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
When running the full test suite the Apache error log contained a couple of warnings

```
PHP Warning: array_merge(): Argument #1 is not an array in /home/vagrant/Nominatim/website/reverse.php on line 107
```
