### PR TITLE
add more build* directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 
 build
+build-*
 settings/local.php
 
 data/wiki_import.sql


### PR DESCRIPTION
The vagrant script use 

    cd Nominatim
    sudo -u $USERNAME mkdir build-vagrant
    cd build-vagrant

Since it's temporary it's good to make sure it doesn't get checked into git accidentally.