### PR TITLE
pgsqlRunPartitionScript needs global $aCMDResult

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -761,6 +761,7 @@
 
 	function pgsqlRunPartitionScript($sTemplate)
 	{
+		global $aCMDResult;
 		$oDB =& getDB();
 
 		$sSQL = 'select distinct partition from country_name';


### PR DESCRIPTION
function pgsqlRunPartitionScript  was missing global $aCMDResult

setup was failing with

```
./build/utils/setup.php --no-partitions --all --osm2pgsql-cache 1000 --osm-file ~irljidel/ireland-and-northern-ireland.osm.pbf 2>&1 | tee setup.log
...
PHP Notice:  Undefined variable: aCMDResult in /home/roles/nominatim/app/Nominatim/build/utils/setup.php on line 768
NOTICE:  type "nearplace" does not exist, skipping
..
ERROR:  relation "location_area_large_0" already exists
ERROR: pgsql returned with error code (3)
pgsql returned with error code (3)
Command exited with non-zero status 255
```
