### PR TITLE
Add osm_tag flag to reverse geocoding

### DIFF
--- a/website/reverse.php
+++ b/website/reverse.php
@@ -76,6 +76,8 @@
 
 		$oReverseGeocode->setLatLon($_GET['lat'], $_GET['lon']);
 		$oReverseGeocode->setZoom(@$_GET['zoom']);
+        
+        $oReverseGeocode->setOsmTagList(@$_GET['osm_tag']);
 
 		$aLookup = $oReverseGeocode->lookup();
 		if (CONST_Debug) var_dump($aLookup);


### PR DESCRIPTION
Add osm_tag to reverse geocoding will only return result that will
contain at least the given label tag.
For example, a osm_tag of "place:city" will return the nearest "place:city"

