### PR TITLE
PHP linting with CodeSniffer

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
+require_once CONST_BasePath.'/lib/PlaceLookup.php';
+require_once CONST_BasePath.'/lib/ReverseGeocode.php';
 
 class Geocode
 {
@@ -49,65 +49,90 @@ class Geocode
 	protected $sQuery = false;
 	protected $aStructuredQuery = false;
 
+
 	function Geocode(&$oDB)
 	{
 		$this->oDB =& $oDB;
-	}
+
+	}//end Geocode()
+
 
 	function setReverseInPlan($bReverse)
 	{
 		$this->bReverseInPlan = $bReverse;
-	}
+
+	}//end setReverseInPlan()
+
 
 	function setLanguagePreference($aLangPref)
 	{
 		$this->aLangPrefOrder = $aLangPref;
-	}
+
+	}//end setLanguagePreference()
+
 
 	function getIncludeAddressDetails()
 	{
 		return $this->bIncludeAddressDetails;
-	}
+
+	}//end getIncludeAddressDetails()
+
 
 	function getIncludeExtraTags()
 	{
 		return $this->bIncludeExtraTags;
-	}
+
+	}//end getIncludeExtraTags()
+
 
 	function getIncludeNameDetails()
 	{
 		return $this->bIncludeNameDetails;
-	}
+
+	}//end getIncludeNameDetails()
+
 
 	function setIncludePolygonAsPoints($b = true)
 	{
 		$this->bIncludePolygonAsPoints = $b;
-	}
+
+	}//end setIncludePolygonAsPoints()
+
 
 	function setIncludePolygonAsText($b = true)
 	{
 		$this->bIncludePolygonAsText = $b;
-	}
+
+	}//end setIncludePolygonAsText()
+
 
 	function setIncludePolygonAsGeoJSON($b = true)
 	{
 		$this->bIncludePolygonAsGeoJSON = $b;
-	}
+
+	}//end setIncludePolygonAsGeoJSON()
+
 
 	function setIncludePolygonAsKML($b = true)
 	{
 		$this->bIncludePolygonAsKML = $b;
-	}
+
+	}//end setIncludePolygonAsKML()
+
 
 	function setIncludePolygonAsSVG($b = true)
 	{
 		$this->bIncludePolygonAsSVG = $b;
-	}
+
+	}//end setIncludePolygonAsSVG()
+
 
 	function setPolygonSimplificationThreshold($f)
 	{
 		$this->fPolygonSimplificationThreshold = $f;
-	}
+
+	}//end setPolygonSimplificationThreshold()
+
 
 	function setLimit($iLimit = 10)
 	{
@@ -115,84 +140,101 @@ class Geocode
 		if ($iLimit < 1) $iLimit = 1;
 
 		$this->iFinalLimit = $iLimit;
-		$this->iLimit = $this->iFinalLimit + min($this->iFinalLimit, 10);
-	}
+		$this->iLimit = ($this->iFinalLimit + min($this->iFinalLimit, 10));
+
+	}//end setLimit()
+
 
 	function getExcludedPlaceIDs()
 	{
 		return $this->aExcludePlaceIDs;
-	}
+
+	}//end getExcludedPlaceIDs()
+
 
 	function setViewBox($fLeft, $fBottom, $fRight, $fTop)
 	{
 		$this->aViewBox = array($fLeft, $fBottom, $fRight, $fTop);
-	}
+
+	}//end setViewBox()
+
 
 	function getViewBoxString()
 	{
 		if (!$this->aViewBox) return null;
 		return $this->aViewBox[0].','.$this->aViewBox[3].','.$this->aViewBox[2].','.$this->aViewBox[1];
-	}
+
+	}//end getViewBoxString()
+
 
 	function setFeatureType($sFeatureType)
 	{
 		switch ($sFeatureType) {
-			case 'country':
-				$this->setRankRange(4, 4);
-				break;
-			case 'state':
-				$this->setRankRange(8, 8);
-				break;
-			case 'city':
-				$this->setRankRange(14, 16);
-				break;
-			case 'settlement':
-				$this->setRankRange(8, 20);
-				break;
+		case 'country':
+			$this->setRankRange(4, 4);
+			break;
+		case 'state':
+			$this->setRankRange(8, 8);
+			break;
+		case 'city':
+			$this->setRankRange(14, 16);
+			break;
+		case 'settlement':
+			$this->setRankRange(8, 20);
+			break;
 		}
-	}
+
+	}//end setFeatureType()
+
 
 	function setRankRange($iMin, $iMax)
 	{
 		$this->iMinAddressRank = $iMin;
 		$this->iMaxAddressRank = $iMax;
-	}
+
+	}//end setRankRange()
+
 
 	function setNearPoint($aNearPoint, $fRadiusDeg = 0.1)
 	{
-		$this->aNearPoint = array((float)$aNearPoint[0], (float)$aNearPoint[1], (float)$fRadiusDeg);
-	}
+		$this->aNearPoint = array((float) $aNearPoint[0], (float) $aNearPoint[1], (float) $fRadiusDeg);
+
+	}//end setNearPoint()
+
 
 	function setQuery($sQueryString)
 	{
 		$this->sQuery = $sQueryString;
 		$this->aStructuredQuery = false;
-	}
+
+	}//end setQuery()
+
 
 	function getQueryString()
 	{
 		return $this->sQuery;
-	}
+
+	}//end getQueryString()
 
 
 	function loadParamArray($aParams)
 	{
-		if (isset($aParams['addressdetails'])) $this->bIncludeAddressDetails = (bool)$aParams['addressdetails'];
-		if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool)$aParams['extratags'];
-		if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool)$aParams['namedetails'];
+		if (isset($aParams['addressdetails'])) $this->bIncludeAddressDetails = (bool) $aParams['addressdetails'];
+		if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool) $aParams['extratags'];
+		if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool) $aParams['namedetails'];
 
-		if (isset($aParams['bounded'])) $this->bBoundedSearch = (bool)$aParams['bounded'];
-		if (isset($aParams['dedupe'])) $this->bDeDupe = (bool)$aParams['dedupe'];
+		if (isset($aParams['bounded'])) $this->bBoundedSearch = (bool) $aParams['bounded'];
+		if (isset($aParams['dedupe'])) $this->bDeDupe = (bool) $aParams['dedupe'];
 
-		if (isset($aParams['limit'])) $this->setLimit((int)$aParams['limit']);
-		if (isset($aParams['offset'])) $this->iOffset = (int)$aParams['offset'];
+		if (isset($aParams['limit'])) $this->setLimit((int) $aParams['limit']);
+		if (isset($aParams['offset'])) $this->iOffset = (int) $aParams['offset'];
 
-		if (isset($aParams['fallback'])) $this->bFallback = (bool)$aParams['fallback'];
+		if (isset($aParams['fallback'])) $this->bFallback = (bool) $aParams['fallback'];
 
 		// List of excluded Place IDs - used for more acurate pageing
 		if (isset($aParams['exclude_place_ids']) && $aParams['exclude_place_ids']) {
 			foreach (explode(',', $aParams['exclude_place_ids']) as $iExcludedPlaceID) {
-				$iExcludedPlaceID = (int)$iExcludedPlaceID;
+				$iExcludedPlaceID = (int) $iExcludedPlaceID;
 				if ($iExcludedPlaceID)
 					$aExcludePlaceIDs[$iExcludedPlaceID] = $iExcludedPlaceID;
 			}
@@ -213,47 +255,54 @@ class Geocode
 					$aCountryCodes[] = strtolower($sCountryCode);
 				}
 			}
+
 			$this->aCountryCodes = $aCountryCodes;
 		}
 
 		if (isset($aParams['viewboxlbrt']) && $aParams['viewboxlbrt']) {
 			$aCoOrdinatesLBRT = explode(',', $aParams['viewboxlbrt']);
 			$this->setViewBox($aCoOrdinatesLBRT[0], $aCoOrdinatesLBRT[1], $aCoOrdinatesLBRT[2], $aCoOrdinatesLBRT[3]);
-		} elseif (isset($aParams['viewbox']) && $aParams['viewbox']) {
+		} else if (isset($aParams['viewbox']) && $aParams['viewbox']) {
 			$aCoOrdinatesLTRB = explode(',', $aParams['viewbox']);
 			$this->setViewBox($aCoOrdinatesLTRB[0], $aCoOrdinatesLTRB[3], $aCoOrdinatesLTRB[2], $aCoOrdinatesLTRB[1]);
 		}
 
 		if (isset($aParams['route']) && $aParams['route'] && isset($aParams['routewidth']) && $aParams['routewidth']) {
 			$aPoints = explode(',', $aParams['route']);
-			if (sizeof($aPoints) % 2 != 0) {
+			if ((sizeof($aPoints) % 2) != 0) {
 				userError("Uneven number of points");
 				exit;
 			}
+
 			$fPrevCoord = false;
 			$aRoute = array();
 			foreach ($aPoints as $i => $fPoint) {
-				if ($i%2) {
-					$aRoute[] = array((float)$fPoint, $fPrevCoord);
+				if (($i % 2)) {
+					$aRoute[] = array((float) $fPoint, $fPrevCoord);
 				} else {
-					$fPrevCoord = (float)$fPoint;
+					$fPrevCoord = (float) $fPoint;
 				}
 			}
+
 			$this->aRoutePoints = $aRoute;
 		}
-	}
+
+	}//end loadParamArray()
+
 
 	function setQueryFromParams($aParams)
 	{
 		// Search query
-		$sQuery = (isset($aParams['q'])?trim($aParams['q']):'');
+		$sQuery = (isset($aParams['q']) ? trim($aParams['q']) : '');
 		if (!$sQuery) {
 			$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
 			$this->setReverseInPlan(false);
 		} else {
 			$this->setQuery($sQuery);
 		}
-	}
+
+	}//end setQueryFromParams()
+
 
 	function loadStructuredAddressElement($sValue, $sKey, $iNewMinAddressRank, $iNewMaxAddressRank, $aItemListValues)
 	{
@@ -264,9 +313,12 @@ class Geocode
 			$this->iMinAddressRank = $iNewMinAddressRank;
 			$this->iMaxAddressRank = $iNewMaxAddressRank;
 		}
+
 		if ($aItemListValues) $this->aAddressRankList = array_merge($this->aAddressRankList, $aItemListValues);
 		return true;
-	}
+
+	}//end loadStructuredAddressElement()
+
 
 	function setStructuredQuery($sAmentiy = false, $sStreet = false, $sCity = false, $sCounty = false, $sState = false, $sCountry = false, $sPostalCode = false)
 	{
@@ -294,7 +346,9 @@ class Geocode
 				$sAllowedTypesSQLList = '(\'place\',\'boundary\')';
 			}
 		}
-	}
+
+	}//end setStructuredQuery()
+
 
 	function fallbackStructuredQuery()
 	{
@@ -315,11 +369,13 @@ class Geocode
 		}
 
 		return false;
-	}
+
+	}//end fallbackStructuredQuery()
+
 
 	function getDetails($aPlaceIDs)
 	{
-		//$aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
+		// $aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
 		if (sizeof($aPlaceIDs) == 0)  return array();
 
 		$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
@@ -358,7 +414,7 @@ class Geocode
 		$sSQL .= ",extratags->'place' ";
 
 		if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank) {
-			//only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines
+			// only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines
 			// with start- and endnumber, the common osm housenumbers are usually saved as points
 			$sHousenumbers = "";
 			$i = 0;
@@ -366,12 +422,12 @@ class Geocode
 			foreach ($aPlaceIDs as $placeID => $housenumber) {
 				$i++;
 				$sHousenumbers .= "(".$placeID.", ".$housenumber.")";
-				if ($i<$length)
+				if ($i < $length)
 					$sHousenumbers .= ", ";
 			}
 
 			if (CONST_Use_US_Tiger_Data) {
-				//Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
+				// Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
 				$sSQL .= " union";
 				$sSQL .= " select 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code";
 				$sSQL .= ", get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress ";
@@ -384,14 +440,15 @@ class Geocode
 				$sSQL .= ", (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance ";
 				$sSQL .= ", null as extra_place ";
 				$sSQL .= " from (select place_id";
-				//interpolate the Tiger housenumbers here
+				// interpolate the Tiger housenumbers here
 				$sSQL .= ", ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) as centroid, parent_place_id, housenumber_for_place";
 				$sSQL .= " from (location_property_tiger ";
 				$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
-				$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
-				$sSQL .= " group by place_id, housenumber_for_place"; //is this group by really needed?, place_id + housenumber (in combination) are unique
+				$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; // postgres wants an alias here
+				$sSQL .= " group by place_id, housenumber_for_place"; // is this group by really needed?, place_id + housenumber (in combination) are unique
 				if (!$this->bDeDupe) $sSQL .= ", place_id ";
-			}
+			}//end if
+
 			// osmline
 			// interpolation line search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
 			$sSQL .= " union ";
@@ -407,14 +464,14 @@ class Geocode
 			$sSQL .= " where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance,";
 			$sSQL .= " null as extra_place ";
 			$sSQL .= " from (select place_id, calculated_country_code ";
-			//interpolate the housenumbers here
+			// interpolate the housenumbers here
 			$sSQL .= ", CASE WHEN startnumber != endnumber THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
 			$sSQL .= " ELSE ST_LineInterpolatePoint(linegeo, 0.5) END as centroid";
 			$sSQL .= ", parent_place_id, housenumber_for_place ";
 			$sSQL .= " from (location_property_osmline ";
 			$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
-			$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
-			$sSQL .= " group by place_id, housenumber_for_place, calculated_country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
+			$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; // postgres wants an alias here
+			$sSQL .= " group by place_id, housenumber_for_place, calculated_country_code "; // is this group by really needed?, place_id + housenumber (in combination) are unique
 			if (!$this->bDeDupe) $sSQL .= ", place_id ";
 
 			if (CONST_Use_Aux_Location_data) {
@@ -435,31 +492,35 @@ class Geocode
 				if (!$this->bDeDupe) $sSQL .= ", place_id";
 				$sSQL .= ", get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) ";
 			}
-		}
+		}//end if
 
 		$sSQL .= " order by importance desc";
 		if (CONST_Debug) {
 			echo "<hr>";
 			var_dump($sSQL);
 		}
+
 		$aSearchResults = chksql($this->oDB->getAll($sSQL), "Could not get details for place.");
 
 		return $aSearchResults;
-	}
+
+	}//end getDetails()
+
 
 	function getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases)
 	{
 		/*
-			 Calculate all searches using aValidTokens i.e.
-			 'Wodsworth Road, Sheffield' =>
+			Calculate all searches using aValidTokens i.e.
+			'Wodsworth Road, Sheffield' =>
 
-			 Phrase Wordset
-			 0      0       (wodsworth road)
-			 0      1       (wodsworth)(road)
-			 1      0       (sheffield)
+			Phrase Wordset
+			0      0       (wodsworth road)
+			0      1       (wodsworth)(road)
+			1      0       (sheffield)
 
-			 Score how good the search is so they can be ordered
-		 */
+			Score how good the search is so they can be ordered
+		*/
+
 		foreach ($aPhrases as $iPhrase => $sPhrase) {
 			$aNewPhraseSearches = array();
 			if ($bStructuredPhrases) $sPhraseType = $aPhraseTypes[$iPhrase];
@@ -473,14 +534,14 @@ class Geocode
 
 				// Add all words from this wordset
 				foreach ($aWordset as $iToken => $sToken) {
-					//echo "<br><b>$sToken</b>";
+					// echo "<br><b>$sToken</b>";
 					$aNewWordsetSearches = array();
 
 					foreach ($aWordsetSearches as $aCurrentSearch) {
-						//echo "<i>";
-						//var_dump($aCurrentSearch);
-						//echo "</i>";
-
+						// echo "<i>";
+						// var_dump($aCurrentSearch);
+						// echo "</i>";
+						//
 						// If the token is valid
 						if (isset($aValidTokens[' '.$sToken])) {
 							foreach ($aValidTokens[' '.$sToken] as $aSearchTerm) {
@@ -490,19 +551,20 @@ class Geocode
 									if ($aSearch['sCountryCode'] === false) {
 										$aSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
 										// Country is almost always at the end of the string - increase score for finding it anywhere else (optimisation)
-										if (($iToken+1 != sizeof($aWordset) || $iPhrase+1 != sizeof($aPhrases))) {
+										if ((($iToken + 1) != sizeof($aWordset) || ($iPhrase + 1) != sizeof($aPhrases))) {
 											$aSearch['iSearchRank'] += 5;
 										}
+
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								} elseif (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null) {
+								} else if (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null) {
 									if ($aSearch['fLat'] === '') {
 										$aSearch['fLat'] = $aSearchTerm['lat'];
 										$aSearch['fLon'] = $aSearchTerm['lon'];
 										$aSearch['fRadius'] = $aSearchTerm['radius'];
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								} elseif ($sPhraseType == 'postalcode') {
+								} else if ($sPhraseType == 'postalcode') {
 									// We need to try the case where the postal code is the primary element (i.e. no way to tell if it is (postalcode, city) OR (city, postalcode) so try both
 									if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
 										// If we already have a name try putting the postcode first
@@ -523,11 +585,12 @@ class Geocode
 											}
 										} else {
 											$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-											//$aSearch['iNamePhrase'] = $iPhrase;
+											// $aSearch['iNamePhrase'] = $iPhrase;
 										}
+
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-									}
-								} elseif (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house') {
+									}//end if
+								} else if (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house') {
 									if ($aSearch['sHouseNumber'] === '') {
 										$aSearch['sHouseNumber'] = $sToken;
 										// sanity check: if the housenumber is not mainly made
@@ -536,14 +599,15 @@ class Geocode
 										// also housenumbers should appear in the first or second phrase
 										if ($iPhrase > 1) $aSearch['iSearchRank'] += 1;
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										/*
+
+										//
 										// Fall back to not searching for this item (better than nothing)
-										$aSearch = $aCurrentSearch;
-										$aSearch['iSearchRank'] += 1;
-										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										 */
+										// $aSearch = $aCurrentSearch;
+										// $aSearch['iSearchRank'] += 1;
+										// if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+										//
 									}
-								} elseif ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null) {
+								} else if ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null) {
 									if ($aSearch['sClass'] === '') {
 										$aSearch['sOperator'] = $aSearchTerm['operator'];
 										$aSearch['sClass'] = $aSearchTerm['class'];
@@ -554,7 +618,7 @@ class Geocode
 
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								} elseif (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
+								} else if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
 									if (sizeof($aSearch['aName'])) {
 										if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false)) {
 											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
@@ -564,12 +628,14 @@ class Geocode
 										}
 									} else {
 										$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-										//$aSearch['iNamePhrase'] = $iPhrase;
+										// $aSearch['iNamePhrase'] = $iPhrase;
 									}
+
 									if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-								}
-							}
-						}
+								}//end if
+							}//end foreach
+						}//end if
+
 						// Look for partial matches.
 						// Note that there is no point in adding country terms here
 						// because country are omitted in the address.
@@ -583,14 +649,15 @@ class Geocode
 										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency) {
 											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										} elseif (isset($aValidTokens[' '.$sToken])) { // revert to the token version?
+										} else if (isset($aValidTokens[' '.$sToken])) { // revert to the token version?
 											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											$aSearch['iSearchRank'] += 1;
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 											foreach ($aValidTokens[' '.$sToken] as $aSearchTermToken) {
 												if (empty($aSearchTermToken['country_code'])
-														&& empty($aSearchTermToken['lat'])
-														&& empty($aSearchTermToken['class'])) {
+												    && empty($aSearchTermToken['lat'])
+												    && empty($aSearchTermToken['class'])
+												) {
 													$aSearch = $aCurrentSearch;
 													$aSearch['iSearchRank'] += 1;
 													$aSearch['aAddress'][$aSearchTermToken['word_id']] = $aSearchTermToken['word_id'];
@@ -601,8 +668,8 @@ class Geocode
 											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										}
-									}
+										}//end if
+									}//end if
 
 									if (!sizeof($aCurrentSearch['aName']) || $aCurrentSearch['iNamePhrase'] == $iPhrase) {
 										$aSearch = $aCurrentSearch;
@@ -614,24 +681,25 @@ class Geocode
 										} else {
 											$aSearch['aNameNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 										}
+
 										$aSearch['iNamePhrase'] = $iPhrase;
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-									}
-								}
-							}
+									}//end if
+								}//end if
+							}//end foreach
 						} else {
 							// Allow skipping a word - but at EXTREAM cost
-							//$aSearch = $aCurrentSearch;
-							//$aSearch['iSearchRank']+=100;
-							//$aNewWordsetSearches[] = $aSearch;
-						}
-					}
+							// $aSearch = $aCurrentSearch;
+							// $aSearch['iSearchRank']+=100;
+							// $aNewWordsetSearches[] = $aSearch;
+						}//end if
+					}//end foreach
 					// Sort and cut
 					usort($aNewWordsetSearches, 'bySearchRank');
 					$aWordsetSearches = array_slice($aNewWordsetSearches, 0, 50);
-				}
-				//var_Dump('<hr>',sizeof($aWordsetSearches)); exit;
+				}//end foreach
 
+				// var_Dump('<hr>',sizeof($aWordsetSearches)); exit;
 				$aNewPhraseSearches = array_merge($aNewPhraseSearches, $aNewWordsetSearches);
 				usort($aNewPhraseSearches, 'bySearchRank');
 
@@ -643,7 +711,7 @@ class Geocode
 				}
 
 				$aNewPhraseSearches = array_slice($aNewPhraseSearches, 0, 50);
-			}
+			}//end foreach
 
 			// Re-group the searches by their score, junk anything over 20 as just not worth trying
 			$aGroupedSearches = array();
@@ -653,6 +721,7 @@ class Geocode
 					$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
 				}
 			}
+
 			ksort($aGroupedSearches);
 
 			$iSearchCount = 0;
@@ -663,12 +732,16 @@ class Geocode
 				if ($iSearchCount > 50) break;
 			}
 
-			//if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
-		}
-		return $aGroupedSearches;
-	}
+			// if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
+		}//end foreach
 
-	/* Perform the actual query lookup.
+		return $aGroupedSearches;
+
+	}//end getGroupedSearches()
+
+
+	/*
+		Perform the actual query lookup.
 
 		Returns an ordered list of results, each with the following fields:
 			osm_type: type of corresponding OSM object
@@ -698,6 +771,8 @@ class Geocode
 			name: full name (currently the same as langaddress)
 			foundorder: secondary ordering for places with same importance
 	*/
+
+
 	function lookup()
 	{
 		if (!$this->sQuery && !$this->aStructuredQuery) return false;
@@ -721,15 +796,15 @@ class Geocode
 		$sViewboxCentreSQL = false;
 		$bBoundingBoxSearch = false;
 		if ($this->aViewBox) {
-			$fHeight = $this->aViewBox[0]-$this->aViewBox[2];
-			$fWidth = $this->aViewBox[1]-$this->aViewBox[3];
-			$aBigViewBox[0] = $this->aViewBox[0] + $fHeight;
-			$aBigViewBox[2] = $this->aViewBox[2] - $fHeight;
-			$aBigViewBox[1] = $this->aViewBox[1] + $fWidth;
-			$aBigViewBox[3] = $this->aViewBox[3] - $fWidth;
+			$fHeight = ($this->aViewBox[0] - $this->aViewBox[2]);
+			$fWidth  = ($this->aViewBox[1] - $this->aViewBox[3]);
+			$aBigViewBox[0] = ($this->aViewBox[0] + $fHeight);
+			$aBigViewBox[2] = ($this->aViewBox[2] - $fHeight);
+			$aBigViewBox[1] = ($this->aViewBox[1] + $fWidth);
+			$aBigViewBox[3] = ($this->aViewBox[3] - $fWidth);
 
-			$this->sViewboxSmallSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$this->aViewBox[0].",".(float)$this->aViewBox[1]."),ST_Point(".(float)$this->aViewBox[2].",".(float)$this->aViewBox[3].")),4326)";
-			$this->sViewboxLargeSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$aBigViewBox[0].",".(float)$aBigViewBox[1]."),ST_Point(".(float)$aBigViewBox[2].",".(float)$aBigViewBox[3].")),4326)";
+			$this->sViewboxSmallSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float) $this->aViewBox[0].",".(float) $this->aViewBox[1]."),ST_Point(".(float) $this->aViewBox[2].",".(float) $this->aViewBox[3].")),4326)";
+			$this->sViewboxLargeSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float) $aBigViewBox[0].",".(float) $aBigViewBox[1]."),ST_Point(".(float) $aBigViewBox[2].",".(float) $aBigViewBox[3].")),4326)";
 			$bBoundingBoxSearch = $this->bBoundedSearch;
 		}
 
@@ -742,18 +817,19 @@ class Geocode
 				$sViewboxCentreSQL .= $aPoint[0].' '.$aPoint[1];
 				$bFirst = false;
 			}
+
 			$sViewboxCentreSQL .= ")'::geometry,4326)";
 
-			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/69).")";
+			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float) ($_GET['routewidth'] / 69).")";
 			$this->sViewboxSmallSQL = chksql($this->oDB->getOne($sSQL), "Could not get small viewbox.");
 			$this->sViewboxSmallSQL = "'".$this->sViewboxSmallSQL."'::geometry";
 
-			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/30).")";
+			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float) ($_GET['routewidth'] / 30).")";
 			$this->sViewboxLargeSQL = chksql($this->oDB->getOne($sSQL), "Could not get large viewbox.");
 			$this->sViewboxLargeSQL = "'".$this->sViewboxLargeSQL."'::geometry";
 
 			$bBoundingBoxSearch = $this->bBoundedSearch;
-		}
+		}//end if
 
 		// Do we have anything that looks like a lat/lon pair?
 		if ($aLooksLike = looksLikeLatLonPair($sQuery)) {
@@ -765,32 +841,33 @@ class Geocode
 		if ($sQuery || $this->aStructuredQuery) {
 			// Start with a blank search
 			$aSearches = array(
-				array('iSearchRank' => 0,
-							'iNamePhrase' => -1,
-							'sCountryCode' => false,
-							'aName' => array(),
-							'aAddress' => array(),
-							'aFullNameAddress' => array(),
-							'aNameNonSearch' => array(),
-							'aAddressNonSearch' => array(),
-							'sOperator' => '',
-							'aFeatureName' => array(),
-							'sClass' => '',
-							'sType' => '',
-							'sHouseNumber' => '',
-							'fLat' => '',
-							'fLon' => '',
-							'fRadius' => ''
-						)
-			);
+			              array(
+			               'iSearchRank' => 0,
+			               'iNamePhrase' => -1,
+			               'sCountryCode' => false,
+			               'aName' => array(),
+			               'aAddress' => array(),
+			               'aFullNameAddress' => array(),
+			               'aNameNonSearch' => array(),
+			               'aAddressNonSearch' => array(),
+			               'sOperator' => '',
+			               'aFeatureName' => array(),
+			               'sClass' => '',
+			               'sType' => '',
+			               'sHouseNumber' => '',
+			               'fLat' => '',
+			               'fLon' => '',
+			               'fRadius' => ''
+			              )
+			             );
 
 			// Do we have a radius search?
 			$sNearPointSQL = false;
 			if ($this->aNearPoint) {
-				$sNearPointSQL = "ST_SetSRID(ST_Point(".(float)$this->aNearPoint[1].",".(float)$this->aNearPoint[0]."),4326)";
-				$aSearches[0]['fLat'] = (float)$this->aNearPoint[0];
-				$aSearches[0]['fLon'] = (float)$this->aNearPoint[1];
-				$aSearches[0]['fRadius'] = (float)$this->aNearPoint[2];
+				$sNearPointSQL = "ST_SetSRID(ST_Point(".(float) $this->aNearPoint[1].",".(float) $this->aNearPoint[0]."),4326)";
+				$aSearches[0]['fLat'] = (float) $this->aNearPoint[0];
+				$aSearches[0]['fLon'] = (float) $this->aNearPoint[1];
+				$aSearches[0]['fRadius'] = (float) $this->aNearPoint[2];
 			}
 
 			// Any 'special' terms in the search?
@@ -825,6 +902,7 @@ class Geocode
 							$aNewSearches[] = $aNewSearch;
 							$bSpecialTerms = true;
 						}
+
 						if ($aSearchTerm['class']) {
 							$aNewSearch['sClass'] = $aSearchTerm['class'];
 							$aNewSearch['sType'] = $aSearchTerm['type'];
@@ -833,8 +911,9 @@ class Geocode
 						}
 					}
 				}
+
 				$aSearches = $aNewSearches;
-			}
+			}//end foreach
 
 			// Split query into phrases
 			// Commas are used to reduce the search space by indicating where phrases split
@@ -883,12 +962,14 @@ class Geocode
 				} else {
 					$aDatabaseWords = array();
 				}
+
 				$aPossibleMainWordIDs = array();
 				$aWordFrequencyScores = array();
 				foreach ($aDatabaseWords as $aToken) {
 					// Very special case - require 2 letter country param to match the country code found
 					if ($bStructuredPhrases && $aToken['country_code'] && !empty($this->aStructuredQuery['country'])
-							&& strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code']) {
+					    && strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code']
+					) {
 						continue;
 					}
 
@@ -897,9 +978,11 @@ class Geocode
 					} else {
 						$aValidTokens[$aToken['word_token']] = array($aToken);
 					}
+
 					if (!$aToken['class'] && !$aToken['country_code']) $aPossibleMainWordIDs[$aToken['word_id']] = 1;
-					$aWordFrequencyScores[$aToken['word_id']] = $aToken['search_name_count'] + 1;
+					$aWordFrequencyScores[$aToken['word_id']] = ($aToken['search_name_count'] + 1);
 				}
+
 				if (CONST_Debug) var_Dump($aPhrases, $aValidTokens);
 
 				// Try and calculate GB postcodes we might be missing
@@ -907,16 +990,17 @@ class Geocode
 					// Source of gb postcodes is now definitive - always use
 					if (preg_match('/^([A-Z][A-Z]?[0-9][0-9A-Z]? ?[0-9])([A-Z][A-Z])$/', strtoupper(trim($sToken)), $aData)) {
 						if (substr($aData[1], -2, 1) != ' ') {
-							$aData[0] = substr($aData[0], 0, strlen($aData[1])-1).' '.substr($aData[0], strlen($aData[1])-1);
+							$aData[0] = substr($aData[0], 0, (strlen($aData[1]) - 1)).' '.substr($aData[0], (strlen($aData[1]) - 1));
 							$aData[1] = substr($aData[1], 0, -1).' '.substr($aData[1], -1, 1);
 						}
+
 						$aGBPostcodeLocation = gbPostcodeCalculate($aData[0], $aData[1], $aData[2], $this->oDB);
 						if ($aGBPostcodeLocation) {
 							$aValidTokens[$sToken] = $aGBPostcodeLocation;
 						}
-					} elseif (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
+					} else if (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
 						// US ZIP+4 codes - if there is no token,
-						// 	merge in the 5-digit ZIP code
+						// merge in the 5-digit ZIP code
 						if (isset($aValidTokens[$aData[1]])) {
 							foreach ($aValidTokens[$aData[1]] as $aToken) {
 								if (!$aToken['class']) {
@@ -928,19 +1012,18 @@ class Geocode
 								}
 							}
 						}
-					}
-				}
+					}//end if
+				}//end foreach
 
 				foreach ($aTokens as $sToken) {
 					// Unknown single word token with a number - assume it is a house number
 					if (!isset($aValidTokens[' '.$sToken]) && strpos($sToken, ' ') === false && preg_match('/[0-9]/', $sToken)) {
-						$aValidTokens[' '.$sToken] = array(array('class'=>'place','type'=>'house'));
+						$aValidTokens[' '.$sToken] = array(array('class' => 'place', 'type' => 'house'));
 					}
 				}
 
 				// Any words that have failed completely?
 				// TODO: suggestions
-
 				// Start the search process
 				// array with: placeid => -1 | tiger-housenumber
 				$aResultPlaceIDs = array();
@@ -955,8 +1038,9 @@ class Geocode
 					$aPhrases[0]['wordsets'] = getInverseWordSets($aPhrases[0]['words'], 0);
 					if (sizeof($aPhrases) > 1) {
 						$aFinalPhrase = end($aPhrases);
-						$aPhrases[sizeof($aPhrases)-1]['wordsets'] = getInverseWordSets($aFinalPhrase['words'], 0);
+						$aPhrases[(sizeof($aPhrases) - 1)]['wordsets'] = getInverseWordSets($aFinalPhrase['words'], 0);
 					}
+
 					$aReverseGroupedSearches = $this->getGroupedSearches($aSearches, null, $aPhrases, $aValidTokens, $aWordFrequencyScores, false);
 
 					foreach ($aGroupedSearches as $aSearches) {
@@ -970,7 +1054,7 @@ class Geocode
 
 					$aGroupedSearches = $aReverseGroupedSearches;
 					ksort($aGroupedSearches);
-				}
+				}//end if
 			} else {
 				// Re-group the searches by their score, junk anything over 20 as just not worth trying
 				$aGroupedSearches = array();
@@ -980,8 +1064,9 @@ class Geocode
 						$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
 					}
 				}
+
 				ksort($aGroupedSearches);
-			}
+			}//end if
 
 			if (CONST_Debug) var_Dump($aGroupedSearches);
 
@@ -997,7 +1082,7 @@ class Geocode
 							$aNewReductionsList = array();
 							foreach ($aReductionsList as $aReductionsWordList) {
 								for ($iReductionWord = 0; $iReductionWord < sizeof($aReductionsWordList); $iReductionWord++) {
-									$aReductionsWordListResult = array_merge(array_slice($aReductionsWordList, 0, $iReductionWord), array_slice($aReductionsWordList, $iReductionWord+1));
+									$aReductionsWordListResult = array_merge(array_slice($aReductionsWordList, 0, $iReductionWord), array_slice($aReductionsWordList, ($iReductionWord + 1)));
 									$aReverseSearch = $aSearch;
 									$aSearch['aAddress'] = $aReductionsWordListResult;
 									$aSearch['iSearchRank'] = $iSearchRank;
@@ -1007,12 +1092,13 @@ class Geocode
 									}
 								}
 							}
+
 							$aReductionsList = $aNewReductionsList;
 						}
-					}
-				}
+					}//end foreach
+				}//end foreach
 				ksort($aGroupedSearches);
-			}
+			}//end if
 
 			// Filter out duplicate searches
 			$aSearchHash = array();
@@ -1070,6 +1156,7 @@ class Geocode
 								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
+
 								if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
 								$sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
@@ -1097,11 +1184,11 @@ class Geocode
 								$sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-							}
-						}
-					} elseif ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass']) {
-					// If a coordinate is given, the search must either
-					// be for a name or a special search. Ignore everythin else.
+							}//end if
+						}//end if
+					} else if ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass']) {
+						// If a coordinate is given, the search must either
+						// be for a name or a special search. Ignore everythin else.
 						$aPlaceIDs = array();
 					} else {
 						$aPlaceIDs = array();
@@ -1127,15 +1214,17 @@ class Geocode
 						if (sizeof($aSearch['aNameNonSearch'])) $aTerms[] = "array_cat(name_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aNameNonSearch'], ",")."]";
 						if (sizeof($aSearch['aAddress']) && $aSearch['aName'] != $aSearch['aAddress']) {
 							// For infrequent name terms disable index usage for address
-							if (CONST_Search_NameOnlySearchFrequencyThreshold &&
-									sizeof($aSearch['aName']) == 1 &&
-									$aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold) {
+							if (CONST_Search_NameOnlySearchFrequencyThreshold
+							    && sizeof($aSearch['aName']) == 1
+							    && $aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold
+							) {
 								$aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join(array_merge($aSearch['aAddress'], $aSearch['aAddressNonSearch']), ",")."]";
 							} else {
 								$aTerms[] = "nameaddress_vector @> ARRAY[".join($aSearch['aAddress'], ",")."]";
 								if (sizeof($aSearch['aAddressNonSearch'])) $aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aAddressNonSearch'], ",")."]";
 							}
 						}
+
 						if ($aSearch['sCountryCode']) $aTerms[] = "country_code = '".pg_escape_string($aSearch['sCountryCode'])."'";
 						if ($aSearch['sHouseNumber']) {
 							$aTerms[] = "address_rank between 16 and 27";
@@ -1143,17 +1232,21 @@ class Geocode
 							if ($this->iMinAddressRank > 0) {
 								$aTerms[] = "address_rank >= ".$this->iMinAddressRank;
 							}
+
 							if ($this->iMaxAddressRank < 30) {
 								$aTerms[] = "address_rank <= ".$this->iMaxAddressRank;
 							}
 						}
+
 						if ($aSearch['fLon'] && $aSearch['fLat']) {
 							$aTerms[] = "ST_DWithin(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326), ".$aSearch['fRadius'].")";
 							$aOrder[] = "ST_Distance(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326)) ASC";
 						}
+
 						if (sizeof($this->aExcludePlaceIDs)) {
 							$aTerms[] = "place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 						}
+
 						if ($sCountryCodesSQL) {
 							$aTerms[] = "country_code in ($sCountryCodesSQL)";
 						}
@@ -1166,6 +1259,7 @@ class Geocode
 						} else {
 							$sImportanceSQL = '(case when importance = 0 OR importance IS NULL then 0.75-(search_rank::float/40) else importance end)';
 						}
+
 						if ($this->sViewboxSmallSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxSmallSQL, centroid) THEN 1 ELSE 0.5 END";
 						if ($this->sViewboxLargeSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxLargeSQL, centroid) THEN 1 ELSE 0.5 END";
 
@@ -1185,29 +1279,29 @@ class Geocode
 							$sSQL .= " order by ".join(', ', $aOrder);
 							if ($aSearch['sHouseNumber'] || $aSearch['sClass'])
 								$sSQL .= " limit 20";
-							elseif (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && $aSearch['sClass'])
+							else if (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && $aSearch['sClass'])
 								$sSQL .= " limit 1";
 							else $sSQL .= " limit ".$this->iLimit;
 
 							if (CONST_Debug) var_dump($sSQL);
 							$aViewBoxPlaceIDs = chksql($this->oDB->getAll($sSQL), "Could not get places for search terms.");
-							//var_dump($aViewBoxPlaceIDs);
+							// var_dump($aViewBoxPlaceIDs);
 							// Did we have an viewbox matches?
 							$aPlaceIDs = array();
 							$bViewBoxMatch = false;
 							foreach ($aViewBoxPlaceIDs as $aViewBoxRow) {
-								//if ($bViewBoxMatch == 1 && $aViewBoxRow['in_small'] == 'f') break;
-								//if ($bViewBoxMatch == 2 && $aViewBoxRow['in_large'] == 'f') break;
-								//if ($aViewBoxRow['in_small'] == 't') $bViewBoxMatch = 1;
-								//else if ($aViewBoxRow['in_large'] == 't') $bViewBoxMatch = 2;
+								// if ($bViewBoxMatch == 1 && $aViewBoxRow['in_small'] == 'f') break;
+								// if ($bViewBoxMatch == 2 && $aViewBoxRow['in_large'] == 'f') break;
+								// if ($aViewBoxRow['in_small'] == 't') $bViewBoxMatch = 1;
+								// else if ($aViewBoxRow['in_large'] == 't') $bViewBoxMatch = 2;
 								$aPlaceIDs[] = $aViewBoxRow['place_id'];
 								$this->exactMatchCache[$aViewBoxRow['place_id']] = $aViewBoxRow['exactmatch'];
 							}
-						}
-						//var_Dump($aPlaceIDs);
-						//exit;
+						}//end if
 
-						//now search for housenumber, if housenumber provided
+						// var_Dump($aPlaceIDs);
+						// exit;
+						// now search for housenumber, if housenumber provided
 						if ($aSearch['sHouseNumber'] && sizeof($aPlaceIDs)) {
 							$searchedHousenumber = intval($aSearch['sHouseNumber']);
 							$aRoadPlaceIDs = $aPlaceIDs;
@@ -1219,71 +1313,74 @@ class Geocode
 							if (sizeof($this->aExcludePlaceIDs)) {
 								$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 							}
+
 							$sSQL .= " limit $this->iLimit";
 							if (CONST_Debug) var_dump($sSQL);
 							$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-							
+
 							// if nothing found, search in the interpolation line table
 							if (!sizeof($aPlaceIDs)) {
 								// do we need to use transliteration and the regex for housenumbers???
-								//new query for lines, not housenumbers anymore
-								if ($searchedHousenumber%2 == 0) {
-									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
+								// new query for lines, not housenumbers anymore
+								if (($searchedHousenumber % 2) == 0) {
+									// if housenumber is even, look for housenumber in streets with interpolationtype even or all
 									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								} else {
-									//look for housenumber in streets with interpolationtype odd or all
+									// look for housenumber in streets with interpolationtype odd or all
 									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
 								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
-								//$sSQL .= " limit $this->iLimit";
+
+								// $sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
-								//get place IDs
+								// get place IDs
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
 							}
-								
+
 							// If nothing found try the aux fallback table
 							if (CONST_Use_Aux_Location_data && !sizeof($aPlaceIDs)) {
 								$sSQL = "select place_id from location_property_aux where parent_place_id in (".$sPlaceIDs.") and housenumber = '".pg_escape_string($aSearch['sHouseNumber'])."'";
 								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and parent_place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
-								//$sSQL .= " limit $this->iLimit";
+
+								// $sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							}
 
-							//if nothing was found in placex or location_property_aux, then search in Tiger data for this housenumber(location_property_tiger)
+							// if nothing was found in placex or location_property_aux, then search in Tiger data for this housenumber(location_property_tiger)
 							if (CONST_Use_US_Tiger_Data && !sizeof($aPlaceIDs)) {
-								//new query for lines, not housenumbers anymore
-								if ($searchedHousenumber%2 == 0) {
-									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
+								// new query for lines, not housenumbers anymore
+								if (($searchedHousenumber % 2) == 0) {
+									// if housenumber is even, look for housenumber in streets with interpolationtype even or all
 									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								} else {
-									//look for housenumber in streets with interpolationtype odd or all
+									// look for housenumber in streets with interpolationtype odd or all
 									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
 								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
-								//$sSQL .= " limit $this->iLimit";
+
+								// $sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
-								//get place IDs
+								// get place IDs
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
 							}
 
 							// Fallback to the road (if no housenumber was found)
 							if (!sizeof($aPlaceIDs) && preg_match('/[0-9]+/', $aSearch['sHouseNumber'])) {
 								$aPlaceIDs = $aRoadPlaceIDs;
-								//set to -1, if no housenumbers were found
+								// set to -1, if no housenumbers were found
 								$searchedHousenumber = -1;
+								// else: housenumber was found, remains saved in searchedHousenumber
 							}
-							//else: housenumber was found, remains saved in searchedHousenumber
-						}
-
+						}//end if
 
 						if ($aSearch['sClass'] && sizeof($aPlaceIDs)) {
 							$sPlaceIDs = join(',', $aPlaceIDs);
@@ -1306,7 +1403,7 @@ class Geocode
 								$sSQL = "select min(rank_search) from placex where place_id in ($sPlaceIDs)";
 
 								if (CONST_Debug) var_dump($sSQL);
-								$this->iMaxRank = ((int)chksql($this->oDB->getOne($sSQL)));
+								$this->iMaxRank = ((int) chksql($this->oDB->getOne($sSQL)));
 
 								// For state / country level searches the normal radius search doesn't work very well
 								$sPlaceGeom = false;
@@ -1335,22 +1432,25 @@ class Geocode
 
 										$sOrderBySQL = '';
 										if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.centroid)";
-										elseif ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
-										elseif ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
+										else if ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
+										else if ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
 
-										$sSQL = "select distinct l.place_id".($sOrderBySQL?','.$sOrderBySQL:'')." from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." as l";
+										$sSQL = "select distinct l.place_id".($sOrderBySQL ? ','.$sOrderBySQL : '')." from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." as l";
 										if ($sCountryCodesSQL) $sSQL .= " join placex as lp using (place_id)";
 										if ($sPlaceIDs) {
 											$sSQL .= ",placex as f where ";
 											$sSQL .= "f.place_id in ($sPlaceIDs) and ST_DWithin(l.centroid, f.centroid, $fRange) ";
 										}
+
 										if ($sPlaceGeom) {
 											$sSQL .= " where ";
 											$sSQL .= "ST_Contains('".$sPlaceGeom."', l.centroid) ";
 										}
+
 										if (sizeof($this->aExcludePlaceIDs)) {
 											$sSQL .= " and l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 										}
+
 										if ($sCountryCodesSQL) $sSQL .= " and lp.calculated_country_code in ($sCountryCodesSQL)";
 										if ($sOrderBySQL) $sSQL .= "order by ".$sOrderBySQL." asc";
 										if ($this->iOffset) $sSQL .= " offset $this->iOffset";
@@ -1364,25 +1464,26 @@ class Geocode
 										if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.geometry)";
 										else $sOrderBySQL = "ST_Distance(l.geometry, f.geometry)";
 
-										$sSQL = "select distinct l.place_id".($sOrderBysSQL?','.$sOrderBysSQL:'')." from placex as l,placex as f where ";
+										$sSQL = "select distinct l.place_id".($sOrderBysSQL ? ','.$sOrderBysSQL : '')." from placex as l,placex as f where ";
 										$sSQL .= "f.place_id in ( $sPlaceIDs) and ST_DWithin(l.geometry, f.centroid, $fRange) ";
 										$sSQL .= "and l.class='".$aSearch['sClass']."' and l.type='".$aSearch['sType']."' ";
 										if (sizeof($this->aExcludePlaceIDs)) {
 											$sSQL .= " and l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 										}
+
 										if ($sCountryCodesSQL) $sSQL .= " and l.calculated_country_code in ($sCountryCodesSQL)";
 										if ($sOrderBy) $sSQL .= "order by ".$OrderBysSQL." asc";
 										if ($this->iOffset) $sSQL .= " offset $this->iOffset";
 										$sSQL .= " limit $this->iLimit";
 										if (CONST_Debug) var_dump($sSQL);
 										$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
-									}
-								}
-							}
+									}//end if
+								}//end if
+							}//end if
 
 							$aPlaceIDs = $aClassPlaceIDs;
-						}
-					}
+						}//end if
+					}//end if
 
 					if (CONST_Debug) {
 						echo "<br><b>Place IDs:</b> ";
@@ -1393,8 +1494,9 @@ class Geocode
 						// array for placeID => -1 | Tiger housenumber
 						$aResultPlaceIDs[$iPlaceID] = $searchedHousenumber;
 					}
+
 					if ($iQueryLoop > 20) break;
-				}
+				}//end foreach
 
 				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30)) {
 					// Need to verify passes rank limits before dropping out of the loop (yuk!)
@@ -1409,22 +1511,24 @@ class Geocode
 						$sSQL .= "and (30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
 						if ($this->aAddressRankList) $sSQL .= " OR 30 in (".join(',', $this->aAddressRankList).")";
 					}
+
 					$sSQL .= ") UNION select place_id from location_property_osmline where place_id in (".join(',', array_keys($aResultPlaceIDs)).")";
 					$sSQL .= " and (30 between $this->iMinAddressRank and $this->iMaxAddressRank)";
 					if (CONST_Debug) var_dump($sSQL);
 					$aFilteredPlaceIDs = chksql($this->oDB->getCol($sSQL));
 					$tempIDs = array();
 					foreach ($aFilteredPlaceIDs as $placeID) {
-						$tempIDs[$placeID] = $aResultPlaceIDs[$placeID];  //assign housenumber to placeID
+						$tempIDs[$placeID] = $aResultPlaceIDs[$placeID]; // assign housenumber to placeID
 					}
-					$aResultPlaceIDs = $tempIDs;
-				}
 
-				//exit;
+					$aResultPlaceIDs = $tempIDs;
+				}//end if
+
+				// exit;
 				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs)) break;
 				if ($iGroupLoop > 4) break;
 				if ($iQueryLoop > 30) break;
-			}
+			}//end foreach
 
 			// Did we find anything?
 			if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs)) {
@@ -1436,8 +1540,8 @@ class Geocode
 			$oReverse->setZoom(18);
 
 			$aLookup = $oReverse->lookup(
-				(float)$this->aNearPoint[0],
-				(float)$this->aNearPoint[1],
+				(float) $this->aNearPoint[0],
+				(float) $this->aNearPoint[1],
 				false
 			);
 
@@ -1446,7 +1550,7 @@ class Geocode
 			if ($aLookup['place_id'])
 				$aSearchResults = $this->getDetails(array($aLookup['place_id'] => -1));
 			else $aSearchResults = array();
-		}
+		}//end if
 
 		// No results? Done
 		if (!sizeof($aSearchResults)) {
@@ -1482,11 +1586,11 @@ class Geocode
 			// Default
 			$fDiameter = getResultDiameter($aResult);
 
-			$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter/2);
+			$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], ($fDiameter / 2));
 			if ($aOutlineResult) {
 				$aResult = array_merge($aResult, $aOutlineResult);
 			}
-			
+
 			if ($aResult['extra_place'] == 'city') {
 				$aResult['class'] = 'place';
 				$aResult['type'] = 'city';
@@ -1495,17 +1599,21 @@ class Geocode
 
 			// Is there an icon set for this type of result?
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type']]['icon']) {
+			    && $aClassType[$aResult['class'].':'.$aResult['type']]['icon']
+			) {
 				$aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aClassType[$aResult['class'].':'.$aResult['type']]['icon'].'.p.20.png';
 			}
 
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label']) {
+			    && $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label']
+			) {
 				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'];
-			} elseif (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type']]['label']) {
+			} else if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
+			    && $aClassType[$aResult['class'].':'.$aResult['type']]['label']
+			) {
 				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type']]['label'];
 			}
+
 			// if tag '&addressdetails=1' is set in query
 			if ($this->bIncludeAddressDetails) {
 				// getAddressDetails() is defined in lib.php and uses the SQL function get_addressdata in functions.sql
@@ -1536,33 +1644,36 @@ class Geocode
 			$iCountWords = 0;
 			$sAddress = $aResult['langaddress'];
 			foreach ($aRecheckWords as $i => $sWord) {
-				if (stripos($sAddress, $sWord)!==false) {
+				if (stripos($sAddress, $sWord) !== false) {
 					$iCountWords++;
 					if (preg_match("/(^|,)\s*".preg_quote($sWord, '/')."\s*(,|$)/", $sAddress)) $iCountWords += 0.1;
 				}
 			}
 
-			$aResult['importance'] = $aResult['importance'] + ($iCountWords*0.1); // 0.1 is a completely arbitrary number but something in the range 0.1 to 0.5 would seem right
+			$aResult['importance'] = ($aResult['importance'] + ($iCountWords * 0.1)); // 0.1 is a completely arbitrary number but something in the range 0.1 to 0.5 would seem right
 
 			$aResult['name'] = $aResult['langaddress'];
 			// secondary ordering (for results with same importance (the smaller the better):
-			//   - approximate importance of address parts
-			$aResult['foundorder'] = -$aResult['addressimportance']/10;
-			//   - number of exact matches from the query
+			// - approximate importance of address parts
+			$aResult['foundorder'] = (-$aResult['addressimportance'] / 10);
+			// - number of exact matches from the query
 			if (isset($this->exactMatchCache[$aResult['place_id']]))
 				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
-			elseif (isset($this->exactMatchCache[$aResult['parent_place_id']]))
+			else if (isset($this->exactMatchCache[$aResult['parent_place_id']]))
 				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
-			//  - importance of the class/type
+			// - importance of the class/type
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
-				&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance']) {
-				$aResult['foundorder'] += 0.0001 * $aClassType[$aResult['class'].':'.$aResult['type']]['importance'];
+				&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance']
+			) {
+				$aResult['foundorder'] += (0.0001 * $aClassType[$aResult['class'].':'.$aResult['type']]['importance']);
 			} else {
 				$aResult['foundorder'] += 0.01;
 			}
+
 			if (CONST_Debug) var_dump($aResult);
 			$aSearchResults[$iResNum] = $aResult;
-		}
+		}//end foreach
+
 		uasort($aSearchResults, 'byImportance');
 
 		$aOSMIDDone = array();
@@ -1579,8 +1690,10 @@ class Geocode
 				if (isset($aResult['zoom'])) $iZoom = $aResult['zoom'];
 				$bFirst = false;
 			}
+
 			if (!$this->bDeDupe || (!isset($aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']])
-						&& !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']]))) {
+			    && !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']]))
+			) {
 				$aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']] = true;
 				$aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']] = true;
 				$aSearchResults[] = $aResult;
@@ -1591,5 +1704,8 @@ class Geocode
 		}
 
 		return $aSearchResults;
-	} // end lookup()
-} // end class
+
+	}//end lookup()
+
+
+}//end class

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -136,20 +136,19 @@ class Geocode
 
 	function setFeatureType($sFeatureType)
 	{
-		switch($sFeatureType)
-		{
-		case 'country':
-			$this->setRankRange(4, 4);
-			break;
-		case 'state':
-			$this->setRankRange(8, 8);
-			break;
-		case 'city':
-			$this->setRankRange(14, 16);
-			break;
-		case 'settlement':
-			$this->setRankRange(8, 20);
-			break;
+		switch ($sFeatureType) {
+			case 'country':
+				$this->setRankRange(4, 4);
+				break;
+			case 'state':
+				$this->setRankRange(8, 8);
+				break;
+			case 'city':
+				$this->setRankRange(14, 16);
+				break;
+			case 'settlement':
+				$this->setRankRange(8, 20);
+				break;
 		}
 	}
 
@@ -191,10 +190,8 @@ class Geocode
 		if (isset($aParams['fallback'])) $this->bFallback = (bool)$aParams['fallback'];
 
 		// List of excluded Place IDs - used for more acurate pageing
-		if (isset($aParams['exclude_place_ids']) && $aParams['exclude_place_ids'])
-		{
-			foreach(explode(',',$aParams['exclude_place_ids']) as $iExcludedPlaceID)
-			{
+		if (isset($aParams['exclude_place_ids']) && $aParams['exclude_place_ids']) {
+			foreach (explode(',', $aParams['exclude_place_ids']) as $iExcludedPlaceID) {
 				$iExcludedPlaceID = (int)$iExcludedPlaceID;
 				if ($iExcludedPlaceID)
 					$aExcludePlaceIDs[$iExcludedPlaceID] = $iExcludedPlaceID;
@@ -209,48 +206,36 @@ class Geocode
 		if (isset($aParams['featuretype'])) $this->setFeatureType($aParams['featuretype']);
 
 		// Country code list
-		if (isset($aParams['countrycodes']))
-		{
+		if (isset($aParams['countrycodes'])) {
 			$aCountryCodes = array();
-			foreach(explode(',',$aParams['countrycodes']) as $sCountryCode)
-			{
-				if (preg_match('/^[a-zA-Z][a-zA-Z]$/', $sCountryCode))
-				{
+			foreach (explode(',', $aParams['countrycodes']) as $sCountryCode) {
+				if (preg_match('/^[a-zA-Z][a-zA-Z]$/', $sCountryCode)) {
 					$aCountryCodes[] = strtolower($sCountryCode);
 				}
 			}
 			$this->aCountryCodes = $aCountryCodes;
 		}
 
-		if (isset($aParams['viewboxlbrt']) && $aParams['viewboxlbrt'])
-		{
-			$aCoOrdinatesLBRT = explode(',',$aParams['viewboxlbrt']);
+		if (isset($aParams['viewboxlbrt']) && $aParams['viewboxlbrt']) {
+			$aCoOrdinatesLBRT = explode(',', $aParams['viewboxlbrt']);
 			$this->setViewBox($aCoOrdinatesLBRT[0], $aCoOrdinatesLBRT[1], $aCoOrdinatesLBRT[2], $aCoOrdinatesLBRT[3]);
-		}
-		else if (isset($aParams['viewbox']) && $aParams['viewbox'])
-		{
-			$aCoOrdinatesLTRB = explode(',',$aParams['viewbox']);
+		} elseif (isset($aParams['viewbox']) && $aParams['viewbox']) {
+			$aCoOrdinatesLTRB = explode(',', $aParams['viewbox']);
 			$this->setViewBox($aCoOrdinatesLTRB[0], $aCoOrdinatesLTRB[3], $aCoOrdinatesLTRB[2], $aCoOrdinatesLTRB[1]);
 		}
 
-		if (isset($aParams['route']) && $aParams['route'] && isset($aParams['routewidth']) && $aParams['routewidth'])
-		{
-			$aPoints = explode(',',$aParams['route']);
-			if (sizeof($aPoints) % 2 != 0)
-			{
+		if (isset($aParams['route']) && $aParams['route'] && isset($aParams['routewidth']) && $aParams['routewidth']) {
+			$aPoints = explode(',', $aParams['route']);
+			if (sizeof($aPoints) % 2 != 0) {
 				userError("Uneven number of points");
 				exit;
 			}
 			$fPrevCoord = false;
 			$aRoute = array();
-			foreach($aPoints as $i => $fPoint)
-			{
-				if ($i%2)
-				{
+			foreach ($aPoints as $i => $fPoint) {
+				if ($i%2) {
 					$aRoute[] = array((float)$fPoint, $fPrevCoord);
-				}
-				else
-				{
+				} else {
 					$fPrevCoord = (float)$fPoint;
 				}
 			}
@@ -262,13 +247,10 @@ class Geocode
 	{
 		// Search query
 		$sQuery = (isset($aParams['q'])?trim($aParams['q']):'');
-		if (!$sQuery)
-		{
+		if (!$sQuery) {
 			$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
 			$this->setReverseInPlan(false);
-		}
-		else
-		{
+		} else {
 			$this->setQuery($sQuery);
 		}
 	}
@@ -278,8 +260,7 @@ class Geocode
 		$sValue = trim($sValue);
 		if (!$sValue) return false;
 		$this->aStructuredQuery[$sKey] = $sValue;
-		if ($this->iMinAddressRank == 0 && $this->iMaxAddressRank == 30)
-		{
+		if ($this->iMinAddressRank == 0 && $this->iMaxAddressRank == 30) {
 			$this->iMinAddressRank = $iNewMinAddressRank;
 			$this->iMaxAddressRank = $iNewMaxAddressRank;
 		}
@@ -304,14 +285,12 @@ class Geocode
 		$this->loadStructuredAddressElement($sCity, 'city', 14, 24, false);
 		$this->loadStructuredAddressElement($sCounty, 'county', 9, 13, false);
 		$this->loadStructuredAddressElement($sState, 'state', 8, 8, false);
-		$this->loadStructuredAddressElement($sPostalCode, 'postalcode' , 5, 11, array(5, 11));
+		$this->loadStructuredAddressElement($sPostalCode, 'postalcode', 5, 11, array(5, 11));
 		$this->loadStructuredAddressElement($sCountry, 'country', 4, 4, false);
 
-		if (sizeof($this->aStructuredQuery) > 0)
-		{
+		if (sizeof($this->aStructuredQuery) > 0) {
 			$this->sQuery = join(', ', $this->aStructuredQuery);
-			if ($this->iMaxAddressRank < 30)
-			{
+			if ($this->iMaxAddressRank < 30) {
 				$sAllowedTypesSQLList = '(\'place\',\'boundary\')';
 			}
 		}
@@ -327,10 +306,8 @@ class Geocode
 
 		$aOrderToFallback = array('postalcode', 'street', 'city', 'county', 'state');
 
-		foreach($aOrderToFallback as $sType)
-		{
-			if (isset($aParams[$sType]))
-			{
+		foreach ($aOrderToFallback as $sType) {
+			if (isset($aParams[$sType])) {
 				unset($aParams[$sType]);
 				$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
 				return true;
@@ -345,7 +322,7 @@ class Geocode
 		//$aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
 		if (sizeof($aPlaceIDs) == 0)  return array();
 
-		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
+		$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
 
 		// Get the details for display (is this a redundant extra step?)
 		$sPlaceIDs = join(',', array_keys($aPlaceIDs));
@@ -367,7 +344,7 @@ class Geocode
 		$sSQL .= "from placex where place_id in ($sPlaceIDs) ";
 		$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
 		if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
-		if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
+		if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
 		$sSQL .= ") ";
 		if ($this->sAllowedTypesSQLList) $sSQL .= "and placex.class in $this->sAllowedTypesSQLList ";
 		$sSQL .= "and linked_place_id is null ";
@@ -380,22 +357,20 @@ class Geocode
 		if ($this->bIncludeNameDetails) $sSQL .= ",name";
 		$sSQL .= ",extratags->'place' ";
 
-		if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank)
-		{
-			//only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines 
+		if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank) {
+			//only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines
 			// with start- and endnumber, the common osm housenumbers are usually saved as points
 			$sHousenumbers = "";
 			$i = 0;
 			$length = count($aPlaceIDs);
-			foreach($aPlaceIDs as $placeID => $housenumber)
-			{
+			foreach ($aPlaceIDs as $placeID => $housenumber) {
 				$i++;
 				$sHousenumbers .= "(".$placeID.", ".$housenumber.")";
-				if($i<$length)
+				if ($i<$length)
 					$sHousenumbers .= ", ";
 			}
-			if (CONST_Use_US_Tiger_Data)
-			{
+
+			if (CONST_Use_US_Tiger_Data) {
 				//Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
 				$sSQL .= " union";
 				$sSQL .= " select 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code";
@@ -442,8 +417,7 @@ class Geocode
 			$sSQL .= " group by place_id, housenumber_for_place, calculated_country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
 			if (!$this->bDeDupe) $sSQL .= ", place_id ";
 
-			if (CONST_Use_Aux_Location_data)
-			{
+			if (CONST_Use_Aux_Location_data) {
 				$sSQL .= " union ";
 				$sSQL .= "select 'L' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 0 as rank_search, 0 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code, ";
 				$sSQL .= "get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress, ";
@@ -464,9 +438,11 @@ class Geocode
 		}
 
 		$sSQL .= " order by importance desc";
-		if (CONST_Debug) { echo "<hr>"; var_dump($sSQL); }
-		$aSearchResults = chksql($this->oDB->getAll($sSQL),
-		                         "Could not get details for place.");
+		if (CONST_Debug) {
+			echo "<hr>";
+			var_dump($sSQL);
+		}
+		$aSearchResults = chksql($this->oDB->getAll($sSQL), "Could not get details for place.");
 
 		return $aSearchResults;
 	}
@@ -484,69 +460,53 @@ class Geocode
 
 			 Score how good the search is so they can be ordered
 		 */
-		foreach($aPhrases as $iPhrase => $sPhrase)
-		{
+		foreach ($aPhrases as $iPhrase => $sPhrase) {
 			$aNewPhraseSearches = array();
 			if ($bStructuredPhrases) $sPhraseType = $aPhraseTypes[$iPhrase];
 			else $sPhraseType = '';
 
-			foreach($aPhrases[$iPhrase]['wordsets'] as $iWordSet => $aWordset)
-			{
+			foreach ($aPhrases[$iPhrase]['wordsets'] as $iWordSet => $aWordset) {
 				// Too many permutations - too expensive
 				if ($iWordSet > 120) break;
 
 				$aWordsetSearches = $aSearches;
 
 				// Add all words from this wordset
-				foreach($aWordset as $iToken => $sToken)
-				{
+				foreach ($aWordset as $iToken => $sToken) {
 					//echo "<br><b>$sToken</b>";
 					$aNewWordsetSearches = array();
 
-					foreach($aWordsetSearches as $aCurrentSearch)
-					{
+					foreach ($aWordsetSearches as $aCurrentSearch) {
 						//echo "<i>";
 						//var_dump($aCurrentSearch);
 						//echo "</i>";
 
 						// If the token is valid
-						if (isset($aValidTokens[' '.$sToken]))
-						{
-							foreach($aValidTokens[' '.$sToken] as $aSearchTerm)
-							{
+						if (isset($aValidTokens[' '.$sToken])) {
+							foreach ($aValidTokens[' '.$sToken] as $aSearchTerm) {
 								$aSearch = $aCurrentSearch;
 								$aSearch['iSearchRank']++;
-								if (($sPhraseType == '' || $sPhraseType == 'country') && !empty($aSearchTerm['country_code']) && $aSearchTerm['country_code'] != '0')
-								{
-									if ($aSearch['sCountryCode'] === false)
-									{
+								if (($sPhraseType == '' || $sPhraseType == 'country') && !empty($aSearchTerm['country_code']) && $aSearchTerm['country_code'] != '0') {
+									if ($aSearch['sCountryCode'] === false) {
 										$aSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
 										// Country is almost always at the end of the string - increase score for finding it anywhere else (optimisation)
-										if (($iToken+1 != sizeof($aWordset) || $iPhrase+1 != sizeof($aPhrases)))
-										{
+										if (($iToken+1 != sizeof($aWordset) || $iPhrase+1 != sizeof($aPhrases))) {
 											$aSearch['iSearchRank'] += 5;
 										}
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								}
-								elseif (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null)
-								{
-									if ($aSearch['fLat'] === '')
-									{
+								} elseif (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null) {
+									if ($aSearch['fLat'] === '') {
 										$aSearch['fLat'] = $aSearchTerm['lat'];
 										$aSearch['fLon'] = $aSearchTerm['lon'];
 										$aSearch['fRadius'] = $aSearchTerm['radius'];
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								}
-								elseif ($sPhraseType == 'postalcode')
-								{
+								} elseif ($sPhraseType == 'postalcode') {
 									// We need to try the case where the postal code is the primary element (i.e. no way to tell if it is (postalcode, city) OR (city, postalcode) so try both
-									if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
-									{
+									if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
 										// If we already have a name try putting the postcode first
-										if (sizeof($aSearch['aName']))
-										{
+										if (sizeof($aSearch['aName'])) {
 											$aNewSearch = $aSearch;
 											$aNewSearch['aAddress'] = array_merge($aNewSearch['aAddress'], $aNewSearch['aName']);
 											$aNewSearch['aName'] = array();
@@ -554,31 +514,21 @@ class Geocode
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aNewSearch;
 										}
 
-										if (sizeof($aSearch['aName']))
-										{
-											if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false))
-											{
+										if (sizeof($aSearch['aName'])) {
+											if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false)) {
 												$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-											}
-											else
-											{
+											} else {
 												$aCurrentSearch['aFullNameAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 												$aSearch['iSearchRank'] += 1000; // skip;
 											}
-										}
-										else
-										{
+										} else {
 											$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											//$aSearch['iNamePhrase'] = $iPhrase;
 										}
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-
-								}
-								elseif (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house')
-								{
-									if ($aSearch['sHouseNumber'] === '')
-									{
+								} elseif (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house') {
+									if ($aSearch['sHouseNumber'] === '') {
 										$aSearch['sHouseNumber'] = $sToken;
 										// sanity check: if the housenumber is not mainly made
 										// up of numbers, add a penalty
@@ -593,11 +543,8 @@ class Geocode
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 										 */
 									}
-								}
-								elseif ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null)
-								{
-									if ($aSearch['sClass'] === '')
-									{
+								} elseif ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null) {
+									if ($aSearch['sClass'] === '') {
 										$aSearch['sOperator'] = $aSearchTerm['operator'];
 										$aSearch['sClass'] = $aSearchTerm['class'];
 										$aSearch['sType'] = $aSearchTerm['type'];
@@ -607,23 +554,15 @@ class Geocode
 
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-								}
-								elseif (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
-								{
-									if (sizeof($aSearch['aName']))
-									{
-										if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false))
-										{
+								} elseif (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
+									if (sizeof($aSearch['aName'])) {
+										if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false)) {
 											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-										}
-										else
-										{
+										} else {
 											$aCurrentSearch['aFullNameAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											$aSearch['iSearchRank'] += 1000; // skip;
 										}
-									}
-									else
-									{
+									} else {
 										$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 										//$aSearch['iNamePhrase'] = $iPhrase;
 									}
@@ -634,66 +573,53 @@ class Geocode
 						// Look for partial matches.
 						// Note that there is no point in adding country terms here
 						// because country are omitted in the address.
-						if (isset($aValidTokens[$sToken]) && $sPhraseType != 'country')
-						{
+						if (isset($aValidTokens[$sToken]) && $sPhraseType != 'country') {
 							// Allow searching for a word - but at extra cost
-							foreach($aValidTokens[$sToken] as $aSearchTerm)
-							{
-								if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
-								{
-									if ((!$bStructuredPhrases || $iPhrase > 0) && sizeof($aCurrentSearch['aName']) && strpos($sToken, ' ') === false)
-									{
+							foreach ($aValidTokens[$sToken] as $aSearchTerm) {
+								if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id']) {
+									if ((!$bStructuredPhrases || $iPhrase > 0) && sizeof($aCurrentSearch['aName']) && strpos($sToken, ' ') === false) {
 										$aSearch = $aCurrentSearch;
 										$aSearch['iSearchRank'] += 1;
-										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
-										{
+										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency) {
 											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										}
-										elseif (isset($aValidTokens[' '.$sToken])) // revert to the token version?
-										{
+										} elseif (isset($aValidTokens[' '.$sToken])) { // revert to the token version?
 											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											$aSearch['iSearchRank'] += 1;
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-											foreach($aValidTokens[' '.$sToken] as $aSearchTermToken)
-											{
+											foreach ($aValidTokens[' '.$sToken] as $aSearchTermToken) {
 												if (empty($aSearchTermToken['country_code'])
 														&& empty($aSearchTermToken['lat'])
-														&& empty($aSearchTermToken['class']))
-												{
+														&& empty($aSearchTermToken['class'])) {
 													$aSearch = $aCurrentSearch;
 													$aSearch['iSearchRank'] += 1;
 													$aSearch['aAddress'][$aSearchTermToken['word_id']] = $aSearchTermToken['word_id'];
 													if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 												}
 											}
-										}
-										else
-										{
+										} else {
 											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 										}
 									}
 
-									if (!sizeof($aCurrentSearch['aName']) || $aCurrentSearch['iNamePhrase'] == $iPhrase)
-									{
+									if (!sizeof($aCurrentSearch['aName']) || $aCurrentSearch['iNamePhrase'] == $iPhrase) {
 										$aSearch = $aCurrentSearch;
 										$aSearch['iSearchRank'] += 1;
 										if (!sizeof($aCurrentSearch['aName'])) $aSearch['iSearchRank'] += 1;
 										if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
-										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
+										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency) {
 											$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-										else
+										} else {
 											$aSearch['aNameNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+										}
 										$aSearch['iNamePhrase'] = $iPhrase;
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
 								}
 							}
-						}
-						else
-						{
+						} else {
 							// Allow skipping a word - but at EXTREAM cost
 							//$aSearch = $aCurrentSearch;
 							//$aSearch['iSearchRank']+=100;
@@ -710,8 +636,7 @@ class Geocode
 				usort($aNewPhraseSearches, 'bySearchRank');
 
 				$aSearchHash = array();
-				foreach($aNewPhraseSearches as $iSearch => $aSearch)
-				{
+				foreach ($aNewPhraseSearches as $iSearch => $aSearch) {
 					$sHash = serialize($aSearch);
 					if (isset($aSearchHash[$sHash])) unset($aNewPhraseSearches[$iSearch]);
 					else $aSearchHash[$sHash] = 1;
@@ -722,10 +647,8 @@ class Geocode
 
 			// Re-group the searches by their score, junk anything over 20 as just not worth trying
 			$aGroupedSearches = array();
-			foreach($aNewPhraseSearches as $aSearch)
-			{
-				if ($aSearch['iSearchRank'] < $this->iMaxRank)
-				{
+			foreach ($aNewPhraseSearches as $aSearch) {
+				if ($aSearch['iSearchRank'] < $this->iMaxRank) {
 					if (!isset($aGroupedSearches[$aSearch['iSearchRank']])) $aGroupedSearches[$aSearch['iSearchRank']] = array();
 					$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
 				}
@@ -734,18 +657,15 @@ class Geocode
 
 			$iSearchCount = 0;
 			$aSearches = array();
-			foreach($aGroupedSearches as $iScore => $aNewSearches)
-			{
+			foreach ($aGroupedSearches as $iScore => $aNewSearches) {
 				$iSearchCount += sizeof($aNewSearches);
 				$aSearches = array_merge($aSearches, $aNewSearches);
 				if ($iSearchCount > 50) break;
 			}
 
 			//if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
-
 		}
 		return $aGroupedSearches;
-
 	}
 
 	/* Perform the actual query lookup.
@@ -782,28 +702,25 @@ class Geocode
 	{
 		if (!$this->sQuery && !$this->aStructuredQuery) return false;
 
-		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
+		$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
 		$sCountryCodesSQL = false;
-		if ($this->aCountryCodes && sizeof($this->aCountryCodes))
-		{
+		if ($this->aCountryCodes && sizeof($this->aCountryCodes)) {
 			$sCountryCodesSQL = join(',', array_map('addQuotes', $this->aCountryCodes));
 		}
 
 		$sQuery = $this->sQuery;
 
 		// Conflicts between US state abreviations and various words for 'the' in different languages
-		if (isset($this->aLangPrefOrder['name:en']))
-		{
-			$sQuery = preg_replace('/(^|,)\s*il\s*(,|$)/','\1illinois\2', $sQuery);
-			$sQuery = preg_replace('/(^|,)\s*al\s*(,|$)/','\1alabama\2', $sQuery);
-			$sQuery = preg_replace('/(^|,)\s*la\s*(,|$)/','\1louisiana\2', $sQuery);
+		if (isset($this->aLangPrefOrder['name:en'])) {
+			$sQuery = preg_replace('/(^|,)\s*il\s*(,|$)/', '\1illinois\2', $sQuery);
+			$sQuery = preg_replace('/(^|,)\s*al\s*(,|$)/', '\1alabama\2', $sQuery);
+			$sQuery = preg_replace('/(^|,)\s*la\s*(,|$)/', '\1louisiana\2', $sQuery);
 		}
 
 		// View Box SQL
 		$sViewboxCentreSQL = false;
 		$bBoundingBoxSearch = false;
-		if ($this->aViewBox)
-		{
+		if ($this->aViewBox) {
 			$fHeight = $this->aViewBox[0]-$this->aViewBox[2];
 			$fWidth = $this->aViewBox[1]-$this->aViewBox[3];
 			$aBigViewBox[0] = $this->aViewBox[0] + $fHeight;
@@ -817,12 +734,10 @@ class Geocode
 		}
 
 		// Route SQL
-		if ($this->aRoutePoints)
-		{
+		if ($this->aRoutePoints) {
 			$sViewboxCentreSQL = "ST_SetSRID('LINESTRING(";
 			$bFirst = true;
-			foreach($this->aRoutePoints as $aPoint)
-			{
+			foreach ($this->aRoutePoints as $aPoint) {
 				if (!$bFirst) $sViewboxCentreSQL .= ",";
 				$sViewboxCentreSQL .= $aPoint[0].' '.$aPoint[1];
 				$bFirst = false;
@@ -830,27 +745,24 @@ class Geocode
 			$sViewboxCentreSQL .= ")'::geometry,4326)";
 
 			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/69).")";
-			$this->sViewboxSmallSQL = chksql($this->oDB->getOne($sSQL),
-			                                 "Could not get small viewbox.");
+			$this->sViewboxSmallSQL = chksql($this->oDB->getOne($sSQL), "Could not get small viewbox.");
 			$this->sViewboxSmallSQL = "'".$this->sViewboxSmallSQL."'::geometry";
 
 			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/30).")";
-			$this->sViewboxLargeSQL = chksql($this->oDB->getOne($sSQL),
-			                                 "Could not get large viewbox.");
+			$this->sViewboxLargeSQL = chksql($this->oDB->getOne($sSQL), "Could not get large viewbox.");
 			$this->sViewboxLargeSQL = "'".$this->sViewboxLargeSQL."'::geometry";
+
 			$bBoundingBoxSearch = $this->bBoundedSearch;
 		}
 
 		// Do we have anything that looks like a lat/lon pair?
-		if ( $aLooksLike = looksLikeLatLonPair($sQuery) )
-		{
+		if ($aLooksLike = looksLikeLatLonPair($sQuery)) {
 			$this->setNearPoint(array($aLooksLike['lat'], $aLooksLike['lon']));
 			$sQuery = $aLooksLike['query'];
 		}
 
 		$aSearchResults = array();
-		if ($sQuery || $this->aStructuredQuery)
-		{
+		if ($sQuery || $this->aStructuredQuery) {
 			// Start with a blank search
 			$aSearches = array(
 				array('iSearchRank' => 0,
@@ -874,8 +786,7 @@ class Geocode
 
 			// Do we have a radius search?
 			$sNearPointSQL = false;
-			if ($this->aNearPoint)
-			{
+			if ($this->aNearPoint) {
 				$sNearPointSQL = "ST_SetSRID(ST_Point(".(float)$this->aNearPoint[1].",".(float)$this->aNearPoint[0]."),4326)";
 				$aSearches[0]['fLat'] = (float)$this->aNearPoint[0];
 				$aSearches[0]['fLon'] = (float)$this->aNearPoint[1];
@@ -886,21 +797,19 @@ class Geocode
 			$bSpecialTerms = false;
 			preg_match_all('/\\[(.*)=(.*)\\]/', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
 			$aSpecialTerms = array();
-			foreach($aSpecialTermsRaw as $aSpecialTerm)
-			{
+			foreach ($aSpecialTermsRaw as $aSpecialTerm) {
 				$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
 				$aSpecialTerms[strtolower($aSpecialTerm[1])] = $aSpecialTerm[2];
 			}
 
 			preg_match_all('/\\[([\\w ]*)\\]/u', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
 			$aSpecialTerms = array();
-			if (isset($this->aStructuredQuery['amenity']) && $this->aStructuredQuery['amenity'])
-			{
+			if (isset($this->aStructuredQuery['amenity']) && $this->aStructuredQuery['amenity']) {
 				$aSpecialTermsRaw[] = array('['.$this->aStructuredQuery['amenity'].']', $this->aStructuredQuery['amenity']);
 				unset($this->aStructuredQuery['amenity']);
 			}
-			foreach($aSpecialTermsRaw as $aSpecialTerm)
-			{
+
+			foreach ($aSpecialTermsRaw as $aSpecialTerm) {
 				$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
 				$sToken = chksql($this->oDB->getOne("select make_standard_name('".$aSpecialTerm[1]."') as string"));
 				$sSQL = 'select * from (select word_id,word_token, word, class, type, country_code, operator';
@@ -908,19 +817,15 @@ class Geocode
 				if (CONST_Debug) var_Dump($sSQL);
 				$aSearchWords = chksql($this->oDB->getAll($sSQL));
 				$aNewSearches = array();
-				foreach($aSearches as $aSearch)
-				{
-					foreach($aSearchWords as $aSearchTerm)
-					{
+				foreach ($aSearches as $aSearch) {
+					foreach ($aSearchWords as $aSearchTerm) {
 						$aNewSearch = $aSearch;
-						if ($aSearchTerm['country_code'])
-						{
+						if ($aSearchTerm['country_code']) {
 							$aNewSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
 							$aNewSearches[] = $aNewSearch;
 							$bSpecialTerms = true;
 						}
-						if ($aSearchTerm['class'])
-						{
+						if ($aSearchTerm['class']) {
 							$aNewSearch['sClass'] = $aSearchTerm['class'];
 							$aNewSearch['sType'] = $aSearchTerm['type'];
 							$aNewSearches[] = $aNewSearch;
@@ -933,14 +838,11 @@ class Geocode
 
 			// Split query into phrases
 			// Commas are used to reduce the search space by indicating where phrases split
-			if ($this->aStructuredQuery)
-			{
+			if ($this->aStructuredQuery) {
 				$aPhrases = $this->aStructuredQuery;
 				$bStructuredPhrases = true;
-			}
-			else
-			{
-				$aPhrases = explode(',',$sQuery);
+			} else {
+				$aPhrases = explode(',', $sQuery);
 				$bStructuredPhrases = false;
 			}
 
@@ -949,19 +851,17 @@ class Geocode
 			// Get all 'sets' of words
 			// Generate a complete list of all
 			$aTokens = array();
-			foreach($aPhrases as $iPhrase => $sPhrase)
-			{
-				$aPhrase = chksql($this->oDB->getRow("select make_standard_name('".pg_escape_string($sPhrase)."') as string"),
-				                  "Cannot nomralize query string (is it an UTF-8 string?)");
-				if (trim($aPhrase['string']))
-				{
+			foreach ($aPhrases as $iPhrase => $sPhrase) {
+				$aPhrase = chksql(
+					$this->oDB->getRow("select make_standard_name('".pg_escape_string($sPhrase)."') as string"),
+					"Cannot nomralize query string (is it an UTF-8 string?)"
+				);
+				if (trim($aPhrase['string'])) {
 					$aPhrases[$iPhrase] = $aPhrase;
-					$aPhrases[$iPhrase]['words'] = explode(' ',$aPhrases[$iPhrase]['string']);
+					$aPhrases[$iPhrase]['words'] = explode(' ', $aPhrases[$iPhrase]['string']);
 					$aPhrases[$iPhrase]['wordsets'] = getWordSets($aPhrases[$iPhrase]['words'], 0);
 					$aTokens = array_merge($aTokens, getTokensFromSets($aPhrases[$iPhrase]['wordsets']));
-				}
-				else
-				{
+				} else {
 					unset($aPhrases[$iPhrase]);
 				}
 			}
@@ -970,41 +870,31 @@ class Geocode
 			$aPhraseTypes = array_keys($aPhrases);
 			$aPhrases = array_values($aPhrases);
 
-			if (sizeof($aTokens))
-			{
+			if (sizeof($aTokens)) {
 				// Check which tokens we have, get the ID numbers
 				$sSQL = 'select word_id,word_token, word, class, type, country_code, operator, search_name_count';
-				$sSQL .= ' from word where word_token in ('.join(',',array_map("getDBQuoted",$aTokens)).')';
+				$sSQL .= ' from word where word_token in ('.join(',', array_map("getDBQuoted", $aTokens)).')';
 
 				if (CONST_Debug) var_Dump($sSQL);
 
 				$aValidTokens = array();
-				if (sizeof($aTokens))
-				{
-					$aDatabaseWords = chksql($this->oDB->getAll($sSQL),
-					                         "Could not get word tokens.");
-				}
-				else
-				{
+				if (sizeof($aTokens)) {
+					$aDatabaseWords = chksql($this->oDB->getAll($sSQL), "Could not get word tokens.");
+				} else {
 					$aDatabaseWords = array();
 				}
 				$aPossibleMainWordIDs = array();
 				$aWordFrequencyScores = array();
-				foreach($aDatabaseWords as $aToken)
-				{
+				foreach ($aDatabaseWords as $aToken) {
 					// Very special case - require 2 letter country param to match the country code found
 					if ($bStructuredPhrases && $aToken['country_code'] && !empty($this->aStructuredQuery['country'])
-							&& strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code'])
-					{
+							&& strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code']) {
 						continue;
 					}
 
-					if (isset($aValidTokens[$aToken['word_token']]))
-					{
+					if (isset($aValidTokens[$aToken['word_token']])) {
 						$aValidTokens[$aToken['word_token']][] = $aToken;
-					}
-					else
-					{
+					} else {
 						$aValidTokens[$aToken['word_token']] = array($aToken);
 					}
 					if (!$aToken['class'] && !$aToken['country_code']) $aPossibleMainWordIDs[$aToken['word_id']] = 1;
@@ -1013,38 +903,26 @@ class Geocode
 				if (CONST_Debug) var_Dump($aPhrases, $aValidTokens);
 
 				// Try and calculate GB postcodes we might be missing
-				foreach($aTokens as $sToken)
-				{
+				foreach ($aTokens as $sToken) {
 					// Source of gb postcodes is now definitive - always use
-					if (preg_match('/^([A-Z][A-Z]?[0-9][0-9A-Z]? ?[0-9])([A-Z][A-Z])$/', strtoupper(trim($sToken)), $aData))
-					{
-						if (substr($aData[1],-2,1) != ' ')
-						{
-							$aData[0] = substr($aData[0],0,strlen($aData[1])-1).' '.substr($aData[0],strlen($aData[1])-1);
-							$aData[1] = substr($aData[1],0,-1).' '.substr($aData[1],-1,1);
+					if (preg_match('/^([A-Z][A-Z]?[0-9][0-9A-Z]? ?[0-9])([A-Z][A-Z])$/', strtoupper(trim($sToken)), $aData)) {
+						if (substr($aData[1], -2, 1) != ' ') {
+							$aData[0] = substr($aData[0], 0, strlen($aData[1])-1).' '.substr($aData[0], strlen($aData[1])-1);
+							$aData[1] = substr($aData[1], 0, -1).' '.substr($aData[1], -1, 1);
 						}
 						$aGBPostcodeLocation = gbPostcodeCalculate($aData[0], $aData[1], $aData[2], $this->oDB);
-						if ($aGBPostcodeLocation)
-						{
+						if ($aGBPostcodeLocation) {
 							$aValidTokens[$sToken] = $aGBPostcodeLocation;
 						}
-					}
-					// US ZIP+4 codes - if there is no token,
-					// 	merge in the 5-digit ZIP code
-					else if (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData))
-					{
-						if (isset($aValidTokens[$aData[1]]))
-						{
-							foreach($aValidTokens[$aData[1]] as $aToken)
-							{
-								if (!$aToken['class'])
-								{
-									if (isset($aValidTokens[$sToken]))
-									{
+					} elseif (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
+						// US ZIP+4 codes - if there is no token,
+						// 	merge in the 5-digit ZIP code
+						if (isset($aValidTokens[$aData[1]])) {
+							foreach ($aValidTokens[$aData[1]] as $aToken) {
+								if (!$aToken['class']) {
+									if (isset($aValidTokens[$sToken])) {
 										$aValidTokens[$sToken][] = $aToken;
-									}
-									else
-									{
+									} else {
 										$aValidTokens[$sToken] = array($aToken);
 									}
 								}
@@ -1053,11 +931,9 @@ class Geocode
 					}
 				}
 
-				foreach($aTokens as $sToken)
-				{
+				foreach ($aTokens as $sToken) {
 					// Unknown single word token with a number - assume it is a house number
-					if (!isset($aValidTokens[' '.$sToken]) && strpos($sToken,' ') === false && preg_match('/[0-9]/', $sToken))
-					{
+					if (!isset($aValidTokens[' '.$sToken]) && strpos($sToken, ' ') === false && preg_match('/[0-9]/', $sToken)) {
 						$aValidTokens[' '.$sToken] = array(array('class'=>'place','type'=>'house'));
 					}
 				}
@@ -1071,45 +947,35 @@ class Geocode
 
 				$aGroupedSearches = $this->getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases);
 
-				if ($this->bReverseInPlan)
-				{
+				if ($this->bReverseInPlan) {
 					// Reverse phrase array and also reverse the order of the wordsets in
 					// the first and final phrase. Don't bother about phrases in the middle
 					// because order in the address doesn't matter.
 					$aPhrases = array_reverse($aPhrases);
 					$aPhrases[0]['wordsets'] = getInverseWordSets($aPhrases[0]['words'], 0);
-					if (sizeof($aPhrases) > 1)
-					{
+					if (sizeof($aPhrases) > 1) {
 						$aFinalPhrase = end($aPhrases);
 						$aPhrases[sizeof($aPhrases)-1]['wordsets'] = getInverseWordSets($aFinalPhrase['words'], 0);
 					}
 					$aReverseGroupedSearches = $this->getGroupedSearches($aSearches, null, $aPhrases, $aValidTokens, $aWordFrequencyScores, false);
 
-					foreach($aGroupedSearches as $aSearches)
-					{
-						foreach($aSearches as $aSearch)
-						{
-							if ($aSearch['iSearchRank'] < $this->iMaxRank)
-							{
+					foreach ($aGroupedSearches as $aSearches) {
+						foreach ($aSearches as $aSearch) {
+							if ($aSearch['iSearchRank'] < $this->iMaxRank) {
 								if (!isset($aReverseGroupedSearches[$aSearch['iSearchRank']])) $aReverseGroupedSearches[$aSearch['iSearchRank']] = array();
 								$aReverseGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
 							}
-
 						}
 					}
 
 					$aGroupedSearches = $aReverseGroupedSearches;
 					ksort($aGroupedSearches);
 				}
-			}
-			else
-			{
+			} else {
 				// Re-group the searches by their score, junk anything over 20 as just not worth trying
 				$aGroupedSearches = array();
-				foreach($aSearches as $aSearch)
-				{
-					if ($aSearch['iSearchRank'] < $this->iMaxRank)
-					{
+				foreach ($aSearches as $aSearch) {
+					if ($aSearch['iSearchRank'] < $this->iMaxRank) {
 						if (!isset($aGroupedSearches[$aSearch['iSearchRank']])) $aGroupedSearches[$aSearch['iSearchRank']] = array();
 						$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
 					}
@@ -1119,31 +985,24 @@ class Geocode
 
 			if (CONST_Debug) var_Dump($aGroupedSearches);
 
-			if (CONST_Search_TryDroppedAddressTerms && sizeof($this->aStructuredQuery) > 0)
-			{
+			if (CONST_Search_TryDroppedAddressTerms && sizeof($this->aStructuredQuery) > 0) {
 				$aCopyGroupedSearches = $aGroupedSearches;
-				foreach($aCopyGroupedSearches as $iGroup => $aSearches)
-				{
-					foreach($aSearches as $iSearch => $aSearch)
-					{
+				foreach ($aCopyGroupedSearches as $iGroup => $aSearches) {
+					foreach ($aSearches as $iSearch => $aSearch) {
 						$aReductionsList = array($aSearch['aAddress']);
 						$iSearchRank = $aSearch['iSearchRank'];
-						while(sizeof($aReductionsList) > 0)
-						{
+						while (sizeof($aReductionsList) > 0) {
 							$iSearchRank += 5;
 							if ($iSearchRank > iMaxRank) break 3;
 							$aNewReductionsList = array();
-							foreach($aReductionsList as $aReductionsWordList)
-							{
-								for ($iReductionWord = 0; $iReductionWord < sizeof($aReductionsWordList); $iReductionWord++)
-								{
+							foreach ($aReductionsList as $aReductionsWordList) {
+								for ($iReductionWord = 0; $iReductionWord < sizeof($aReductionsWordList); $iReductionWord++) {
 									$aReductionsWordListResult = array_merge(array_slice($aReductionsWordList, 0, $iReductionWord), array_slice($aReductionsWordList, $iReductionWord+1));
 									$aReverseSearch = $aSearch;
 									$aSearch['aAddress'] = $aReductionsWordListResult;
 									$aSearch['iSearchRank'] = $iSearchRank;
 									$aGroupedSearches[$iSearchRank][] = $aReverseSearch;
-									if (sizeof($aReductionsWordListResult) > 0)
-									{
+									if (sizeof($aReductionsWordListResult) > 0) {
 										$aNewReductionsList[] = $aReductionsWordListResult;
 									}
 								}
@@ -1157,18 +1016,13 @@ class Geocode
 
 			// Filter out duplicate searches
 			$aSearchHash = array();
-			foreach($aGroupedSearches as $iGroup => $aSearches)
-			{
-				foreach($aSearches as $iSearch => $aSearch)
-				{
+			foreach ($aGroupedSearches as $iGroup => $aSearches) {
+				foreach ($aSearches as $iSearch => $aSearch) {
 					$sHash = serialize($aSearch);
-					if (isset($aSearchHash[$sHash]))
-					{
+					if (isset($aSearchHash[$sHash])) {
 						unset($aGroupedSearches[$iGroup][$iSearch]);
 						if (sizeof($aGroupedSearches[$iGroup]) == 0) unset($aGroupedSearches[$iGroup]);
-					}
-					else
-					{
+					} else {
 						$aSearchHash[$sHash] = 1;
 					}
 				}
@@ -1178,25 +1032,22 @@ class Geocode
 
 			$iGroupLoop = 0;
 			$iQueryLoop = 0;
-			foreach($aGroupedSearches as $iGroupedRank => $aSearches)
-			{
+			foreach ($aGroupedSearches as $iGroupedRank => $aSearches) {
 				$iGroupLoop++;
-				foreach($aSearches as $aSearch)
-				{
+				foreach ($aSearches as $aSearch) {
 					$iQueryLoop++;
 					$searchedHousenumber = -1;
 
-					if (CONST_Debug) { echo "<hr><b>Search Loop, group $iGroupLoop, loop $iQueryLoop</b>"; }
-					if (CONST_Debug) _debugDumpGroupedSearches(array($iGroupedRank => array($aSearch)), $aValidTokens);
+					if (CONST_Debug) {
+						echo "<hr><b>Search Loop, group $iGroupLoop, loop $iQueryLoop</b>";
+						_debugDumpGroupedSearches(array($iGroupedRank => array($aSearch)), $aValidTokens);
+					}
 
 					// No location term?
-					if (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['fLon'])
-					{
-						if ($aSearch['sCountryCode'] && !$aSearch['sClass'] && !$aSearch['sHouseNumber'])
-						{
+					if (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['fLon']) {
+						if ($aSearch['sCountryCode'] && !$aSearch['sClass'] && !$aSearch['sHouseNumber']) {
 							// Just looking for a country by code - look it up
-							if (4 >= $this->iMinAddressRank && 4 <= $this->iMaxAddressRank)
-							{
+							if (4 >= $this->iMinAddressRank && 4 <= $this->iMaxAddressRank) {
 								$sSQL = "select place_id from placex where calculated_country_code='".$aSearch['sCountryCode']."' and rank_search = 4";
 								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
 								if ($bBoundingBoxSearch)
@@ -1204,26 +1055,20 @@ class Geocode
 								$sSQL .= " order by st_area(geometry) desc limit 1";
 								if (CONST_Debug) var_dump($sSQL);
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-							}
-							else
-							{
+							} else {
 								$aPlaceIDs = array();
 							}
-						}
-						else
-						{
+						} else {
 							if (!$bBoundingBoxSearch && !$aSearch['fLon']) continue;
 							if (!$aSearch['sClass']) continue;
 							$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
-							if (chksql($this->oDB->getOne($sSQL)))
-							{
+							if (chksql($this->oDB->getOne($sSQL))) {
 								$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
 								if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
 								$sSQL .= " where st_contains($this->sViewboxSmallSQL, ct.centroid)";
 								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-								if (sizeof($this->aExcludePlaceIDs))
-								{
-									$sSQL .= " and place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+								if (sizeof($this->aExcludePlaceIDs)) {
+									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
 								if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
 								$sSQL .= " limit $this->iLimit";
@@ -1234,8 +1079,7 @@ class Geocode
 								// there have been results in the small box, so no further
 								// expansion in that case.
 								// Also don't expand if bounded results were requested.
-								if (!sizeof($aPlaceIDs) && !sizeof($this->aExcludePlaceIDs) && !$this->bBoundedSearch)
-								{
+								if (!sizeof($aPlaceIDs) && !sizeof($this->aExcludePlaceIDs) && !$this->bBoundedSearch) {
 									$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
 									if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
 									$sSQL .= " where st_contains($this->sViewboxLargeSQL, ct.centroid)";
@@ -1245,35 +1089,28 @@ class Geocode
 									if (CONST_Debug) var_dump($sSQL);
 									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 								}
-							}
-							else
-							{
+							} else {
 								$sSQL = "select place_id from placex where class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
 								$sSQL .= " and st_contains($this->sViewboxSmallSQL, geometry) and linked_place_id is null";
 								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-								if ($sViewboxCentreSQL)	$sSQL .= " order by st_distance($sViewboxCentreSQL, centroid) asc";
+								if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, centroid) asc";
 								$sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							}
 						}
-					}
+					} elseif ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass']) {
 					// If a coordinate is given, the search must either
 					// be for a name or a special search. Ignore everythin else.
-					else if ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass'])
-					{
 						$aPlaceIDs = array();
-					}
-					else
-					{
+					} else {
 						$aPlaceIDs = array();
 
 						// First we need a position, either aName or fLat or both
 						$aTerms = array();
 						$aOrder = array();
 
-						if ($aSearch['sHouseNumber'] && sizeof($aSearch['aAddress']))
-						{
+						if ($aSearch['sHouseNumber'] && sizeof($aSearch['aAddress'])) {
 							$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
                                 $aOrder[] = "";
 							$aOrder[0] = " (exists(select place_id from placex where parent_place_id = search_name.place_id";
@@ -1286,99 +1123,79 @@ class Geocode
 
 						// TODO: filter out the pointless search terms (2 letter name tokens and less)
 						// they might be right - but they are just too darned expensive to run
-						if (sizeof($aSearch['aName'])) $aTerms[] = "name_vector @> ARRAY[".join($aSearch['aName'],",")."]";
-						if (sizeof($aSearch['aNameNonSearch'])) $aTerms[] = "array_cat(name_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aNameNonSearch'],",")."]";
-						if (sizeof($aSearch['aAddress']) && $aSearch['aName'] != $aSearch['aAddress'])
-						{
+						if (sizeof($aSearch['aName'])) $aTerms[] = "name_vector @> ARRAY[".join($aSearch['aName'], ",")."]";
+						if (sizeof($aSearch['aNameNonSearch'])) $aTerms[] = "array_cat(name_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aNameNonSearch'], ",")."]";
+						if (sizeof($aSearch['aAddress']) && $aSearch['aName'] != $aSearch['aAddress']) {
 							// For infrequent name terms disable index usage for address
 							if (CONST_Search_NameOnlySearchFrequencyThreshold &&
 									sizeof($aSearch['aName']) == 1 &&
-									$aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold)
-							{
-								$aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join(array_merge($aSearch['aAddress'],$aSearch['aAddressNonSearch']),",")."]";
-							}
-							else
-							{
-								$aTerms[] = "nameaddress_vector @> ARRAY[".join($aSearch['aAddress'],",")."]";
-								if (sizeof($aSearch['aAddressNonSearch'])) $aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aAddressNonSearch'],",")."]";
+									$aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold) {
+								$aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join(array_merge($aSearch['aAddress'], $aSearch['aAddressNonSearch']), ",")."]";
+							} else {
+								$aTerms[] = "nameaddress_vector @> ARRAY[".join($aSearch['aAddress'], ",")."]";
+								if (sizeof($aSearch['aAddressNonSearch'])) $aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aAddressNonSearch'], ",")."]";
 							}
 						}
 						if ($aSearch['sCountryCode']) $aTerms[] = "country_code = '".pg_escape_string($aSearch['sCountryCode'])."'";
-						if ($aSearch['sHouseNumber'])
-						{
+						if ($aSearch['sHouseNumber']) {
 							$aTerms[] = "address_rank between 16 and 27";
-						}
-						else
-						{
-							if ($this->iMinAddressRank > 0)
-							{
+						} else {
+							if ($this->iMinAddressRank > 0) {
 								$aTerms[] = "address_rank >= ".$this->iMinAddressRank;
 							}
-							if ($this->iMaxAddressRank < 30)
-							{
+							if ($this->iMaxAddressRank < 30) {
 								$aTerms[] = "address_rank <= ".$this->iMaxAddressRank;
 							}
 						}
-						if ($aSearch['fLon'] && $aSearch['fLat'])
-						{
+						if ($aSearch['fLon'] && $aSearch['fLat']) {
 							$aTerms[] = "ST_DWithin(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326), ".$aSearch['fRadius'].")";
 							$aOrder[] = "ST_Distance(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326)) ASC";
 						}
-						if (sizeof($this->aExcludePlaceIDs))
-						{
-							$aTerms[] = "place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+						if (sizeof($this->aExcludePlaceIDs)) {
+							$aTerms[] = "place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 						}
-						if ($sCountryCodesSQL)
-						{
+						if ($sCountryCodesSQL) {
 							$aTerms[] = "country_code in ($sCountryCodesSQL)";
 						}
 
 						if ($bBoundingBoxSearch) $aTerms[] = "centroid && $this->sViewboxSmallSQL";
 						if ($sNearPointSQL) $aOrder[] = "ST_Distance($sNearPointSQL, centroid) asc";
 
-						if ($aSearch['sHouseNumber'])
-						{
+						if ($aSearch['sHouseNumber']) {
 							$sImportanceSQL = '- abs(26 - address_rank) + 3';
-						}
-						else
-						{
+						} else {
 							$sImportanceSQL = '(case when importance = 0 OR importance IS NULL then 0.75-(search_rank::float/40) else importance end)';
 						}
 						if ($this->sViewboxSmallSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxSmallSQL, centroid) THEN 1 ELSE 0.5 END";
 						if ($this->sViewboxLargeSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxLargeSQL, centroid) THEN 1 ELSE 0.5 END";
 
 						$aOrder[] = "$sImportanceSQL DESC";
-						if (sizeof($aSearch['aFullNameAddress']))
-						{
-							$sExactMatchSQL = '(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s) as exactmatch';
+						if (sizeof($aSearch['aFullNameAddress'])) {
+							$sExactMatchSQL = '(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'], ",").']) INTERSECT select unnest(nameaddress_vector))s) as exactmatch';
 							$aOrder[] = 'exactmatch DESC';
 						} else {
 							$sExactMatchSQL = '0::int as exactmatch';
 						}
 
-						if (sizeof($aTerms))
-						{
+						if (sizeof($aTerms)) {
 							$sSQL = "select place_id, ";
 							$sSQL .= $sExactMatchSQL;
 							$sSQL .= " from search_name";
-							$sSQL .= " where ".join(' and ',$aTerms);
-							$sSQL .= " order by ".join(', ',$aOrder);
+							$sSQL .= " where ".join(' and ', $aTerms);
+							$sSQL .= " order by ".join(', ', $aOrder);
 							if ($aSearch['sHouseNumber'] || $aSearch['sClass'])
 								$sSQL .= " limit 20";
 							elseif (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && $aSearch['sClass'])
 								$sSQL .= " limit 1";
-							else
-								$sSQL .= " limit ".$this->iLimit;
+							else $sSQL .= " limit ".$this->iLimit;
 
-							if (CONST_Debug) { var_dump($sSQL); }
-							$aViewBoxPlaceIDs = chksql($this->oDB->getAll($sSQL),
-							                           "Could not get places for search terms.");
+							if (CONST_Debug) var_dump($sSQL);
+							$aViewBoxPlaceIDs = chksql($this->oDB->getAll($sSQL), "Could not get places for search terms.");
 							//var_dump($aViewBoxPlaceIDs);
 							// Did we have an viewbox matches?
 							$aPlaceIDs = array();
 							$bViewBoxMatch = false;
-							foreach($aViewBoxPlaceIDs as $aViewBoxRow)
-							{
+							foreach ($aViewBoxPlaceIDs as $aViewBoxRow) {
 								//if ($bViewBoxMatch == 1 && $aViewBoxRow['in_small'] == 'f') break;
 								//if ($bViewBoxMatch == 2 && $aViewBoxRow['in_large'] == 'f') break;
 								//if ($aViewBoxRow['in_small'] == 't') $bViewBoxMatch = 1;
@@ -1391,38 +1208,34 @@ class Geocode
 						//exit;
 
 						//now search for housenumber, if housenumber provided
-						if ($aSearch['sHouseNumber'] && sizeof($aPlaceIDs))
-						{
+						if ($aSearch['sHouseNumber'] && sizeof($aPlaceIDs)) {
 							$searchedHousenumber = intval($aSearch['sHouseNumber']);
 							$aRoadPlaceIDs = $aPlaceIDs;
-							$sPlaceIDs = join(',',$aPlaceIDs);
+							$sPlaceIDs = join(',', $aPlaceIDs);
 
 							// Now they are indexed, look for a house attached to a street we found
 							$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
 							$sSQL = "select place_id from placex where parent_place_id in (".$sPlaceIDs.") and transliteration(housenumber) ~* E'".$sHouseNumberRegex."'";
-							if (sizeof($this->aExcludePlaceIDs))
-							{
-								$sSQL .= " and place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+							if (sizeof($this->aExcludePlaceIDs)) {
+								$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 							}
 							$sSQL .= " limit $this->iLimit";
 							if (CONST_Debug) var_dump($sSQL);
 							$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							
 							// if nothing found, search in the interpolation line table
-							if(!sizeof($aPlaceIDs))
-							{
+							if (!sizeof($aPlaceIDs)) {
 								// do we need to use transliteration and the regex for housenumbers???
 								//new query for lines, not housenumbers anymore
-								if($searchedHousenumber%2 == 0){
+								if ($searchedHousenumber%2 == 0) {
 									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
 									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-								}else{
+								} else {
 									//look for housenumber in streets with interpolationtype odd or all
 									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
-								if (sizeof($this->aExcludePlaceIDs))
-								{
+								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
 								//$sSQL .= " limit $this->iLimit";
@@ -1432,12 +1245,10 @@ class Geocode
 							}
 								
 							// If nothing found try the aux fallback table
-							if (CONST_Use_Aux_Location_data && !sizeof($aPlaceIDs))
-							{
+							if (CONST_Use_Aux_Location_data && !sizeof($aPlaceIDs)) {
 								$sSQL = "select place_id from location_property_aux where parent_place_id in (".$sPlaceIDs.") and housenumber = '".pg_escape_string($aSearch['sHouseNumber'])."'";
-								if (sizeof($this->aExcludePlaceIDs))
-								{
-									$sSQL .= " and parent_place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+								if (sizeof($this->aExcludePlaceIDs)) {
+									$sSQL .= " and parent_place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
 								//$sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
@@ -1445,19 +1256,17 @@ class Geocode
 							}
 
 							//if nothing was found in placex or location_property_aux, then search in Tiger data for this housenumber(location_property_tiger)
-							if (CONST_Use_US_Tiger_Data && !sizeof($aPlaceIDs))
-							{
+							if (CONST_Use_US_Tiger_Data && !sizeof($aPlaceIDs)) {
 								//new query for lines, not housenumbers anymore
-								if($searchedHousenumber%2 == 0){
+								if ($searchedHousenumber%2 == 0) {
 									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
 									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-								}else{
+								} else {
 									//look for housenumber in streets with interpolationtype odd or all
 									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
-								if (sizeof($this->aExcludePlaceIDs))
-								{
+								if (sizeof($this->aExcludePlaceIDs)) {
 									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
 								//$sSQL .= " limit $this->iLimit";
@@ -1467,8 +1276,7 @@ class Geocode
 							}
 
 							// Fallback to the road (if no housenumber was found)
-							if (!sizeof($aPlaceIDs) && preg_match('/[0-9]+/', $aSearch['sHouseNumber']))
-							{
+							if (!sizeof($aPlaceIDs) && preg_match('/[0-9]+/', $aSearch['sHouseNumber'])) {
 								$aPlaceIDs = $aRoadPlaceIDs;
 								//set to -1, if no housenumbers were found
 								$searchedHousenumber = -1;
@@ -1477,13 +1285,11 @@ class Geocode
 						}
 
 
-						if ($aSearch['sClass'] && sizeof($aPlaceIDs))
-						{
+						if ($aSearch['sClass'] && sizeof($aPlaceIDs)) {
 							$sPlaceIDs = join(',', $aPlaceIDs);
 							$aClassPlaceIDs = array();
 
-							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'name')
-							{
+							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'name') {
 								// If they were searching for a named class (i.e. 'Kings Head pub') then we might have an extra match
 								$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
 								$sSQL .= " and linked_place_id is null";
@@ -1493,8 +1299,7 @@ class Geocode
 								$aClassPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							}
 
-							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'near') // & in
-							{
+							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'near') { // & in
 								$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
 								$bCacheTable = chksql($this->oDB->getOne($sSQL));
 
@@ -1505,56 +1310,46 @@ class Geocode
 
 								// For state / country level searches the normal radius search doesn't work very well
 								$sPlaceGeom = false;
-								if ($this->iMaxRank < 9 && $bCacheTable)
-								{
+								if ($this->iMaxRank < 9 && $bCacheTable) {
 									// Try and get a polygon to search in instead
 									$sSQL = "select geometry from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank + 5 and st_geometrytype(geometry) in ('ST_Polygon','ST_MultiPolygon') order by rank_search asc limit 1";
 									if (CONST_Debug) var_dump($sSQL);
 									$sPlaceGeom = chksql($this->oDB->getOne($sSQL));
 								}
 
-								if ($sPlaceGeom)
-								{
+								if ($sPlaceGeom) {
 									$sPlaceIDs = false;
-								}
-								else
-								{
+								} else {
 									$this->iMaxRank += 5;
 									$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank";
 									if (CONST_Debug) var_dump($sSQL);
 									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-									$sPlaceIDs = join(',',$aPlaceIDs);
+									$sPlaceIDs = join(',', $aPlaceIDs);
 								}
 
-								if ($sPlaceIDs || $sPlaceGeom)
-								{
-
+								if ($sPlaceIDs || $sPlaceGeom) {
 									$fRange = 0.01;
-									if ($bCacheTable)
-									{
+									if ($bCacheTable) {
 										// More efficient - can make the range bigger
 										$fRange = 0.05;
 
 										$sOrderBySQL = '';
 										if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.centroid)";
-										else if ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
-										else if ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
+										elseif ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
+										elseif ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
 
 										$sSQL = "select distinct l.place_id".($sOrderBySQL?','.$sOrderBySQL:'')." from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." as l";
 										if ($sCountryCodesSQL) $sSQL .= " join placex as lp using (place_id)";
-										if ($sPlaceIDs)
-										{
+										if ($sPlaceIDs) {
 											$sSQL .= ",placex as f where ";
 											$sSQL .= "f.place_id in ($sPlaceIDs) and ST_DWithin(l.centroid, f.centroid, $fRange) ";
 										}
-										if ($sPlaceGeom)
-										{
+										if ($sPlaceGeom) {
 											$sSQL .= " where ";
 											$sSQL .= "ST_Contains('".$sPlaceGeom."', l.centroid) ";
 										}
-										if (sizeof($this->aExcludePlaceIDs))
-										{
-											$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+										if (sizeof($this->aExcludePlaceIDs)) {
+											$sSQL .= " and l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 										}
 										if ($sCountryCodesSQL) $sSQL .= " and lp.calculated_country_code in ($sCountryCodesSQL)";
 										if ($sOrderBySQL) $sSQL .= "order by ".$sOrderBySQL." asc";
@@ -1562,9 +1357,7 @@ class Geocode
 										$sSQL .= " limit $this->iLimit";
 										if (CONST_Debug) var_dump($sSQL);
 										$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
-									}
-									else
-									{
+									} else {
 										if (isset($aSearch['fRadius']) && $aSearch['fRadius']) $fRange = $aSearch['fRadius'];
 
 										$sOrderBySQL = '';
@@ -1574,9 +1367,8 @@ class Geocode
 										$sSQL = "select distinct l.place_id".($sOrderBysSQL?','.$sOrderBysSQL:'')." from placex as l,placex as f where ";
 										$sSQL .= "f.place_id in ( $sPlaceIDs) and ST_DWithin(l.geometry, f.centroid, $fRange) ";
 										$sSQL .= "and l.class='".$aSearch['sClass']."' and l.type='".$aSearch['sType']."' ";
-										if (sizeof($this->aExcludePlaceIDs))
-										{
-											$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+										if (sizeof($this->aExcludePlaceIDs)) {
+											$sSQL .= " and l.place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 										}
 										if ($sCountryCodesSQL) $sSQL .= " and l.calculated_country_code in ($sCountryCodesSQL)";
 										if ($sOrderBy) $sSQL .= "order by ".$OrderBysSQL." asc";
@@ -1589,43 +1381,40 @@ class Geocode
 							}
 
 							$aPlaceIDs = $aClassPlaceIDs;
-
 						}
-
 					}
 
-					if (CONST_Debug) { echo "<br><b>Place IDs:</b> "; var_Dump($aPlaceIDs); }
+					if (CONST_Debug) {
+						echo "<br><b>Place IDs:</b> ";
+						var_Dump($aPlaceIDs);
+					}
 
-					foreach($aPlaceIDs as $iPlaceID)
-					{
+					foreach ($aPlaceIDs as $iPlaceID) {
 						// array for placeID => -1 | Tiger housenumber
 						$aResultPlaceIDs[$iPlaceID] = $searchedHousenumber;
 					}
 					if ($iQueryLoop > 20) break;
 				}
 
-				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30))
-				{
+				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30)) {
 					// Need to verify passes rank limits before dropping out of the loop (yuk!)
 					// reduces the number of place ids, like a filter
 					// rank_address is 30 for interpolated housenumbers
-					$sSQL = "select place_id from placex where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
+					$sSQL = "select place_id from placex where place_id in (".join(',', array_keys($aResultPlaceIDs)).") ";
 					$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
 					if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
-					if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
-					if (CONST_Use_US_Tiger_Data)
-					{
-						$sSQL .= ") UNION select place_id from location_property_tiger where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
+					if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',', $this->aAddressRankList).")";
+					if (CONST_Use_US_Tiger_Data) {
+						$sSQL .= ") UNION select place_id from location_property_tiger where place_id in (".join(',', array_keys($aResultPlaceIDs)).") ";
 						$sSQL .= "and (30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
-						if ($this->aAddressRankList) $sSQL .= " OR 30 in (".join(',',$this->aAddressRankList).")";
+						if ($this->aAddressRankList) $sSQL .= " OR 30 in (".join(',', $this->aAddressRankList).")";
 					}
-					$sSQL .= ") UNION select place_id from location_property_osmline where place_id in (".join(',',array_keys($aResultPlaceIDs)).")";
+					$sSQL .= ") UNION select place_id from location_property_osmline where place_id in (".join(',', array_keys($aResultPlaceIDs)).")";
 					$sSQL .= " and (30 between $this->iMinAddressRank and $this->iMaxAddressRank)";
 					if (CONST_Debug) var_dump($sSQL);
 					$aFilteredPlaceIDs = chksql($this->oDB->getCol($sSQL));
 					$tempIDs = array();
-					foreach($aFilteredPlaceIDs as $placeID)
-					{
+					foreach ($aFilteredPlaceIDs as $placeID) {
 						$tempIDs[$placeID] = $aResultPlaceIDs[$placeID];  //assign housenumber to placeID
 					}
 					$aResultPlaceIDs = $tempIDs;
@@ -1638,37 +1427,31 @@ class Geocode
 			}
 
 			// Did we find anything?
-			if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs))
-			{
+			if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs)) {
 				$aSearchResults = $this->getDetails($aResultPlaceIDs);
 			}
-
-		}
-		else
-		{
+		} else {
 			// Just interpret as a reverse geocode
 			$oReverse = new ReverseGeocode($this->oDB);
 			$oReverse->setZoom(18);
 
-			$aLookup = $oReverse->lookup((float)$this->aNearPoint[0],
-			                             (float)$this->aNearPoint[1],
-			                             false);
+			$aLookup = $oReverse->lookup(
+				(float)$this->aNearPoint[0],
+				(float)$this->aNearPoint[1],
+				false
+			);
 
 			if (CONST_Debug) var_dump("Reverse search", $aLookup);
 
 			if ($aLookup['place_id'])
 				$aSearchResults = $this->getDetails(array($aLookup['place_id'] => -1));
-			else
-				$aSearchResults = array();
+			else $aSearchResults = array();
 		}
 
 		// No results? Done
-		if (!sizeof($aSearchResults))
-		{
-			if ($this->bFallback)
-			{
-				if ($this->fallbackStructuredQuery())
-				{
+		if (!sizeof($aSearchResults)) {
+			if ($this->bFallback) {
+				if ($this->fallbackStructuredQuery()) {
 					return $this->lookup();
 				}
 			}
@@ -1677,13 +1460,15 @@ class Geocode
 		}
 
 		$aClassType = getClassTypesWithImportance();
-		$aRecheckWords = preg_split('/\b[\s,\\-]*/u',$sQuery);
-		foreach($aRecheckWords as $i => $sWord)
-		{
+		$aRecheckWords = preg_split('/\b[\s,\\-]*/u', $sQuery);
+		foreach ($aRecheckWords as $i => $sWord) {
 			if (!preg_match('/\pL/', $sWord)) unset($aRecheckWords[$i]);
 		}
 
-		if (CONST_Debug) { echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords); }
+		if (CONST_Debug) {
+			echo '<i>Recheck words:<\i>';
+			var_dump($aRecheckWords);
+		}
 
 		$oPlaceLookup = new PlaceLookup($this->oDB);
 		$oPlaceLookup->setIncludePolygonAsPoints($this->bIncludePolygonAsPoints);
@@ -1693,19 +1478,16 @@ class Geocode
 		$oPlaceLookup->setIncludePolygonAsSVG($this->bIncludePolygonAsSVG);
 		$oPlaceLookup->setPolygonSimplificationThreshold($this->fPolygonSimplificationThreshold);
 
-		foreach($aSearchResults as $iResNum => $aResult)
-		{
+		foreach ($aSearchResults as $iResNum => $aResult) {
 			// Default
 			$fDiameter = getResultDiameter($aResult);
 
 			$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter/2);
-			if ($aOutlineResult)
-			{
+			if ($aOutlineResult) {
 				$aResult = array_merge($aResult, $aOutlineResult);
 			}
 			
-			if ($aResult['extra_place'] == 'city')
-			{
+			if ($aResult['extra_place'] == 'city') {
 				$aResult['class'] = 'place';
 				$aResult['type'] = 'city';
 				$aResult['rank_search'] = 16;
@@ -1713,63 +1495,48 @@ class Geocode
 
 			// Is there an icon set for this type of result?
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
-			{
+					&& $aClassType[$aResult['class'].':'.$aResult['type']]['icon']) {
 				$aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aClassType[$aResult['class'].':'.$aResult['type']]['icon'].'.p.20.png';
 			}
 
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
-			{
+					&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label']) {
 				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'];
-			}
-			elseif (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type']]['label'])
-			{
+			} elseif (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
+					&& $aClassType[$aResult['class'].':'.$aResult['type']]['label']) {
 				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type']]['label'];
 			}
 			// if tag '&addressdetails=1' is set in query
-			if ($this->bIncludeAddressDetails)
-			{
+			if ($this->bIncludeAddressDetails) {
 				// getAddressDetails() is defined in lib.php and uses the SQL function get_addressdata in functions.sql
 				$aResult['address'] = getAddressDetails($this->oDB, $sLanguagePrefArraySQL, $aResult['place_id'], $aResult['country_code'], $aResultPlaceIDs[$aResult['place_id']]);
-				if ($aResult['extra_place'] == 'city' && !isset($aResult['address']['city']))
-				{
+				if ($aResult['extra_place'] == 'city' && !isset($aResult['address']['city'])) {
 					$aResult['address'] = array_merge(array('city' => array_shift(array_values($aResult['address']))), $aResult['address']);
 				}
 			}
-			if ($this->bIncludeExtraTags)
-			{
-				if ($aResult['extra'])
-				{
+
+			if ($this->bIncludeExtraTags) {
+				if ($aResult['extra']) {
 					$aResult['sExtraTags'] = json_decode($aResult['extra']);
-				}
-				else
-				{
+				} else {
 					$aResult['sExtraTags'] = (object) array();
 				}
 			}
 
-			if ($this->bIncludeNameDetails)
-			{
-				if ($aResult['names'])
-				{
+			if ($this->bIncludeNameDetails) {
+				if ($aResult['names']) {
 					$aResult['sNameDetails'] = json_decode($aResult['names']);
-				}
-				else
-				{
+				} else {
 					$aResult['sNameDetails'] = (object) array();
 				}
 			}
 
 			// Adjust importance for the number of exact string matches in the result
-			$aResult['importance'] = max(0.001,$aResult['importance']);
+			$aResult['importance'] = max(0.001, $aResult['importance']);
 			$iCountWords = 0;
 			$sAddress = $aResult['langaddress'];
-			foreach($aRecheckWords as $i => $sWord)
-			{
-				if (stripos($sAddress, $sWord)!==false)
-				{
+			foreach ($aRecheckWords as $i => $sWord) {
+				if (stripos($sAddress, $sWord)!==false) {
 					$iCountWords++;
 					if (preg_match("/(^|,)\s*".preg_quote($sWord, '/')."\s*(,|$)/", $sAddress)) $iCountWords += 0.1;
 				}
@@ -1784,19 +1551,16 @@ class Geocode
 			//   - number of exact matches from the query
 			if (isset($this->exactMatchCache[$aResult['place_id']]))
 				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
-			else if (isset($this->exactMatchCache[$aResult['parent_place_id']]))
+			elseif (isset($this->exactMatchCache[$aResult['parent_place_id']]))
 				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
 			//  - importance of the class/type
 			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
-				&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
-			{
+				&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance']) {
 				$aResult['foundorder'] += 0.0001 * $aClassType[$aResult['class'].':'.$aResult['type']]['importance'];
-			}
-			else
-			{
+			} else {
 				$aResult['foundorder'] += 0.01;
 			}
-			if (CONST_Debug) { var_dump($aResult); }
+			if (CONST_Debug) var_dump($aResult);
 			$aSearchResults[$iResNum] = $aResult;
 		}
 		uasort($aSearchResults, 'byImportance');
@@ -1807,19 +1571,16 @@ class Geocode
 		$aSearchResults = array();
 
 		$bFirst = true;
-		foreach($aToFilter as $iResNum => $aResult)
-		{
+		foreach ($aToFilter as $iResNum => $aResult) {
 			$this->aExcludePlaceIDs[$aResult['place_id']] = $aResult['place_id'];
-			if ($bFirst)
-			{
+			if ($bFirst) {
 				$fLat = $aResult['lat'];
 				$fLon = $aResult['lon'];
 				if (isset($aResult['zoom'])) $iZoom = $aResult['zoom'];
 				$bFirst = false;
 			}
 			if (!$this->bDeDupe || (!isset($aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']])
-						&& !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']])))
-			{
+						&& !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']]))) {
 				$aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']] = true;
 				$aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']] = true;
 				$aSearchResults[] = $aResult;
@@ -1830,9 +1591,5 @@ class Geocode
 		}
 
 		return $aSearchResults;
-
 	} // end lookup()
-
-
 } // end class
-

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -1,614 +1,559 @@
 <?php
-	require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-	require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
 
-	class Geocode
+require_once(CONST_BasePath.'/lib/PlaceLookup.php');
+require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
+
+class Geocode
+{
+	protected $oDB;
+
+	protected $aLangPrefOrder = array();
+
+	protected $bIncludeAddressDetails = false;
+	protected $bIncludeExtraTags = false;
+	protected $bIncludeNameDetails = false;
+
+	protected $bIncludePolygonAsPoints = false;
+	protected $bIncludePolygonAsText = false;
+	protected $bIncludePolygonAsGeoJSON = false;
+	protected $bIncludePolygonAsKML = false;
+	protected $bIncludePolygonAsSVG = false;
+	protected $fPolygonSimplificationThreshold = 0.0;
+
+	protected $aExcludePlaceIDs = array();
+	protected $bDeDupe = true;
+	protected $bReverseInPlan = false;
+
+	protected $iLimit = 20;
+	protected $iFinalLimit = 10;
+	protected $iOffset = 0;
+	protected $bFallback = false;
+
+	protected $aCountryCodes = false;
+	protected $aNearPoint = false;
+
+	protected $bBoundedSearch = false;
+	protected $aViewBox = false;
+	protected $sViewboxSmallSQL = false;
+	protected $sViewboxLargeSQL = false;
+	protected $aRoutePoints = false;
+
+	protected $iMaxRank = 20;
+	protected $iMinAddressRank = 0;
+	protected $iMaxAddressRank = 30;
+	protected $aAddressRankList = array();
+	protected $exactMatchCache = array();
+
+	protected $sAllowedTypesSQLList = false;
+
+	protected $sQuery = false;
+	protected $aStructuredQuery = false;
+
+	function Geocode(&$oDB)
 	{
-		protected $oDB;
+		$this->oDB =& $oDB;
+	}
 
-		protected $aLangPrefOrder = array();
+	function setReverseInPlan($bReverse)
+	{
+		$this->bReverseInPlan = $bReverse;
+	}
 
-		protected $bIncludeAddressDetails = false;
-		protected $bIncludeExtraTags = false;
-		protected $bIncludeNameDetails = false;
+	function setLanguagePreference($aLangPref)
+	{
+		$this->aLangPrefOrder = $aLangPref;
+	}
 
-		protected $bIncludePolygonAsPoints = false;
-		protected $bIncludePolygonAsText = false;
-		protected $bIncludePolygonAsGeoJSON = false;
-		protected $bIncludePolygonAsKML = false;
-		protected $bIncludePolygonAsSVG = false;
-		protected $fPolygonSimplificationThreshold = 0.0;
+	function getIncludeAddressDetails()
+	{
+		return $this->bIncludeAddressDetails;
+	}
 
-		protected $aExcludePlaceIDs = array();
-		protected $bDeDupe = true;
-		protected $bReverseInPlan = false;
+	function getIncludeExtraTags()
+	{
+		return $this->bIncludeExtraTags;
+	}
 
-		protected $iLimit = 20;
-		protected $iFinalLimit = 10;
-		protected $iOffset = 0;
-		protected $bFallback = false;
+	function getIncludeNameDetails()
+	{
+		return $this->bIncludeNameDetails;
+	}
 
-		protected $aCountryCodes = false;
-		protected $aNearPoint = false;
+	function setIncludePolygonAsPoints($b = true)
+	{
+		$this->bIncludePolygonAsPoints = $b;
+	}
 
-		protected $bBoundedSearch = false;
-		protected $aViewBox = false;
-		protected $sViewboxSmallSQL = false;
-		protected $sViewboxLargeSQL = false;
-		protected $aRoutePoints = false;
+	function setIncludePolygonAsText($b = true)
+	{
+		$this->bIncludePolygonAsText = $b;
+	}
 
-		protected $iMaxRank = 20;
-		protected $iMinAddressRank = 0;
-		protected $iMaxAddressRank = 30;
-		protected $aAddressRankList = array();
-		protected $exactMatchCache = array();
+	function setIncludePolygonAsGeoJSON($b = true)
+	{
+		$this->bIncludePolygonAsGeoJSON = $b;
+	}
 
-		protected $sAllowedTypesSQLList = false;
+	function setIncludePolygonAsKML($b = true)
+	{
+		$this->bIncludePolygonAsKML = $b;
+	}
 
-		protected $sQuery = false;
-		protected $aStructuredQuery = false;
+	function setIncludePolygonAsSVG($b = true)
+	{
+		$this->bIncludePolygonAsSVG = $b;
+	}
 
-		function Geocode(&$oDB)
+	function setPolygonSimplificationThreshold($f)
+	{
+		$this->fPolygonSimplificationThreshold = $f;
+	}
+
+	function setLimit($iLimit = 10)
+	{
+		if ($iLimit > 50) $iLimit = 50;
+		if ($iLimit < 1) $iLimit = 1;
+
+		$this->iFinalLimit = $iLimit;
+		$this->iLimit = $this->iFinalLimit + min($this->iFinalLimit, 10);
+	}
+
+	function getExcludedPlaceIDs()
+	{
+		return $this->aExcludePlaceIDs;
+	}
+
+	function setViewBox($fLeft, $fBottom, $fRight, $fTop)
+	{
+		$this->aViewBox = array($fLeft, $fBottom, $fRight, $fTop);
+	}
+
+	function getViewBoxString()
+	{
+		if (!$this->aViewBox) return null;
+		return $this->aViewBox[0].','.$this->aViewBox[3].','.$this->aViewBox[2].','.$this->aViewBox[1];
+	}
+
+	function setFeatureType($sFeatureType)
+	{
+		switch($sFeatureType)
 		{
-			$this->oDB =& $oDB;
+		case 'country':
+			$this->setRankRange(4, 4);
+			break;
+		case 'state':
+			$this->setRankRange(8, 8);
+			break;
+		case 'city':
+			$this->setRankRange(14, 16);
+			break;
+		case 'settlement':
+			$this->setRankRange(8, 20);
+			break;
 		}
+	}
 
-		function setReverseInPlan($bReverse)
+	function setRankRange($iMin, $iMax)
+	{
+		$this->iMinAddressRank = $iMin;
+		$this->iMaxAddressRank = $iMax;
+	}
+
+	function setNearPoint($aNearPoint, $fRadiusDeg = 0.1)
+	{
+		$this->aNearPoint = array((float)$aNearPoint[0], (float)$aNearPoint[1], (float)$fRadiusDeg);
+	}
+
+	function setQuery($sQueryString)
+	{
+		$this->sQuery = $sQueryString;
+		$this->aStructuredQuery = false;
+	}
+
+	function getQueryString()
+	{
+		return $this->sQuery;
+	}
+
+
+	function loadParamArray($aParams)
+	{
+		if (isset($aParams['addressdetails'])) $this->bIncludeAddressDetails = (bool)$aParams['addressdetails'];
+		if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool)$aParams['extratags'];
+		if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool)$aParams['namedetails'];
+
+		if (isset($aParams['bounded'])) $this->bBoundedSearch = (bool)$aParams['bounded'];
+		if (isset($aParams['dedupe'])) $this->bDeDupe = (bool)$aParams['dedupe'];
+
+		if (isset($aParams['limit'])) $this->setLimit((int)$aParams['limit']);
+		if (isset($aParams['offset'])) $this->iOffset = (int)$aParams['offset'];
+
+		if (isset($aParams['fallback'])) $this->bFallback = (bool)$aParams['fallback'];
+
+		// List of excluded Place IDs - used for more acurate pageing
+		if (isset($aParams['exclude_place_ids']) && $aParams['exclude_place_ids'])
 		{
-			$this->bReverseInPlan = $bReverse;
-		}
-
-		function setLanguagePreference($aLangPref)
-		{
-			$this->aLangPrefOrder = $aLangPref;
-		}
-
-		function getIncludeAddressDetails()
-		{
-			return $this->bIncludeAddressDetails;
-		}
-
-		function getIncludeExtraTags()
-		{
-			return $this->bIncludeExtraTags;
-		}
-
-		function getIncludeNameDetails()
-		{
-			return $this->bIncludeNameDetails;
-		}
-
-		function setIncludePolygonAsPoints($b = true)
-		{
-			$this->bIncludePolygonAsPoints = $b;
-		}
-
-		function setIncludePolygonAsText($b = true)
-		{
-			$this->bIncludePolygonAsText = $b;
-		}
-
-		function setIncludePolygonAsGeoJSON($b = true)
-		{
-			$this->bIncludePolygonAsGeoJSON = $b;
-		}
-
-		function setIncludePolygonAsKML($b = true)
-		{
-			$this->bIncludePolygonAsKML = $b;
-		}
-
-		function setIncludePolygonAsSVG($b = true)
-		{
-			$this->bIncludePolygonAsSVG = $b;
-		}
-
-		function setPolygonSimplificationThreshold($f)
-		{
-			$this->fPolygonSimplificationThreshold = $f;
-		}
-
-		function setLimit($iLimit = 10)
-		{
-			if ($iLimit > 50) $iLimit = 50;
-			if ($iLimit < 1) $iLimit = 1;
-
-			$this->iFinalLimit = $iLimit;
-			$this->iLimit = $this->iFinalLimit + min($this->iFinalLimit, 10);
-		}
-
-		function getExcludedPlaceIDs()
-		{
-			return $this->aExcludePlaceIDs;
-		}
-
-		function setViewBox($fLeft, $fBottom, $fRight, $fTop)
-		{
-			$this->aViewBox = array($fLeft, $fBottom, $fRight, $fTop);
-		}
-
-		function getViewBoxString()
-		{
-			if (!$this->aViewBox) return null;
-			return $this->aViewBox[0].','.$this->aViewBox[3].','.$this->aViewBox[2].','.$this->aViewBox[1];
-		}
-
-		function setFeatureType($sFeatureType)
-		{
-			switch($sFeatureType)
+			foreach(explode(',',$aParams['exclude_place_ids']) as $iExcludedPlaceID)
 			{
-			case 'country':
-				$this->setRankRange(4, 4);
-				break;
-			case 'state':
-				$this->setRankRange(8, 8);
-				break;
-			case 'city':
-				$this->setRankRange(14, 16);
-				break;
-			case 'settlement':
-				$this->setRankRange(8, 20);
-				break;
+				$iExcludedPlaceID = (int)$iExcludedPlaceID;
+				if ($iExcludedPlaceID)
+					$aExcludePlaceIDs[$iExcludedPlaceID] = $iExcludedPlaceID;
 			}
+
+			if (isset($aExcludePlaceIDs))
+				$this->aExcludePlaceIDs = $aExcludePlaceIDs;
 		}
 
-		function setRankRange($iMin, $iMax)
+		// Only certain ranks of feature
+		if (isset($aParams['featureType'])) $this->setFeatureType($aParams['featureType']);
+		if (isset($aParams['featuretype'])) $this->setFeatureType($aParams['featuretype']);
+
+		// Country code list
+		if (isset($aParams['countrycodes']))
 		{
-			$this->iMinAddressRank = $iMin;
-			$this->iMaxAddressRank = $iMax;
-		}
-
-		function setNearPoint($aNearPoint, $fRadiusDeg = 0.1)
-		{
-			$this->aNearPoint = array((float)$aNearPoint[0], (float)$aNearPoint[1], (float)$fRadiusDeg);
-		}
-
-		function setQuery($sQueryString)
-		{
-			$this->sQuery = $sQueryString;
-			$this->aStructuredQuery = false;
-		}
-
-		function getQueryString()
-		{
-			return $this->sQuery;
-		}
-
-
-		function loadParamArray($aParams)
-		{
-			if (isset($aParams['addressdetails'])) $this->bIncludeAddressDetails = (bool)$aParams['addressdetails'];
-			if (isset($aParams['extratags'])) $this->bIncludeExtraTags = (bool)$aParams['extratags'];
-			if (isset($aParams['namedetails'])) $this->bIncludeNameDetails = (bool)$aParams['namedetails'];
-
-			if (isset($aParams['bounded'])) $this->bBoundedSearch = (bool)$aParams['bounded'];
-			if (isset($aParams['dedupe'])) $this->bDeDupe = (bool)$aParams['dedupe'];
-
-			if (isset($aParams['limit'])) $this->setLimit((int)$aParams['limit']);
-			if (isset($aParams['offset'])) $this->iOffset = (int)$aParams['offset'];
-
-			if (isset($aParams['fallback'])) $this->bFallback = (bool)$aParams['fallback'];
-
-			// List of excluded Place IDs - used for more acurate pageing
-			if (isset($aParams['exclude_place_ids']) && $aParams['exclude_place_ids'])
+			$aCountryCodes = array();
+			foreach(explode(',',$aParams['countrycodes']) as $sCountryCode)
 			{
-				foreach(explode(',',$aParams['exclude_place_ids']) as $iExcludedPlaceID)
+				if (preg_match('/^[a-zA-Z][a-zA-Z]$/', $sCountryCode))
 				{
-					$iExcludedPlaceID = (int)$iExcludedPlaceID;
-					if ($iExcludedPlaceID)
-						$aExcludePlaceIDs[$iExcludedPlaceID] = $iExcludedPlaceID;
+					$aCountryCodes[] = strtolower($sCountryCode);
 				}
-
-				if (isset($aExcludePlaceIDs))
-					$this->aExcludePlaceIDs = $aExcludePlaceIDs;
 			}
-
-			// Only certain ranks of feature
-			if (isset($aParams['featureType'])) $this->setFeatureType($aParams['featureType']);
-			if (isset($aParams['featuretype'])) $this->setFeatureType($aParams['featuretype']);
-
-			// Country code list
-			if (isset($aParams['countrycodes']))
-			{
-				$aCountryCodes = array();
-				foreach(explode(',',$aParams['countrycodes']) as $sCountryCode)
-				{
-					if (preg_match('/^[a-zA-Z][a-zA-Z]$/', $sCountryCode))
-					{
-						$aCountryCodes[] = strtolower($sCountryCode);
-					}
-				}
-				$this->aCountryCodes = $aCountryCodes;
-			}
-
-			if (isset($aParams['viewboxlbrt']) && $aParams['viewboxlbrt'])
-			{
-				$aCoOrdinatesLBRT = explode(',',$aParams['viewboxlbrt']);
-				$this->setViewBox($aCoOrdinatesLBRT[0], $aCoOrdinatesLBRT[1], $aCoOrdinatesLBRT[2], $aCoOrdinatesLBRT[3]);
-			}
-			else if (isset($aParams['viewbox']) && $aParams['viewbox'])
-			{
-				$aCoOrdinatesLTRB = explode(',',$aParams['viewbox']);
-				$this->setViewBox($aCoOrdinatesLTRB[0], $aCoOrdinatesLTRB[3], $aCoOrdinatesLTRB[2], $aCoOrdinatesLTRB[1]);
-			}
-
-			if (isset($aParams['route']) && $aParams['route'] && isset($aParams['routewidth']) && $aParams['routewidth'])
-			{
-				$aPoints = explode(',',$aParams['route']);
-				if (sizeof($aPoints) % 2 != 0)
-				{
-					userError("Uneven number of points");
-					exit;
-				}
-				$fPrevCoord = false;
-				$aRoute = array();
-				foreach($aPoints as $i => $fPoint)
-				{
-					if ($i%2)
-					{
-						$aRoute[] = array((float)$fPoint, $fPrevCoord);
-					}
-					else
-					{
-						$fPrevCoord = (float)$fPoint;
-					}
-				}
-				$this->aRoutePoints = $aRoute;
-			}
+			$this->aCountryCodes = $aCountryCodes;
 		}
 
-		function setQueryFromParams($aParams)
+		if (isset($aParams['viewboxlbrt']) && $aParams['viewboxlbrt'])
 		{
-			// Search query
-			$sQuery = (isset($aParams['q'])?trim($aParams['q']):'');
-			if (!$sQuery)
+			$aCoOrdinatesLBRT = explode(',',$aParams['viewboxlbrt']);
+			$this->setViewBox($aCoOrdinatesLBRT[0], $aCoOrdinatesLBRT[1], $aCoOrdinatesLBRT[2], $aCoOrdinatesLBRT[3]);
+		}
+		else if (isset($aParams['viewbox']) && $aParams['viewbox'])
+		{
+			$aCoOrdinatesLTRB = explode(',',$aParams['viewbox']);
+			$this->setViewBox($aCoOrdinatesLTRB[0], $aCoOrdinatesLTRB[3], $aCoOrdinatesLTRB[2], $aCoOrdinatesLTRB[1]);
+		}
+
+		if (isset($aParams['route']) && $aParams['route'] && isset($aParams['routewidth']) && $aParams['routewidth'])
+		{
+			$aPoints = explode(',',$aParams['route']);
+			if (sizeof($aPoints) % 2 != 0)
 			{
+				userError("Uneven number of points");
+				exit;
+			}
+			$fPrevCoord = false;
+			$aRoute = array();
+			foreach($aPoints as $i => $fPoint)
+			{
+				if ($i%2)
+				{
+					$aRoute[] = array((float)$fPoint, $fPrevCoord);
+				}
+				else
+				{
+					$fPrevCoord = (float)$fPoint;
+				}
+			}
+			$this->aRoutePoints = $aRoute;
+		}
+	}
+
+	function setQueryFromParams($aParams)
+	{
+		// Search query
+		$sQuery = (isset($aParams['q'])?trim($aParams['q']):'');
+		if (!$sQuery)
+		{
+			$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
+			$this->setReverseInPlan(false);
+		}
+		else
+		{
+			$this->setQuery($sQuery);
+		}
+	}
+
+	function loadStructuredAddressElement($sValue, $sKey, $iNewMinAddressRank, $iNewMaxAddressRank, $aItemListValues)
+	{
+		$sValue = trim($sValue);
+		if (!$sValue) return false;
+		$this->aStructuredQuery[$sKey] = $sValue;
+		if ($this->iMinAddressRank == 0 && $this->iMaxAddressRank == 30)
+		{
+			$this->iMinAddressRank = $iNewMinAddressRank;
+			$this->iMaxAddressRank = $iNewMaxAddressRank;
+		}
+		if ($aItemListValues) $this->aAddressRankList = array_merge($this->aAddressRankList, $aItemListValues);
+		return true;
+	}
+
+	function setStructuredQuery($sAmentiy = false, $sStreet = false, $sCity = false, $sCounty = false, $sState = false, $sCountry = false, $sPostalCode = false)
+	{
+		$this->sQuery = false;
+
+		// Reset
+		$this->iMinAddressRank = 0;
+		$this->iMaxAddressRank = 30;
+		$this->aAddressRankList = array();
+
+		$this->aStructuredQuery = array();
+		$this->sAllowedTypesSQLList = '';
+
+		$this->loadStructuredAddressElement($sAmentiy, 'amenity', 26, 30, false);
+		$this->loadStructuredAddressElement($sStreet, 'street', 26, 30, false);
+		$this->loadStructuredAddressElement($sCity, 'city', 14, 24, false);
+		$this->loadStructuredAddressElement($sCounty, 'county', 9, 13, false);
+		$this->loadStructuredAddressElement($sState, 'state', 8, 8, false);
+		$this->loadStructuredAddressElement($sPostalCode, 'postalcode' , 5, 11, array(5, 11));
+		$this->loadStructuredAddressElement($sCountry, 'country', 4, 4, false);
+
+		if (sizeof($this->aStructuredQuery) > 0)
+		{
+			$this->sQuery = join(', ', $this->aStructuredQuery);
+			if ($this->iMaxAddressRank < 30)
+			{
+				$sAllowedTypesSQLList = '(\'place\',\'boundary\')';
+			}
+		}
+	}
+
+	function fallbackStructuredQuery()
+	{
+		if (!$this->aStructuredQuery) return false;
+
+		$aParams = $this->aStructuredQuery;
+
+		if (sizeof($aParams) == 1) return false;
+
+		$aOrderToFallback = array('postalcode', 'street', 'city', 'county', 'state');
+
+		foreach($aOrderToFallback as $sType)
+		{
+			if (isset($aParams[$sType]))
+			{
+				unset($aParams[$sType]);
 				$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
-				$this->setReverseInPlan(false);
-			}
-			else
-			{
-				$this->setQuery($sQuery);
+				return true;
 			}
 		}
 
-		function loadStructuredAddressElement($sValue, $sKey, $iNewMinAddressRank, $iNewMaxAddressRank, $aItemListValues)
+		return false;
+	}
+
+	function getDetails($aPlaceIDs)
+	{
+		//$aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
+		if (sizeof($aPlaceIDs) == 0)  return array();
+
+		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
+
+		// Get the details for display (is this a redundant extra step?)
+		$sPlaceIDs = join(',', array_keys($aPlaceIDs));
+
+		$sImportanceSQL = '';
+		if ($this->sViewboxSmallSQL) $sImportanceSQL .= " case when ST_Contains($this->sViewboxSmallSQL, ST_Collect(centroid)) THEN 1 ELSE 0.75 END * ";
+		if ($this->sViewboxLargeSQL) $sImportanceSQL .= " case when ST_Contains($this->sViewboxLargeSQL, ST_Collect(centroid)) THEN 1 ELSE 0.75 END * ";
+
+		$sSQL = "select osm_type,osm_id,class,type,admin_level,rank_search,rank_address,min(place_id) as place_id, min(parent_place_id) as parent_place_id, calculated_country_code as country_code,";
+		$sSQL .= "get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
+		$sSQL .= "get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
+		$sSQL .= "get_name_by_language(name, ARRAY['ref']) as ref,";
+		if ($this->bIncludeExtraTags) $sSQL .= "hstore_to_json(extratags)::text as extra,";
+		if ($this->bIncludeNameDetails) $sSQL .= "hstore_to_json(name)::text as names,";
+		$sSQL .= "avg(ST_X(centroid)) as lon,avg(ST_Y(centroid)) as lat, ";
+		$sSQL .= $sImportanceSQL."coalesce(importance,0.75-(rank_search::float/40)) as importance, ";
+		$sSQL .= "(select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance, ";
+		$sSQL .= "(extratags->'place') as extra_place ";
+		$sSQL .= "from placex where place_id in ($sPlaceIDs) ";
+		$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
+		if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
+		if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
+		$sSQL .= ") ";
+		if ($this->sAllowedTypesSQLList) $sSQL .= "and placex.class in $this->sAllowedTypesSQLList ";
+		$sSQL .= "and linked_place_id is null ";
+		$sSQL .= "group by osm_type,osm_id,class,type,admin_level,rank_search,rank_address,calculated_country_code,importance";
+		if (!$this->bDeDupe) $sSQL .= ",place_id";
+		$sSQL .= ",langaddress ";
+		$sSQL .= ",placename ";
+		$sSQL .= ",ref ";
+		if ($this->bIncludeExtraTags) $sSQL .= ",extratags";
+		if ($this->bIncludeNameDetails) $sSQL .= ",name";
+		$sSQL .= ",extratags->'place' ";
+
+		if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank)
 		{
-			$sValue = trim($sValue);
-			if (!$sValue) return false;
-			$this->aStructuredQuery[$sKey] = $sValue;
-			if ($this->iMinAddressRank == 0 && $this->iMaxAddressRank == 30)
+			//only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines 
+			// with start- and endnumber, the common osm housenumbers are usually saved as points
+			$sHousenumbers = "";
+			$i = 0;
+			$length = count($aPlaceIDs);
+			foreach($aPlaceIDs as $placeID => $housenumber)
 			{
-				$this->iMinAddressRank = $iNewMinAddressRank;
-				$this->iMaxAddressRank = $iNewMaxAddressRank;
+				$i++;
+				$sHousenumbers .= "(".$placeID.", ".$housenumber.")";
+				if($i<$length)
+					$sHousenumbers .= ", ";
 			}
-			if ($aItemListValues) $this->aAddressRankList = array_merge($this->aAddressRankList, $aItemListValues);
-			return true;
-		}
-
-		function setStructuredQuery($sAmentiy = false, $sStreet = false, $sCity = false, $sCounty = false, $sState = false, $sCountry = false, $sPostalCode = false)
-		{
-			$this->sQuery = false;
-
-			// Reset
-			$this->iMinAddressRank = 0;
-			$this->iMaxAddressRank = 30;
-			$this->aAddressRankList = array();
-
-			$this->aStructuredQuery = array();
-			$this->sAllowedTypesSQLList = '';
-
-			$this->loadStructuredAddressElement($sAmentiy, 'amenity', 26, 30, false);
-			$this->loadStructuredAddressElement($sStreet, 'street', 26, 30, false);
-			$this->loadStructuredAddressElement($sCity, 'city', 14, 24, false);
-			$this->loadStructuredAddressElement($sCounty, 'county', 9, 13, false);
-			$this->loadStructuredAddressElement($sState, 'state', 8, 8, false);
-			$this->loadStructuredAddressElement($sPostalCode, 'postalcode' , 5, 11, array(5, 11));
-			$this->loadStructuredAddressElement($sCountry, 'country', 4, 4, false);
-
-			if (sizeof($this->aStructuredQuery) > 0)
+			if (CONST_Use_US_Tiger_Data)
 			{
-				$this->sQuery = join(', ', $this->aStructuredQuery);
-				if ($this->iMaxAddressRank < 30)
-				{
-					$sAllowedTypesSQLList = '(\'place\',\'boundary\')';
-				}
+				//Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
+				$sSQL .= " union";
+				$sSQL .= " select 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code";
+				$sSQL .= ", get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress ";
+				$sSQL .= ", null as placename";
+				$sSQL .= ", null as ref";
+				if ($this->bIncludeExtraTags) $sSQL .= ", null as extra";
+				if ($this->bIncludeNameDetails) $sSQL .= ", null as names";
+				$sSQL .= ", avg(st_x(centroid)) as lon, avg(st_y(centroid)) as lat,";
+				$sSQL .= $sImportanceSQL."-1.15 as importance ";
+				$sSQL .= ", (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance ";
+				$sSQL .= ", null as extra_place ";
+				$sSQL .= " from (select place_id";
+				//interpolate the Tiger housenumbers here
+				$sSQL .= ", ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) as centroid, parent_place_id, housenumber_for_place";
+				$sSQL .= " from (location_property_tiger ";
+				$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
+				$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
+				$sSQL .= " group by place_id, housenumber_for_place"; //is this group by really needed?, place_id + housenumber (in combination) are unique
+				if (!$this->bDeDupe) $sSQL .= ", place_id ";
 			}
-		}
+			// osmline
+			// interpolation line search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
+			$sSQL .= " union ";
+			$sSQL .= "select 'W' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, calculated_country_code as country_code, ";
+			$sSQL .= "get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress, ";
+			$sSQL .= "null as placename, ";
+			$sSQL .= "null as ref, ";
+			if ($this->bIncludeExtraTags) $sSQL .= "null as extra, ";
+			if ($this->bIncludeNameDetails) $sSQL .= "null as names, ";
+			$sSQL .= " avg(st_x(centroid)) as lon, avg(st_y(centroid)) as lat,";
+			$sSQL .= $sImportanceSQL."-0.1 as importance, ";  // slightly smaller than the importance for normal houses with rank 30, which is 0
+			$sSQL .= " (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p";
+			$sSQL .= " where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance,";
+			$sSQL .= " null as extra_place ";
+			$sSQL .= " from (select place_id, calculated_country_code ";
+			//interpolate the housenumbers here
+			$sSQL .= ", CASE WHEN startnumber != endnumber THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
+			$sSQL .= " ELSE ST_LineInterpolatePoint(linegeo, 0.5) END as centroid";
+			$sSQL .= ", parent_place_id, housenumber_for_place ";
+			$sSQL .= " from (location_property_osmline ";
+			$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
+			$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
+			$sSQL .= " group by place_id, housenumber_for_place, calculated_country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
+			if (!$this->bDeDupe) $sSQL .= ", place_id ";
 
-		function fallbackStructuredQuery()
-		{
-			if (!$this->aStructuredQuery) return false;
-
-			$aParams = $this->aStructuredQuery;
-
-			if (sizeof($aParams) == 1) return false;
-
-			$aOrderToFallback = array('postalcode', 'street', 'city', 'county', 'state');
-
-			foreach($aOrderToFallback as $sType)
+			if (CONST_Use_Aux_Location_data)
 			{
-				if (isset($aParams[$sType]))
-				{
-					unset($aParams[$sType]);
-					$this->setStructuredQuery(@$aParams['amenity'], @$aParams['street'], @$aParams['city'], @$aParams['county'], @$aParams['state'], @$aParams['country'], @$aParams['postalcode']);
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		function getDetails($aPlaceIDs)
-		{
-			//$aPlaceIDs is an array with key: placeID and value: tiger-housenumber, if found, else -1
-			if (sizeof($aPlaceIDs) == 0)  return array();
-
-			$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
-
-			// Get the details for display (is this a redundant extra step?)
-			$sPlaceIDs = join(',', array_keys($aPlaceIDs));
-
-			$sImportanceSQL = '';
-			if ($this->sViewboxSmallSQL) $sImportanceSQL .= " case when ST_Contains($this->sViewboxSmallSQL, ST_Collect(centroid)) THEN 1 ELSE 0.75 END * ";
-			if ($this->sViewboxLargeSQL) $sImportanceSQL .= " case when ST_Contains($this->sViewboxLargeSQL, ST_Collect(centroid)) THEN 1 ELSE 0.75 END * ";
-
-			$sSQL = "select osm_type,osm_id,class,type,admin_level,rank_search,rank_address,min(place_id) as place_id, min(parent_place_id) as parent_place_id, calculated_country_code as country_code,";
-			$sSQL .= "get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
-			$sSQL .= "get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
-			$sSQL .= "get_name_by_language(name, ARRAY['ref']) as ref,";
-			if ($this->bIncludeExtraTags) $sSQL .= "hstore_to_json(extratags)::text as extra,";
-			if ($this->bIncludeNameDetails) $sSQL .= "hstore_to_json(name)::text as names,";
-			$sSQL .= "avg(ST_X(centroid)) as lon,avg(ST_Y(centroid)) as lat, ";
-			$sSQL .= $sImportanceSQL."coalesce(importance,0.75-(rank_search::float/40)) as importance, ";
-			$sSQL .= "(select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(CASE WHEN placex.rank_search < 28 THEN placex.place_id ELSE placex.parent_place_id END) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance, ";
-			$sSQL .= "(extratags->'place') as extra_place ";
-			$sSQL .= "from placex where place_id in ($sPlaceIDs) ";
-			$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-			if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
-			if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
-			$sSQL .= ") ";
-			if ($this->sAllowedTypesSQLList) $sSQL .= "and placex.class in $this->sAllowedTypesSQLList ";
-			$sSQL .= "and linked_place_id is null ";
-			$sSQL .= "group by osm_type,osm_id,class,type,admin_level,rank_search,rank_address,calculated_country_code,importance";
-			if (!$this->bDeDupe) $sSQL .= ",place_id";
-			$sSQL .= ",langaddress ";
-			$sSQL .= ",placename ";
-			$sSQL .= ",ref ";
-			if ($this->bIncludeExtraTags) $sSQL .= ",extratags";
-			if ($this->bIncludeNameDetails) $sSQL .= ",name";
-			$sSQL .= ",extratags->'place' ";
-
-			if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank)
-			{
-				//only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines 
-				// with start- and endnumber, the common osm housenumbers are usually saved as points
-				$sHousenumbers = "";
-				$i = 0;
-				$length = count($aPlaceIDs);
-				foreach($aPlaceIDs as $placeID => $housenumber)
-				{
-					$i++;
-					$sHousenumbers .= "(".$placeID.", ".$housenumber.")";
-					if($i<$length)
-						$sHousenumbers .= ", ";
-				}
-				if (CONST_Use_US_Tiger_Data)
-				{
-					//Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
-					$sSQL .= " union";
-					$sSQL .= " select 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code";
-					$sSQL .= ", get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress ";
-					$sSQL .= ", null as placename";
-					$sSQL .= ", null as ref";
-					if ($this->bIncludeExtraTags) $sSQL .= ", null as extra";
-					if ($this->bIncludeNameDetails) $sSQL .= ", null as names";
-					$sSQL .= ", avg(st_x(centroid)) as lon, avg(st_y(centroid)) as lat,";
-					$sSQL .= $sImportanceSQL."-1.15 as importance ";
-					$sSQL .= ", (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance ";
-					$sSQL .= ", null as extra_place ";
-					$sSQL .= " from (select place_id";
-					//interpolate the Tiger housenumbers here
-					$sSQL .= ", ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) as centroid, parent_place_id, housenumber_for_place";
-					$sSQL .= " from (location_property_tiger ";
-					$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
-					$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
-					$sSQL .= " group by place_id, housenumber_for_place"; //is this group by really needed?, place_id + housenumber (in combination) are unique
-					if (!$this->bDeDupe) $sSQL .= ", place_id ";
-				}
-				// osmline
-				// interpolation line search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
 				$sSQL .= " union ";
-				$sSQL .= "select 'W' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, calculated_country_code as country_code, ";
-				$sSQL .= "get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress, ";
+				$sSQL .= "select 'L' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 0 as rank_search, 0 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code, ";
+				$sSQL .= "get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress, ";
 				$sSQL .= "null as placename, ";
 				$sSQL .= "null as ref, ";
 				if ($this->bIncludeExtraTags) $sSQL .= "null as extra, ";
 				if ($this->bIncludeNameDetails) $sSQL .= "null as names, ";
-				$sSQL .= " avg(st_x(centroid)) as lon, avg(st_y(centroid)) as lat,";
-				$sSQL .= $sImportanceSQL."-0.1 as importance, ";  // slightly smaller than the importance for normal houses with rank 30, which is 0
-				$sSQL .= " (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p";
-				$sSQL .= " where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance,";
-				$sSQL .= " null as extra_place ";
-				$sSQL .= " from (select place_id, calculated_country_code ";
-				//interpolate the housenumbers here
-				$sSQL .= ", CASE WHEN startnumber != endnumber THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
-				$sSQL .= " ELSE ST_LineInterpolatePoint(linegeo, 0.5) END as centroid";
-				$sSQL .= ", parent_place_id, housenumber_for_place ";
-				$sSQL .= " from (location_property_osmline ";
-				$sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
-				$sSQL .= " where housenumber_for_place>=0 and 30 between $this->iMinAddressRank and $this->iMaxAddressRank) as blub"; //postgres wants an alias here
-				$sSQL .= " group by place_id, housenumber_for_place, calculated_country_code "; //is this group by really needed?, place_id + housenumber (in combination) are unique
-				if (!$this->bDeDupe) $sSQL .= ", place_id ";
-
-				if (CONST_Use_Aux_Location_data)
-				{
-					$sSQL .= " union ";
-					$sSQL .= "select 'L' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 0 as rank_search, 0 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code, ";
-					$sSQL .= "get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress, ";
-					$sSQL .= "null as placename, ";
-					$sSQL .= "null as ref, ";
-					if ($this->bIncludeExtraTags) $sSQL .= "null as extra, ";
-					if ($this->bIncludeNameDetails) $sSQL .= "null as names, ";
-					$sSQL .= "avg(ST_X(centroid)) as lon, avg(ST_Y(centroid)) as lat, ";
-					$sSQL .= $sImportanceSQL."-1.10 as importance, ";
-					$sSQL .= "(select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(location_property_aux.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance, ";
-					$sSQL .= "null as extra_place ";
-					$sSQL .= "from location_property_aux where place_id in ($sPlaceIDs) ";
-					$sSQL .= "and 30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
-					$sSQL .= "group by place_id";
-					if (!$this->bDeDupe) $sSQL .= ", place_id";
-					$sSQL .= ", get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) ";
-				}
+				$sSQL .= "avg(ST_X(centroid)) as lon, avg(ST_Y(centroid)) as lat, ";
+				$sSQL .= $sImportanceSQL."-1.10 as importance, ";
+				$sSQL .= "(select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(location_property_aux.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance, ";
+				$sSQL .= "null as extra_place ";
+				$sSQL .= "from location_property_aux where place_id in ($sPlaceIDs) ";
+				$sSQL .= "and 30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
+				$sSQL .= "group by place_id";
+				if (!$this->bDeDupe) $sSQL .= ", place_id";
+				$sSQL .= ", get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) ";
 			}
-
-			$sSQL .= " order by importance desc";
-			if (CONST_Debug) { echo "<hr>"; var_dump($sSQL); }
-			$aSearchResults = chksql($this->oDB->getAll($sSQL),
-			                         "Could not get details for place.");
-
-			return $aSearchResults;
 		}
 
-		function getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases)
+		$sSQL .= " order by importance desc";
+		if (CONST_Debug) { echo "<hr>"; var_dump($sSQL); }
+		$aSearchResults = chksql($this->oDB->getAll($sSQL),
+		                         "Could not get details for place.");
+
+		return $aSearchResults;
+	}
+
+	function getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases)
+	{
+		/*
+			 Calculate all searches using aValidTokens i.e.
+			 'Wodsworth Road, Sheffield' =>
+
+			 Phrase Wordset
+			 0      0       (wodsworth road)
+			 0      1       (wodsworth)(road)
+			 1      0       (sheffield)
+
+			 Score how good the search is so they can be ordered
+		 */
+		foreach($aPhrases as $iPhrase => $sPhrase)
 		{
-			/*
-				 Calculate all searches using aValidTokens i.e.
-				 'Wodsworth Road, Sheffield' =>
+			$aNewPhraseSearches = array();
+			if ($bStructuredPhrases) $sPhraseType = $aPhraseTypes[$iPhrase];
+			else $sPhraseType = '';
 
-				 Phrase Wordset
-				 0      0       (wodsworth road)
-				 0      1       (wodsworth)(road)
-				 1      0       (sheffield)
-
-				 Score how good the search is so they can be ordered
-			 */
-			foreach($aPhrases as $iPhrase => $sPhrase)
+			foreach($aPhrases[$iPhrase]['wordsets'] as $iWordSet => $aWordset)
 			{
-				$aNewPhraseSearches = array();
-				if ($bStructuredPhrases) $sPhraseType = $aPhraseTypes[$iPhrase];
-				else $sPhraseType = '';
+				// Too many permutations - too expensive
+				if ($iWordSet > 120) break;
 
-				foreach($aPhrases[$iPhrase]['wordsets'] as $iWordSet => $aWordset)
+				$aWordsetSearches = $aSearches;
+
+				// Add all words from this wordset
+				foreach($aWordset as $iToken => $sToken)
 				{
-					// Too many permutations - too expensive
-					if ($iWordSet > 120) break;
+					//echo "<br><b>$sToken</b>";
+					$aNewWordsetSearches = array();
 
-					$aWordsetSearches = $aSearches;
-
-					// Add all words from this wordset
-					foreach($aWordset as $iToken => $sToken)
+					foreach($aWordsetSearches as $aCurrentSearch)
 					{
-						//echo "<br><b>$sToken</b>";
-						$aNewWordsetSearches = array();
+						//echo "<i>";
+						//var_dump($aCurrentSearch);
+						//echo "</i>";
 
-						foreach($aWordsetSearches as $aCurrentSearch)
+						// If the token is valid
+						if (isset($aValidTokens[' '.$sToken]))
 						{
-							//echo "<i>";
-							//var_dump($aCurrentSearch);
-							//echo "</i>";
-
-							// If the token is valid
-							if (isset($aValidTokens[' '.$sToken]))
+							foreach($aValidTokens[' '.$sToken] as $aSearchTerm)
 							{
-								foreach($aValidTokens[' '.$sToken] as $aSearchTerm)
+								$aSearch = $aCurrentSearch;
+								$aSearch['iSearchRank']++;
+								if (($sPhraseType == '' || $sPhraseType == 'country') && !empty($aSearchTerm['country_code']) && $aSearchTerm['country_code'] != '0')
 								{
-									$aSearch = $aCurrentSearch;
-									$aSearch['iSearchRank']++;
-									if (($sPhraseType == '' || $sPhraseType == 'country') && !empty($aSearchTerm['country_code']) && $aSearchTerm['country_code'] != '0')
+									if ($aSearch['sCountryCode'] === false)
 									{
-										if ($aSearch['sCountryCode'] === false)
+										$aSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
+										// Country is almost always at the end of the string - increase score for finding it anywhere else (optimisation)
+										if (($iToken+1 != sizeof($aWordset) || $iPhrase+1 != sizeof($aPhrases)))
 										{
-											$aSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
-											// Country is almost always at the end of the string - increase score for finding it anywhere else (optimisation)
-											if (($iToken+1 != sizeof($aWordset) || $iPhrase+1 != sizeof($aPhrases)))
-											{
-												$aSearch['iSearchRank'] += 5;
-											}
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+											$aSearch['iSearchRank'] += 5;
 										}
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-									elseif (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null)
+								}
+								elseif (isset($aSearchTerm['lat']) && $aSearchTerm['lat'] !== '' && $aSearchTerm['lat'] !== null)
+								{
+									if ($aSearch['fLat'] === '')
 									{
-										if ($aSearch['fLat'] === '')
-										{
-											$aSearch['fLat'] = $aSearchTerm['lat'];
-											$aSearch['fLon'] = $aSearchTerm['lon'];
-											$aSearch['fRadius'] = $aSearchTerm['radius'];
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										}
+										$aSearch['fLat'] = $aSearchTerm['lat'];
+										$aSearch['fLon'] = $aSearchTerm['lon'];
+										$aSearch['fRadius'] = $aSearchTerm['radius'];
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
-									elseif ($sPhraseType == 'postalcode')
+								}
+								elseif ($sPhraseType == 'postalcode')
+								{
+									// We need to try the case where the postal code is the primary element (i.e. no way to tell if it is (postalcode, city) OR (city, postalcode) so try both
+									if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
 									{
-										// We need to try the case where the postal code is the primary element (i.e. no way to tell if it is (postalcode, city) OR (city, postalcode) so try both
-										if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
+										// If we already have a name try putting the postcode first
+										if (sizeof($aSearch['aName']))
 										{
-											// If we already have a name try putting the postcode first
-											if (sizeof($aSearch['aName']))
-											{
-												$aNewSearch = $aSearch;
-												$aNewSearch['aAddress'] = array_merge($aNewSearch['aAddress'], $aNewSearch['aName']);
-												$aNewSearch['aName'] = array();
-												$aNewSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aNewSearch;
-											}
-
-											if (sizeof($aSearch['aName']))
-											{
-												if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false))
-												{
-													$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												}
-												else
-												{
-													$aCurrentSearch['aFullNameAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-													$aSearch['iSearchRank'] += 1000; // skip;
-												}
-											}
-											else
-											{
-												$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												//$aSearch['iNamePhrase'] = $iPhrase;
-											}
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+											$aNewSearch = $aSearch;
+											$aNewSearch['aAddress'] = array_merge($aNewSearch['aAddress'], $aNewSearch['aName']);
+											$aNewSearch['aName'] = array();
+											$aNewSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aNewSearch;
 										}
 
-									}
-									elseif (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house')
-									{
-										if ($aSearch['sHouseNumber'] === '')
-										{
-											$aSearch['sHouseNumber'] = $sToken;
-											// sanity check: if the housenumber is not mainly made
-											// up of numbers, add a penalty
-											if (preg_match_all("/[^0-9]/", $sToken, $aMatches) > 2) $aSearch['iSearchRank']++;
-											// also housenumbers should appear in the first or second phrase
-											if ($iPhrase > 1) $aSearch['iSearchRank'] += 1;
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-											/*
-											// Fall back to not searching for this item (better than nothing)
-											$aSearch = $aCurrentSearch;
-											$aSearch['iSearchRank'] += 1;
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-											 */
-										}
-									}
-									elseif ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null)
-									{
-										if ($aSearch['sClass'] === '')
-										{
-											$aSearch['sOperator'] = $aSearchTerm['operator'];
-											$aSearch['sClass'] = $aSearchTerm['class'];
-											$aSearch['sType'] = $aSearchTerm['type'];
-											if (sizeof($aSearch['aName'])) $aSearch['sOperator'] = 'name';
-											else $aSearch['sOperator'] = 'near'; // near = in for the moment
-											if (strlen($aSearchTerm['operator']) == 0) $aSearch['iSearchRank'] += 1;
-
-											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-										}
-									}
-									elseif (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
-									{
 										if (sizeof($aSearch['aName']))
 										{
 											if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false))
@@ -628,100 +573,540 @@
 										}
 										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 									}
+
+								}
+								elseif (($sPhraseType == '' || $sPhraseType == 'street') && $aSearchTerm['class'] == 'place' && $aSearchTerm['type'] == 'house')
+								{
+									if ($aSearch['sHouseNumber'] === '')
+									{
+										$aSearch['sHouseNumber'] = $sToken;
+										// sanity check: if the housenumber is not mainly made
+										// up of numbers, add a penalty
+										if (preg_match_all("/[^0-9]/", $sToken, $aMatches) > 2) $aSearch['iSearchRank']++;
+										// also housenumbers should appear in the first or second phrase
+										if ($iPhrase > 1) $aSearch['iSearchRank'] += 1;
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+										/*
+										// Fall back to not searching for this item (better than nothing)
+										$aSearch = $aCurrentSearch;
+										$aSearch['iSearchRank'] += 1;
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+										 */
+									}
+								}
+								elseif ($sPhraseType == '' && $aSearchTerm['class'] !== '' && $aSearchTerm['class'] !== null)
+								{
+									if ($aSearch['sClass'] === '')
+									{
+										$aSearch['sOperator'] = $aSearchTerm['operator'];
+										$aSearch['sClass'] = $aSearchTerm['class'];
+										$aSearch['sType'] = $aSearchTerm['type'];
+										if (sizeof($aSearch['aName'])) $aSearch['sOperator'] = 'name';
+										else $aSearch['sOperator'] = 'near'; // near = in for the moment
+										if (strlen($aSearchTerm['operator']) == 0) $aSearch['iSearchRank'] += 1;
+
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+									}
+								}
+								elseif (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
+								{
+									if (sizeof($aSearch['aName']))
+									{
+										if ((!$bStructuredPhrases || $iPhrase > 0) && $sPhraseType != 'country' && (!isset($aValidTokens[$sToken]) || strpos($sToken, ' ') !== false))
+										{
+											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+										}
+										else
+										{
+											$aCurrentSearch['aFullNameAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+											$aSearch['iSearchRank'] += 1000; // skip;
+										}
+									}
+									else
+									{
+										$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+										//$aSearch['iNamePhrase'] = $iPhrase;
+									}
+									if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 								}
 							}
-							// Look for partial matches.
-							// Note that there is no point in adding country terms here
-							// because country are omitted in the address.
-							if (isset($aValidTokens[$sToken]) && $sPhraseType != 'country')
+						}
+						// Look for partial matches.
+						// Note that there is no point in adding country terms here
+						// because country are omitted in the address.
+						if (isset($aValidTokens[$sToken]) && $sPhraseType != 'country')
+						{
+							// Allow searching for a word - but at extra cost
+							foreach($aValidTokens[$sToken] as $aSearchTerm)
 							{
-								// Allow searching for a word - but at extra cost
-								foreach($aValidTokens[$sToken] as $aSearchTerm)
+								if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
 								{
-									if (isset($aSearchTerm['word_id']) && $aSearchTerm['word_id'])
+									if ((!$bStructuredPhrases || $iPhrase > 0) && sizeof($aCurrentSearch['aName']) && strpos($sToken, ' ') === false)
 									{
-										if ((!$bStructuredPhrases || $iPhrase > 0) && sizeof($aCurrentSearch['aName']) && strpos($sToken, ' ') === false)
+										$aSearch = $aCurrentSearch;
+										$aSearch['iSearchRank'] += 1;
+										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
 										{
-											$aSearch = $aCurrentSearch;
+											$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+										}
+										elseif (isset($aValidTokens[' '.$sToken])) // revert to the token version?
+										{
+											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											$aSearch['iSearchRank'] += 1;
-											if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
+											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+											foreach($aValidTokens[' '.$sToken] as $aSearchTermToken)
 											{
-												$aSearch['aAddress'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-											}
-											elseif (isset($aValidTokens[' '.$sToken])) // revert to the token version?
-											{
-												$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												$aSearch['iSearchRank'] += 1;
-												if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-												foreach($aValidTokens[' '.$sToken] as $aSearchTermToken)
+												if (empty($aSearchTermToken['country_code'])
+														&& empty($aSearchTermToken['lat'])
+														&& empty($aSearchTermToken['class']))
 												{
-													if (empty($aSearchTermToken['country_code'])
-															&& empty($aSearchTermToken['lat'])
-															&& empty($aSearchTermToken['class']))
-													{
-														$aSearch = $aCurrentSearch;
-														$aSearch['iSearchRank'] += 1;
-														$aSearch['aAddress'][$aSearchTermToken['word_id']] = $aSearchTermToken['word_id'];
-														if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-													}
+													$aSearch = $aCurrentSearch;
+													$aSearch['iSearchRank'] += 1;
+													$aSearch['aAddress'][$aSearchTermToken['word_id']] = $aSearchTermToken['word_id'];
+													if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 												}
 											}
-											else
-											{
-												$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-												if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
-												if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
-											}
 										}
-
-										if (!sizeof($aCurrentSearch['aName']) || $aCurrentSearch['iNamePhrase'] == $iPhrase)
+										else
 										{
-											$aSearch = $aCurrentSearch;
-											$aSearch['iSearchRank'] += 1;
-											if (!sizeof($aCurrentSearch['aName'])) $aSearch['iSearchRank'] += 1;
+											$aSearch['aAddressNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
 											if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
-											if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
-												$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-											else
-												$aSearch['aNameNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
-											$aSearch['iNamePhrase'] = $iPhrase;
 											if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
 										}
 									}
+
+									if (!sizeof($aCurrentSearch['aName']) || $aCurrentSearch['iNamePhrase'] == $iPhrase)
+									{
+										$aSearch = $aCurrentSearch;
+										$aSearch['iSearchRank'] += 1;
+										if (!sizeof($aCurrentSearch['aName'])) $aSearch['iSearchRank'] += 1;
+										if (preg_match('#^[0-9]+$#', $sToken)) $aSearch['iSearchRank'] += 2;
+										if ($aWordFrequencyScores[$aSearchTerm['word_id']] < CONST_Max_Word_Frequency)
+											$aSearch['aName'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+										else
+											$aSearch['aNameNonSearch'][$aSearchTerm['word_id']] = $aSearchTerm['word_id'];
+										$aSearch['iNamePhrase'] = $iPhrase;
+										if ($aSearch['iSearchRank'] < $this->iMaxRank) $aNewWordsetSearches[] = $aSearch;
+									}
 								}
 							}
-							else
-							{
-								// Allow skipping a word - but at EXTREAM cost
-								//$aSearch = $aCurrentSearch;
-								//$aSearch['iSearchRank']+=100;
-								//$aNewWordsetSearches[] = $aSearch;
-							}
 						}
-						// Sort and cut
-						usort($aNewWordsetSearches, 'bySearchRank');
-						$aWordsetSearches = array_slice($aNewWordsetSearches, 0, 50);
+						else
+						{
+							// Allow skipping a word - but at EXTREAM cost
+							//$aSearch = $aCurrentSearch;
+							//$aSearch['iSearchRank']+=100;
+							//$aNewWordsetSearches[] = $aSearch;
+						}
 					}
-					//var_Dump('<hr>',sizeof($aWordsetSearches)); exit;
+					// Sort and cut
+					usort($aNewWordsetSearches, 'bySearchRank');
+					$aWordsetSearches = array_slice($aNewWordsetSearches, 0, 50);
+				}
+				//var_Dump('<hr>',sizeof($aWordsetSearches)); exit;
 
-					$aNewPhraseSearches = array_merge($aNewPhraseSearches, $aNewWordsetSearches);
-					usort($aNewPhraseSearches, 'bySearchRank');
+				$aNewPhraseSearches = array_merge($aNewPhraseSearches, $aNewWordsetSearches);
+				usort($aNewPhraseSearches, 'bySearchRank');
 
-					$aSearchHash = array();
-					foreach($aNewPhraseSearches as $iSearch => $aSearch)
-					{
-						$sHash = serialize($aSearch);
-						if (isset($aSearchHash[$sHash])) unset($aNewPhraseSearches[$iSearch]);
-						else $aSearchHash[$sHash] = 1;
-					}
-
-					$aNewPhraseSearches = array_slice($aNewPhraseSearches, 0, 50);
+				$aSearchHash = array();
+				foreach($aNewPhraseSearches as $iSearch => $aSearch)
+				{
+					$sHash = serialize($aSearch);
+					if (isset($aSearchHash[$sHash])) unset($aNewPhraseSearches[$iSearch]);
+					else $aSearchHash[$sHash] = 1;
 				}
 
+				$aNewPhraseSearches = array_slice($aNewPhraseSearches, 0, 50);
+			}
+
+			// Re-group the searches by their score, junk anything over 20 as just not worth trying
+			$aGroupedSearches = array();
+			foreach($aNewPhraseSearches as $aSearch)
+			{
+				if ($aSearch['iSearchRank'] < $this->iMaxRank)
+				{
+					if (!isset($aGroupedSearches[$aSearch['iSearchRank']])) $aGroupedSearches[$aSearch['iSearchRank']] = array();
+					$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
+				}
+			}
+			ksort($aGroupedSearches);
+
+			$iSearchCount = 0;
+			$aSearches = array();
+			foreach($aGroupedSearches as $iScore => $aNewSearches)
+			{
+				$iSearchCount += sizeof($aNewSearches);
+				$aSearches = array_merge($aSearches, $aNewSearches);
+				if ($iSearchCount > 50) break;
+			}
+
+			//if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
+
+		}
+		return $aGroupedSearches;
+
+	}
+
+	/* Perform the actual query lookup.
+
+		Returns an ordered list of results, each with the following fields:
+			osm_type: type of corresponding OSM object
+						N - node
+						W - way
+						R - relation
+						P - postcode (internally computed)
+			osm_id: id of corresponding OSM object
+			class: general object class (corresponds to tag key of primary OSM tag)
+			type: subclass of object (corresponds to tag value of primary OSM tag)
+			admin_level: see http://wiki.openstreetmap.org/wiki/Admin_level
+			rank_search: rank in search hierarchy
+						(see also http://wiki.openstreetmap.org/wiki/Nominatim/Development_overview#Country_to_street_level)
+			rank_address: rank in address hierarchy (determines orer in address)
+			place_id: internal key (may differ between different instances)
+			country_code: ISO country code
+			langaddress: localized full address
+			placename: localized name of object
+			ref: content of ref tag (if available)
+			lon: longitude
+			lat: latitude
+			importance: importance of place based on Wikipedia link count
+			addressimportance: cumulated importance of address elements
+			extra_place: type of place (for admin boundaries, if there is a place tag)
+			aBoundingBox: bounding Box
+			label: short description of the object class/type (English only)
+			name: full name (currently the same as langaddress)
+			foundorder: secondary ordering for places with same importance
+	*/
+	function lookup()
+	{
+		if (!$this->sQuery && !$this->aStructuredQuery) return false;
+
+		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
+		$sCountryCodesSQL = false;
+		if ($this->aCountryCodes && sizeof($this->aCountryCodes))
+		{
+			$sCountryCodesSQL = join(',', array_map('addQuotes', $this->aCountryCodes));
+		}
+
+		$sQuery = $this->sQuery;
+
+		// Conflicts between US state abreviations and various words for 'the' in different languages
+		if (isset($this->aLangPrefOrder['name:en']))
+		{
+			$sQuery = preg_replace('/(^|,)\s*il\s*(,|$)/','\1illinois\2', $sQuery);
+			$sQuery = preg_replace('/(^|,)\s*al\s*(,|$)/','\1alabama\2', $sQuery);
+			$sQuery = preg_replace('/(^|,)\s*la\s*(,|$)/','\1louisiana\2', $sQuery);
+		}
+
+		// View Box SQL
+		$sViewboxCentreSQL = false;
+		$bBoundingBoxSearch = false;
+		if ($this->aViewBox)
+		{
+			$fHeight = $this->aViewBox[0]-$this->aViewBox[2];
+			$fWidth = $this->aViewBox[1]-$this->aViewBox[3];
+			$aBigViewBox[0] = $this->aViewBox[0] + $fHeight;
+			$aBigViewBox[2] = $this->aViewBox[2] - $fHeight;
+			$aBigViewBox[1] = $this->aViewBox[1] + $fWidth;
+			$aBigViewBox[3] = $this->aViewBox[3] - $fWidth;
+
+			$this->sViewboxSmallSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$this->aViewBox[0].",".(float)$this->aViewBox[1]."),ST_Point(".(float)$this->aViewBox[2].",".(float)$this->aViewBox[3].")),4326)";
+			$this->sViewboxLargeSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$aBigViewBox[0].",".(float)$aBigViewBox[1]."),ST_Point(".(float)$aBigViewBox[2].",".(float)$aBigViewBox[3].")),4326)";
+			$bBoundingBoxSearch = $this->bBoundedSearch;
+		}
+
+		// Route SQL
+		if ($this->aRoutePoints)
+		{
+			$sViewboxCentreSQL = "ST_SetSRID('LINESTRING(";
+			$bFirst = true;
+			foreach($this->aRoutePoints as $aPoint)
+			{
+				if (!$bFirst) $sViewboxCentreSQL .= ",";
+				$sViewboxCentreSQL .= $aPoint[0].' '.$aPoint[1];
+				$bFirst = false;
+			}
+			$sViewboxCentreSQL .= ")'::geometry,4326)";
+
+			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/69).")";
+			$this->sViewboxSmallSQL = chksql($this->oDB->getOne($sSQL),
+			                                 "Could not get small viewbox.");
+			$this->sViewboxSmallSQL = "'".$this->sViewboxSmallSQL."'::geometry";
+
+			$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/30).")";
+			$this->sViewboxLargeSQL = chksql($this->oDB->getOne($sSQL),
+			                                 "Could not get large viewbox.");
+			$this->sViewboxLargeSQL = "'".$this->sViewboxLargeSQL."'::geometry";
+			$bBoundingBoxSearch = $this->bBoundedSearch;
+		}
+
+		// Do we have anything that looks like a lat/lon pair?
+		if ( $aLooksLike = looksLikeLatLonPair($sQuery) )
+		{
+			$this->setNearPoint(array($aLooksLike['lat'], $aLooksLike['lon']));
+			$sQuery = $aLooksLike['query'];
+		}
+
+		$aSearchResults = array();
+		if ($sQuery || $this->aStructuredQuery)
+		{
+			// Start with a blank search
+			$aSearches = array(
+				array('iSearchRank' => 0,
+							'iNamePhrase' => -1,
+							'sCountryCode' => false,
+							'aName' => array(),
+							'aAddress' => array(),
+							'aFullNameAddress' => array(),
+							'aNameNonSearch' => array(),
+							'aAddressNonSearch' => array(),
+							'sOperator' => '',
+							'aFeatureName' => array(),
+							'sClass' => '',
+							'sType' => '',
+							'sHouseNumber' => '',
+							'fLat' => '',
+							'fLon' => '',
+							'fRadius' => ''
+						)
+			);
+
+			// Do we have a radius search?
+			$sNearPointSQL = false;
+			if ($this->aNearPoint)
+			{
+				$sNearPointSQL = "ST_SetSRID(ST_Point(".(float)$this->aNearPoint[1].",".(float)$this->aNearPoint[0]."),4326)";
+				$aSearches[0]['fLat'] = (float)$this->aNearPoint[0];
+				$aSearches[0]['fLon'] = (float)$this->aNearPoint[1];
+				$aSearches[0]['fRadius'] = (float)$this->aNearPoint[2];
+			}
+
+			// Any 'special' terms in the search?
+			$bSpecialTerms = false;
+			preg_match_all('/\\[(.*)=(.*)\\]/', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
+			$aSpecialTerms = array();
+			foreach($aSpecialTermsRaw as $aSpecialTerm)
+			{
+				$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
+				$aSpecialTerms[strtolower($aSpecialTerm[1])] = $aSpecialTerm[2];
+			}
+
+			preg_match_all('/\\[([\\w ]*)\\]/u', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
+			$aSpecialTerms = array();
+			if (isset($this->aStructuredQuery['amenity']) && $this->aStructuredQuery['amenity'])
+			{
+				$aSpecialTermsRaw[] = array('['.$this->aStructuredQuery['amenity'].']', $this->aStructuredQuery['amenity']);
+				unset($this->aStructuredQuery['amenity']);
+			}
+			foreach($aSpecialTermsRaw as $aSpecialTerm)
+			{
+				$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
+				$sToken = chksql($this->oDB->getOne("select make_standard_name('".$aSpecialTerm[1]."') as string"));
+				$sSQL = 'select * from (select word_id,word_token, word, class, type, country_code, operator';
+				$sSQL .= ' from word where word_token in (\' '.$sToken.'\')) as x where (class is not null and class not in (\'place\')) or country_code is not null';
+				if (CONST_Debug) var_Dump($sSQL);
+				$aSearchWords = chksql($this->oDB->getAll($sSQL));
+				$aNewSearches = array();
+				foreach($aSearches as $aSearch)
+				{
+					foreach($aSearchWords as $aSearchTerm)
+					{
+						$aNewSearch = $aSearch;
+						if ($aSearchTerm['country_code'])
+						{
+							$aNewSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
+							$aNewSearches[] = $aNewSearch;
+							$bSpecialTerms = true;
+						}
+						if ($aSearchTerm['class'])
+						{
+							$aNewSearch['sClass'] = $aSearchTerm['class'];
+							$aNewSearch['sType'] = $aSearchTerm['type'];
+							$aNewSearches[] = $aNewSearch;
+							$bSpecialTerms = true;
+						}
+					}
+				}
+				$aSearches = $aNewSearches;
+			}
+
+			// Split query into phrases
+			// Commas are used to reduce the search space by indicating where phrases split
+			if ($this->aStructuredQuery)
+			{
+				$aPhrases = $this->aStructuredQuery;
+				$bStructuredPhrases = true;
+			}
+			else
+			{
+				$aPhrases = explode(',',$sQuery);
+				$bStructuredPhrases = false;
+			}
+
+			// Convert each phrase to standard form
+			// Create a list of standard words
+			// Get all 'sets' of words
+			// Generate a complete list of all
+			$aTokens = array();
+			foreach($aPhrases as $iPhrase => $sPhrase)
+			{
+				$aPhrase = chksql($this->oDB->getRow("select make_standard_name('".pg_escape_string($sPhrase)."') as string"),
+				                  "Cannot nomralize query string (is it an UTF-8 string?)");
+				if (trim($aPhrase['string']))
+				{
+					$aPhrases[$iPhrase] = $aPhrase;
+					$aPhrases[$iPhrase]['words'] = explode(' ',$aPhrases[$iPhrase]['string']);
+					$aPhrases[$iPhrase]['wordsets'] = getWordSets($aPhrases[$iPhrase]['words'], 0);
+					$aTokens = array_merge($aTokens, getTokensFromSets($aPhrases[$iPhrase]['wordsets']));
+				}
+				else
+				{
+					unset($aPhrases[$iPhrase]);
+				}
+			}
+
+			// Reindex phrases - we make assumptions later on that they are numerically keyed in order
+			$aPhraseTypes = array_keys($aPhrases);
+			$aPhrases = array_values($aPhrases);
+
+			if (sizeof($aTokens))
+			{
+				// Check which tokens we have, get the ID numbers
+				$sSQL = 'select word_id,word_token, word, class, type, country_code, operator, search_name_count';
+				$sSQL .= ' from word where word_token in ('.join(',',array_map("getDBQuoted",$aTokens)).')';
+
+				if (CONST_Debug) var_Dump($sSQL);
+
+				$aValidTokens = array();
+				if (sizeof($aTokens))
+				{
+					$aDatabaseWords = chksql($this->oDB->getAll($sSQL),
+					                         "Could not get word tokens.");
+				}
+				else
+				{
+					$aDatabaseWords = array();
+				}
+				$aPossibleMainWordIDs = array();
+				$aWordFrequencyScores = array();
+				foreach($aDatabaseWords as $aToken)
+				{
+					// Very special case - require 2 letter country param to match the country code found
+					if ($bStructuredPhrases && $aToken['country_code'] && !empty($this->aStructuredQuery['country'])
+							&& strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code'])
+					{
+						continue;
+					}
+
+					if (isset($aValidTokens[$aToken['word_token']]))
+					{
+						$aValidTokens[$aToken['word_token']][] = $aToken;
+					}
+					else
+					{
+						$aValidTokens[$aToken['word_token']] = array($aToken);
+					}
+					if (!$aToken['class'] && !$aToken['country_code']) $aPossibleMainWordIDs[$aToken['word_id']] = 1;
+					$aWordFrequencyScores[$aToken['word_id']] = $aToken['search_name_count'] + 1;
+				}
+				if (CONST_Debug) var_Dump($aPhrases, $aValidTokens);
+
+				// Try and calculate GB postcodes we might be missing
+				foreach($aTokens as $sToken)
+				{
+					// Source of gb postcodes is now definitive - always use
+					if (preg_match('/^([A-Z][A-Z]?[0-9][0-9A-Z]? ?[0-9])([A-Z][A-Z])$/', strtoupper(trim($sToken)), $aData))
+					{
+						if (substr($aData[1],-2,1) != ' ')
+						{
+							$aData[0] = substr($aData[0],0,strlen($aData[1])-1).' '.substr($aData[0],strlen($aData[1])-1);
+							$aData[1] = substr($aData[1],0,-1).' '.substr($aData[1],-1,1);
+						}
+						$aGBPostcodeLocation = gbPostcodeCalculate($aData[0], $aData[1], $aData[2], $this->oDB);
+						if ($aGBPostcodeLocation)
+						{
+							$aValidTokens[$sToken] = $aGBPostcodeLocation;
+						}
+					}
+					// US ZIP+4 codes - if there is no token,
+					// 	merge in the 5-digit ZIP code
+					else if (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData))
+					{
+						if (isset($aValidTokens[$aData[1]]))
+						{
+							foreach($aValidTokens[$aData[1]] as $aToken)
+							{
+								if (!$aToken['class'])
+								{
+									if (isset($aValidTokens[$sToken]))
+									{
+										$aValidTokens[$sToken][] = $aToken;
+									}
+									else
+									{
+										$aValidTokens[$sToken] = array($aToken);
+									}
+								}
+							}
+						}
+					}
+				}
+
+				foreach($aTokens as $sToken)
+				{
+					// Unknown single word token with a number - assume it is a house number
+					if (!isset($aValidTokens[' '.$sToken]) && strpos($sToken,' ') === false && preg_match('/[0-9]/', $sToken))
+					{
+						$aValidTokens[' '.$sToken] = array(array('class'=>'place','type'=>'house'));
+					}
+				}
+
+				// Any words that have failed completely?
+				// TODO: suggestions
+
+				// Start the search process
+				// array with: placeid => -1 | tiger-housenumber
+				$aResultPlaceIDs = array();
+
+				$aGroupedSearches = $this->getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases);
+
+				if ($this->bReverseInPlan)
+				{
+					// Reverse phrase array and also reverse the order of the wordsets in
+					// the first and final phrase. Don't bother about phrases in the middle
+					// because order in the address doesn't matter.
+					$aPhrases = array_reverse($aPhrases);
+					$aPhrases[0]['wordsets'] = getInverseWordSets($aPhrases[0]['words'], 0);
+					if (sizeof($aPhrases) > 1)
+					{
+						$aFinalPhrase = end($aPhrases);
+						$aPhrases[sizeof($aPhrases)-1]['wordsets'] = getInverseWordSets($aFinalPhrase['words'], 0);
+					}
+					$aReverseGroupedSearches = $this->getGroupedSearches($aSearches, null, $aPhrases, $aValidTokens, $aWordFrequencyScores, false);
+
+					foreach($aGroupedSearches as $aSearches)
+					{
+						foreach($aSearches as $aSearch)
+						{
+							if ($aSearch['iSearchRank'] < $this->iMaxRank)
+							{
+								if (!isset($aReverseGroupedSearches[$aSearch['iSearchRank']])) $aReverseGroupedSearches[$aSearch['iSearchRank']] = array();
+								$aReverseGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
+							}
+
+						}
+					}
+
+					$aGroupedSearches = $aReverseGroupedSearches;
+					ksort($aGroupedSearches);
+				}
+			}
+			else
+			{
 				// Re-group the searches by their score, junk anything over 20 as just not worth trying
 				$aGroupedSearches = array();
-				foreach($aNewPhraseSearches as $aSearch)
+				foreach($aSearches as $aSearch)
 				{
 					if ($aSearch['iSearchRank'] < $this->iMaxRank)
 					{
@@ -730,1108 +1115,724 @@
 					}
 				}
 				ksort($aGroupedSearches);
-
-				$iSearchCount = 0;
-				$aSearches = array();
-				foreach($aGroupedSearches as $iScore => $aNewSearches)
-				{
-					$iSearchCount += sizeof($aNewSearches);
-					$aSearches = array_merge($aSearches, $aNewSearches);
-					if ($iSearchCount > 50) break;
-				}
-
-				//if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
-
-			}
-			return $aGroupedSearches;
-
-		}
-
-		/* Perform the actual query lookup.
-
-			Returns an ordered list of results, each with the following fields:
-				osm_type: type of corresponding OSM object
-							N - node
-							W - way
-							R - relation
-							P - postcode (internally computed)
-				osm_id: id of corresponding OSM object
-				class: general object class (corresponds to tag key of primary OSM tag)
-				type: subclass of object (corresponds to tag value of primary OSM tag)
-				admin_level: see http://wiki.openstreetmap.org/wiki/Admin_level
-				rank_search: rank in search hierarchy
-							(see also http://wiki.openstreetmap.org/wiki/Nominatim/Development_overview#Country_to_street_level)
-				rank_address: rank in address hierarchy (determines orer in address)
-				place_id: internal key (may differ between different instances)
-				country_code: ISO country code
-				langaddress: localized full address
-				placename: localized name of object
-				ref: content of ref tag (if available)
-				lon: longitude
-				lat: latitude
-				importance: importance of place based on Wikipedia link count
-				addressimportance: cumulated importance of address elements
-				extra_place: type of place (for admin boundaries, if there is a place tag)
-				aBoundingBox: bounding Box
-				label: short description of the object class/type (English only)
-				name: full name (currently the same as langaddress)
-				foundorder: secondary ordering for places with same importance
-		*/
-		function lookup()
-		{
-			if (!$this->sQuery && !$this->aStructuredQuery) return false;
-
-			$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$this->aLangPrefOrder))."]";
-			$sCountryCodesSQL = false;
-			if ($this->aCountryCodes && sizeof($this->aCountryCodes))
-			{
-				$sCountryCodesSQL = join(',', array_map('addQuotes', $this->aCountryCodes));
 			}
 
-			$sQuery = $this->sQuery;
+			if (CONST_Debug) var_Dump($aGroupedSearches);
 
-			// Conflicts between US state abreviations and various words for 'the' in different languages
-			if (isset($this->aLangPrefOrder['name:en']))
+			if (CONST_Search_TryDroppedAddressTerms && sizeof($this->aStructuredQuery) > 0)
 			{
-				$sQuery = preg_replace('/(^|,)\s*il\s*(,|$)/','\1illinois\2', $sQuery);
-				$sQuery = preg_replace('/(^|,)\s*al\s*(,|$)/','\1alabama\2', $sQuery);
-				$sQuery = preg_replace('/(^|,)\s*la\s*(,|$)/','\1louisiana\2', $sQuery);
-			}
-
-			// View Box SQL
-			$sViewboxCentreSQL = false;
-			$bBoundingBoxSearch = false;
-			if ($this->aViewBox)
-			{
-				$fHeight = $this->aViewBox[0]-$this->aViewBox[2];
-				$fWidth = $this->aViewBox[1]-$this->aViewBox[3];
-				$aBigViewBox[0] = $this->aViewBox[0] + $fHeight;
-				$aBigViewBox[2] = $this->aViewBox[2] - $fHeight;
-				$aBigViewBox[1] = $this->aViewBox[1] + $fWidth;
-				$aBigViewBox[3] = $this->aViewBox[3] - $fWidth;
-
-				$this->sViewboxSmallSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$this->aViewBox[0].",".(float)$this->aViewBox[1]."),ST_Point(".(float)$this->aViewBox[2].",".(float)$this->aViewBox[3].")),4326)";
-				$this->sViewboxLargeSQL = "ST_SetSRID(ST_MakeBox2D(ST_Point(".(float)$aBigViewBox[0].",".(float)$aBigViewBox[1]."),ST_Point(".(float)$aBigViewBox[2].",".(float)$aBigViewBox[3].")),4326)";
-				$bBoundingBoxSearch = $this->bBoundedSearch;
-			}
-
-			// Route SQL
-			if ($this->aRoutePoints)
-			{
-				$sViewboxCentreSQL = "ST_SetSRID('LINESTRING(";
-				$bFirst = true;
-				foreach($this->aRoutePoints as $aPoint)
-				{
-					if (!$bFirst) $sViewboxCentreSQL .= ",";
-					$sViewboxCentreSQL .= $aPoint[0].' '.$aPoint[1];
-					$bFirst = false;
-				}
-				$sViewboxCentreSQL .= ")'::geometry,4326)";
-
-				$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/69).")";
-				$this->sViewboxSmallSQL = chksql($this->oDB->getOne($sSQL),
-				                                 "Could not get small viewbox.");
-				$this->sViewboxSmallSQL = "'".$this->sViewboxSmallSQL."'::geometry";
-
-				$sSQL = "select st_buffer(".$sViewboxCentreSQL.",".(float)($_GET['routewidth']/30).")";
-				$this->sViewboxLargeSQL = chksql($this->oDB->getOne($sSQL),
-				                                 "Could not get large viewbox.");
-				$this->sViewboxLargeSQL = "'".$this->sViewboxLargeSQL."'::geometry";
-				$bBoundingBoxSearch = $this->bBoundedSearch;
-			}
-
-			// Do we have anything that looks like a lat/lon pair?
-			if ( $aLooksLike = looksLikeLatLonPair($sQuery) )
-			{
-				$this->setNearPoint(array($aLooksLike['lat'], $aLooksLike['lon']));
-				$sQuery = $aLooksLike['query'];
-			}
-
-			$aSearchResults = array();
-			if ($sQuery || $this->aStructuredQuery)
-			{
-				// Start with a blank search
-				$aSearches = array(
-					array('iSearchRank' => 0,
-								'iNamePhrase' => -1,
-								'sCountryCode' => false,
-								'aName' => array(),
-								'aAddress' => array(),
-								'aFullNameAddress' => array(),
-								'aNameNonSearch' => array(),
-								'aAddressNonSearch' => array(),
-								'sOperator' => '',
-								'aFeatureName' => array(),
-								'sClass' => '',
-								'sType' => '',
-								'sHouseNumber' => '',
-								'fLat' => '',
-								'fLon' => '',
-								'fRadius' => ''
-							)
-				);
-
-				// Do we have a radius search?
-				$sNearPointSQL = false;
-				if ($this->aNearPoint)
-				{
-					$sNearPointSQL = "ST_SetSRID(ST_Point(".(float)$this->aNearPoint[1].",".(float)$this->aNearPoint[0]."),4326)";
-					$aSearches[0]['fLat'] = (float)$this->aNearPoint[0];
-					$aSearches[0]['fLon'] = (float)$this->aNearPoint[1];
-					$aSearches[0]['fRadius'] = (float)$this->aNearPoint[2];
-				}
-
-				// Any 'special' terms in the search?
-				$bSpecialTerms = false;
-				preg_match_all('/\\[(.*)=(.*)\\]/', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
-				$aSpecialTerms = array();
-				foreach($aSpecialTermsRaw as $aSpecialTerm)
-				{
-					$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
-					$aSpecialTerms[strtolower($aSpecialTerm[1])] = $aSpecialTerm[2];
-				}
-
-				preg_match_all('/\\[([\\w ]*)\\]/u', $sQuery, $aSpecialTermsRaw, PREG_SET_ORDER);
-				$aSpecialTerms = array();
-				if (isset($this->aStructuredQuery['amenity']) && $this->aStructuredQuery['amenity'])
-				{
-					$aSpecialTermsRaw[] = array('['.$this->aStructuredQuery['amenity'].']', $this->aStructuredQuery['amenity']);
-					unset($this->aStructuredQuery['amenity']);
-				}
-				foreach($aSpecialTermsRaw as $aSpecialTerm)
-				{
-					$sQuery = str_replace($aSpecialTerm[0], ' ', $sQuery);
-					$sToken = chksql($this->oDB->getOne("select make_standard_name('".$aSpecialTerm[1]."') as string"));
-					$sSQL = 'select * from (select word_id,word_token, word, class, type, country_code, operator';
-					$sSQL .= ' from word where word_token in (\' '.$sToken.'\')) as x where (class is not null and class not in (\'place\')) or country_code is not null';
-					if (CONST_Debug) var_Dump($sSQL);
-					$aSearchWords = chksql($this->oDB->getAll($sSQL));
-					$aNewSearches = array();
-					foreach($aSearches as $aSearch)
-					{
-						foreach($aSearchWords as $aSearchTerm)
-						{
-							$aNewSearch = $aSearch;
-							if ($aSearchTerm['country_code'])
-							{
-								$aNewSearch['sCountryCode'] = strtolower($aSearchTerm['country_code']);
-								$aNewSearches[] = $aNewSearch;
-								$bSpecialTerms = true;
-							}
-							if ($aSearchTerm['class'])
-							{
-								$aNewSearch['sClass'] = $aSearchTerm['class'];
-								$aNewSearch['sType'] = $aSearchTerm['type'];
-								$aNewSearches[] = $aNewSearch;
-								$bSpecialTerms = true;
-							}
-						}
-					}
-					$aSearches = $aNewSearches;
-				}
-
-				// Split query into phrases
-				// Commas are used to reduce the search space by indicating where phrases split
-				if ($this->aStructuredQuery)
-				{
-					$aPhrases = $this->aStructuredQuery;
-					$bStructuredPhrases = true;
-				}
-				else
-				{
-					$aPhrases = explode(',',$sQuery);
-					$bStructuredPhrases = false;
-				}
-
-				// Convert each phrase to standard form
-				// Create a list of standard words
-				// Get all 'sets' of words
-				// Generate a complete list of all
-				$aTokens = array();
-				foreach($aPhrases as $iPhrase => $sPhrase)
-				{
-					$aPhrase = chksql($this->oDB->getRow("select make_standard_name('".pg_escape_string($sPhrase)."') as string"),
-					                  "Cannot nomralize query string (is it an UTF-8 string?)");
-					if (trim($aPhrase['string']))
-					{
-						$aPhrases[$iPhrase] = $aPhrase;
-						$aPhrases[$iPhrase]['words'] = explode(' ',$aPhrases[$iPhrase]['string']);
-						$aPhrases[$iPhrase]['wordsets'] = getWordSets($aPhrases[$iPhrase]['words'], 0);
-						$aTokens = array_merge($aTokens, getTokensFromSets($aPhrases[$iPhrase]['wordsets']));
-					}
-					else
-					{
-						unset($aPhrases[$iPhrase]);
-					}
-				}
-
-				// Reindex phrases - we make assumptions later on that they are numerically keyed in order
-				$aPhraseTypes = array_keys($aPhrases);
-				$aPhrases = array_values($aPhrases);
-
-				if (sizeof($aTokens))
-				{
-					// Check which tokens we have, get the ID numbers
-					$sSQL = 'select word_id,word_token, word, class, type, country_code, operator, search_name_count';
-					$sSQL .= ' from word where word_token in ('.join(',',array_map("getDBQuoted",$aTokens)).')';
-
-					if (CONST_Debug) var_Dump($sSQL);
-
-					$aValidTokens = array();
-					if (sizeof($aTokens))
-					{
-						$aDatabaseWords = chksql($this->oDB->getAll($sSQL),
-						                         "Could not get word tokens.");
-					}
-					else
-					{
-						$aDatabaseWords = array();
-					}
-					$aPossibleMainWordIDs = array();
-					$aWordFrequencyScores = array();
-					foreach($aDatabaseWords as $aToken)
-					{
-						// Very special case - require 2 letter country param to match the country code found
-						if ($bStructuredPhrases && $aToken['country_code'] && !empty($this->aStructuredQuery['country'])
-								&& strlen($this->aStructuredQuery['country']) == 2 && strtolower($this->aStructuredQuery['country']) != $aToken['country_code'])
-						{
-							continue;
-						}
-
-						if (isset($aValidTokens[$aToken['word_token']]))
-						{
-							$aValidTokens[$aToken['word_token']][] = $aToken;
-						}
-						else
-						{
-							$aValidTokens[$aToken['word_token']] = array($aToken);
-						}
-						if (!$aToken['class'] && !$aToken['country_code']) $aPossibleMainWordIDs[$aToken['word_id']] = 1;
-						$aWordFrequencyScores[$aToken['word_id']] = $aToken['search_name_count'] + 1;
-					}
-					if (CONST_Debug) var_Dump($aPhrases, $aValidTokens);
-
-					// Try and calculate GB postcodes we might be missing
-					foreach($aTokens as $sToken)
-					{
-						// Source of gb postcodes is now definitive - always use
-						if (preg_match('/^([A-Z][A-Z]?[0-9][0-9A-Z]? ?[0-9])([A-Z][A-Z])$/', strtoupper(trim($sToken)), $aData))
-						{
-							if (substr($aData[1],-2,1) != ' ')
-							{
-								$aData[0] = substr($aData[0],0,strlen($aData[1])-1).' '.substr($aData[0],strlen($aData[1])-1);
-								$aData[1] = substr($aData[1],0,-1).' '.substr($aData[1],-1,1);
-							}
-							$aGBPostcodeLocation = gbPostcodeCalculate($aData[0], $aData[1], $aData[2], $this->oDB);
-							if ($aGBPostcodeLocation)
-							{
-								$aValidTokens[$sToken] = $aGBPostcodeLocation;
-							}
-						}
-						// US ZIP+4 codes - if there is no token,
-						// 	merge in the 5-digit ZIP code
-						else if (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData))
-						{
-							if (isset($aValidTokens[$aData[1]]))
-							{
-								foreach($aValidTokens[$aData[1]] as $aToken)
-								{
-									if (!$aToken['class'])
-									{
-										if (isset($aValidTokens[$sToken]))
-										{
-											$aValidTokens[$sToken][] = $aToken;
-										}
-										else
-										{
-											$aValidTokens[$sToken] = array($aToken);
-										}
-									}
-								}
-							}
-						}
-					}
-
-					foreach($aTokens as $sToken)
-					{
-						// Unknown single word token with a number - assume it is a house number
-						if (!isset($aValidTokens[' '.$sToken]) && strpos($sToken,' ') === false && preg_match('/[0-9]/', $sToken))
-						{
-							$aValidTokens[' '.$sToken] = array(array('class'=>'place','type'=>'house'));
-						}
-					}
-
-					// Any words that have failed completely?
-					// TODO: suggestions
-
-					// Start the search process
-					// array with: placeid => -1 | tiger-housenumber
-					$aResultPlaceIDs = array();
-
-					$aGroupedSearches = $this->getGroupedSearches($aSearches, $aPhraseTypes, $aPhrases, $aValidTokens, $aWordFrequencyScores, $bStructuredPhrases);
-
-					if ($this->bReverseInPlan)
-					{
-						// Reverse phrase array and also reverse the order of the wordsets in
-						// the first and final phrase. Don't bother about phrases in the middle
-						// because order in the address doesn't matter.
-						$aPhrases = array_reverse($aPhrases);
-						$aPhrases[0]['wordsets'] = getInverseWordSets($aPhrases[0]['words'], 0);
-						if (sizeof($aPhrases) > 1)
-						{
-							$aFinalPhrase = end($aPhrases);
-							$aPhrases[sizeof($aPhrases)-1]['wordsets'] = getInverseWordSets($aFinalPhrase['words'], 0);
-						}
-						$aReverseGroupedSearches = $this->getGroupedSearches($aSearches, null, $aPhrases, $aValidTokens, $aWordFrequencyScores, false);
-
-						foreach($aGroupedSearches as $aSearches)
-						{
-							foreach($aSearches as $aSearch)
-							{
-								if ($aSearch['iSearchRank'] < $this->iMaxRank)
-								{
-									if (!isset($aReverseGroupedSearches[$aSearch['iSearchRank']])) $aReverseGroupedSearches[$aSearch['iSearchRank']] = array();
-									$aReverseGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
-								}
-
-							}
-						}
-
-						$aGroupedSearches = $aReverseGroupedSearches;
-						ksort($aGroupedSearches);
-					}
-				}
-				else
-				{
-					// Re-group the searches by their score, junk anything over 20 as just not worth trying
-					$aGroupedSearches = array();
-					foreach($aSearches as $aSearch)
-					{
-						if ($aSearch['iSearchRank'] < $this->iMaxRank)
-						{
-							if (!isset($aGroupedSearches[$aSearch['iSearchRank']])) $aGroupedSearches[$aSearch['iSearchRank']] = array();
-							$aGroupedSearches[$aSearch['iSearchRank']][] = $aSearch;
-						}
-					}
-					ksort($aGroupedSearches);
-				}
-
-				if (CONST_Debug) var_Dump($aGroupedSearches);
-
-				if (CONST_Search_TryDroppedAddressTerms && sizeof($this->aStructuredQuery) > 0)
-				{
-					$aCopyGroupedSearches = $aGroupedSearches;
-					foreach($aCopyGroupedSearches as $iGroup => $aSearches)
-					{
-						foreach($aSearches as $iSearch => $aSearch)
-						{
-							$aReductionsList = array($aSearch['aAddress']);
-							$iSearchRank = $aSearch['iSearchRank'];
-							while(sizeof($aReductionsList) > 0)
-							{
-								$iSearchRank += 5;
-								if ($iSearchRank > iMaxRank) break 3;
-								$aNewReductionsList = array();
-								foreach($aReductionsList as $aReductionsWordList)
-								{
-									for ($iReductionWord = 0; $iReductionWord < sizeof($aReductionsWordList); $iReductionWord++)
-									{
-										$aReductionsWordListResult = array_merge(array_slice($aReductionsWordList, 0, $iReductionWord), array_slice($aReductionsWordList, $iReductionWord+1));
-										$aReverseSearch = $aSearch;
-										$aSearch['aAddress'] = $aReductionsWordListResult;
-										$aSearch['iSearchRank'] = $iSearchRank;
-										$aGroupedSearches[$iSearchRank][] = $aReverseSearch;
-										if (sizeof($aReductionsWordListResult) > 0)
-										{
-											$aNewReductionsList[] = $aReductionsWordListResult;
-										}
-									}
-								}
-								$aReductionsList = $aNewReductionsList;
-							}
-						}
-					}
-					ksort($aGroupedSearches);
-				}
-
-				// Filter out duplicate searches
-				$aSearchHash = array();
-				foreach($aGroupedSearches as $iGroup => $aSearches)
+				$aCopyGroupedSearches = $aGroupedSearches;
+				foreach($aCopyGroupedSearches as $iGroup => $aSearches)
 				{
 					foreach($aSearches as $iSearch => $aSearch)
 					{
-						$sHash = serialize($aSearch);
-						if (isset($aSearchHash[$sHash]))
+						$aReductionsList = array($aSearch['aAddress']);
+						$iSearchRank = $aSearch['iSearchRank'];
+						while(sizeof($aReductionsList) > 0)
 						{
-							unset($aGroupedSearches[$iGroup][$iSearch]);
-							if (sizeof($aGroupedSearches[$iGroup]) == 0) unset($aGroupedSearches[$iGroup]);
-						}
-						else
-						{
-							$aSearchHash[$sHash] = 1;
+							$iSearchRank += 5;
+							if ($iSearchRank > iMaxRank) break 3;
+							$aNewReductionsList = array();
+							foreach($aReductionsList as $aReductionsWordList)
+							{
+								for ($iReductionWord = 0; $iReductionWord < sizeof($aReductionsWordList); $iReductionWord++)
+								{
+									$aReductionsWordListResult = array_merge(array_slice($aReductionsWordList, 0, $iReductionWord), array_slice($aReductionsWordList, $iReductionWord+1));
+									$aReverseSearch = $aSearch;
+									$aSearch['aAddress'] = $aReductionsWordListResult;
+									$aSearch['iSearchRank'] = $iSearchRank;
+									$aGroupedSearches[$iSearchRank][] = $aReverseSearch;
+									if (sizeof($aReductionsWordListResult) > 0)
+									{
+										$aNewReductionsList[] = $aReductionsWordListResult;
+									}
+								}
+							}
+							$aReductionsList = $aNewReductionsList;
 						}
 					}
 				}
+				ksort($aGroupedSearches);
+			}
 
-				if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
-
-				$iGroupLoop = 0;
-				$iQueryLoop = 0;
-				foreach($aGroupedSearches as $iGroupedRank => $aSearches)
+			// Filter out duplicate searches
+			$aSearchHash = array();
+			foreach($aGroupedSearches as $iGroup => $aSearches)
+			{
+				foreach($aSearches as $iSearch => $aSearch)
 				{
-					$iGroupLoop++;
-					foreach($aSearches as $aSearch)
+					$sHash = serialize($aSearch);
+					if (isset($aSearchHash[$sHash]))
 					{
-						$iQueryLoop++;
-						$searchedHousenumber = -1;
+						unset($aGroupedSearches[$iGroup][$iSearch]);
+						if (sizeof($aGroupedSearches[$iGroup]) == 0) unset($aGroupedSearches[$iGroup]);
+					}
+					else
+					{
+						$aSearchHash[$sHash] = 1;
+					}
+				}
+			}
 
-						if (CONST_Debug) { echo "<hr><b>Search Loop, group $iGroupLoop, loop $iQueryLoop</b>"; }
-						if (CONST_Debug) _debugDumpGroupedSearches(array($iGroupedRank => array($aSearch)), $aValidTokens);
+			if (CONST_Debug) _debugDumpGroupedSearches($aGroupedSearches, $aValidTokens);
 
-						// No location term?
-						if (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['fLon'])
+			$iGroupLoop = 0;
+			$iQueryLoop = 0;
+			foreach($aGroupedSearches as $iGroupedRank => $aSearches)
+			{
+				$iGroupLoop++;
+				foreach($aSearches as $aSearch)
+				{
+					$iQueryLoop++;
+					$searchedHousenumber = -1;
+
+					if (CONST_Debug) { echo "<hr><b>Search Loop, group $iGroupLoop, loop $iQueryLoop</b>"; }
+					if (CONST_Debug) _debugDumpGroupedSearches(array($iGroupedRank => array($aSearch)), $aValidTokens);
+
+					// No location term?
+					if (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['fLon'])
+					{
+						if ($aSearch['sCountryCode'] && !$aSearch['sClass'] && !$aSearch['sHouseNumber'])
 						{
-							if ($aSearch['sCountryCode'] && !$aSearch['sClass'] && !$aSearch['sHouseNumber'])
+							// Just looking for a country by code - look it up
+							if (4 >= $this->iMinAddressRank && 4 <= $this->iMaxAddressRank)
 							{
-								// Just looking for a country by code - look it up
-								if (4 >= $this->iMinAddressRank && 4 <= $this->iMaxAddressRank)
-								{
-									$sSQL = "select place_id from placex where calculated_country_code='".$aSearch['sCountryCode']."' and rank_search = 4";
-									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-									if ($bBoundingBoxSearch)
-										$sSQL .= " and _st_intersects($this->sViewboxSmallSQL, geometry)";
-									$sSQL .= " order by st_area(geometry) desc limit 1";
-									if (CONST_Debug) var_dump($sSQL);
-									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-								}
-								else
-								{
-									$aPlaceIDs = array();
-								}
+								$sSQL = "select place_id from placex where calculated_country_code='".$aSearch['sCountryCode']."' and rank_search = 4";
+								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
+								if ($bBoundingBoxSearch)
+									$sSQL .= " and _st_intersects($this->sViewboxSmallSQL, geometry)";
+								$sSQL .= " order by st_area(geometry) desc limit 1";
+								if (CONST_Debug) var_dump($sSQL);
+								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							}
 							else
 							{
-								if (!$bBoundingBoxSearch && !$aSearch['fLon']) continue;
-								if (!$aSearch['sClass']) continue;
-								$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
-								if (chksql($this->oDB->getOne($sSQL)))
-								{
-									$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
-									if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
-									$sSQL .= " where st_contains($this->sViewboxSmallSQL, ct.centroid)";
-									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-									if (sizeof($this->aExcludePlaceIDs))
-									{
-										$sSQL .= " and place_id not in (".join(',',$this->aExcludePlaceIDs).")";
-									}
-									if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
-									$sSQL .= " limit $this->iLimit";
-									if (CONST_Debug) var_dump($sSQL);
-									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-
-									// If excluded place IDs are given, it is fair to assume that
-									// there have been results in the small box, so no further
-									// expansion in that case.
-									// Also don't expand if bounded results were requested.
-									if (!sizeof($aPlaceIDs) && !sizeof($this->aExcludePlaceIDs) && !$this->bBoundedSearch)
-									{
-										$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
-										if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
-										$sSQL .= " where st_contains($this->sViewboxLargeSQL, ct.centroid)";
-										if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-										if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
-										$sSQL .= " limit $this->iLimit";
-										if (CONST_Debug) var_dump($sSQL);
-										$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-									}
-								}
-								else
-								{
-									$sSQL = "select place_id from placex where class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
-									$sSQL .= " and st_contains($this->sViewboxSmallSQL, geometry) and linked_place_id is null";
-									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-									if ($sViewboxCentreSQL)	$sSQL .= " order by st_distance($sViewboxCentreSQL, centroid) asc";
-									$sSQL .= " limit $this->iLimit";
-									if (CONST_Debug) var_dump($sSQL);
-									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-								}
+								$aPlaceIDs = array();
 							}
-						}
-						// If a coordinate is given, the search must either
-						// be for a name or a special search. Ignore everythin else.
-						else if ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass'])
-						{
-							$aPlaceIDs = array();
 						}
 						else
 						{
-							$aPlaceIDs = array();
-
-							// First we need a position, either aName or fLat or both
-							$aTerms = array();
-							$aOrder = array();
-
-							if ($aSearch['sHouseNumber'] && sizeof($aSearch['aAddress']))
+							if (!$bBoundingBoxSearch && !$aSearch['fLon']) continue;
+							if (!$aSearch['sClass']) continue;
+							$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
+							if (chksql($this->oDB->getOne($sSQL)))
 							{
-								$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
-                                $aOrder[] = "";
-								$aOrder[0] = " (exists(select place_id from placex where parent_place_id = search_name.place_id";
-                                $aOrder[0] .= " and transliteration(housenumber) ~* E'".$sHouseNumberRegex."' limit 1) ";
-								// also housenumbers from interpolation lines table are needed
-								$aOrder[0] .= " or exists(select place_id from location_property_osmline where parent_place_id = search_name.place_id";
-                                $aOrder[0] .= " and ".intval($aSearch['sHouseNumber']).">=startnumber and ".intval($aSearch['sHouseNumber'])."<=endnumber limit 1))";
-								$aOrder[0] .= " desc";
-							}
-
-							// TODO: filter out the pointless search terms (2 letter name tokens and less)
-							// they might be right - but they are just too darned expensive to run
-							if (sizeof($aSearch['aName'])) $aTerms[] = "name_vector @> ARRAY[".join($aSearch['aName'],",")."]";
-							if (sizeof($aSearch['aNameNonSearch'])) $aTerms[] = "array_cat(name_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aNameNonSearch'],",")."]";
-							if (sizeof($aSearch['aAddress']) && $aSearch['aName'] != $aSearch['aAddress'])
-							{
-								// For infrequent name terms disable index usage for address
-								if (CONST_Search_NameOnlySearchFrequencyThreshold &&
-										sizeof($aSearch['aName']) == 1 &&
-										$aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold)
-								{
-									$aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join(array_merge($aSearch['aAddress'],$aSearch['aAddressNonSearch']),",")."]";
-								}
-								else
-								{
-									$aTerms[] = "nameaddress_vector @> ARRAY[".join($aSearch['aAddress'],",")."]";
-									if (sizeof($aSearch['aAddressNonSearch'])) $aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aAddressNonSearch'],",")."]";
-								}
-							}
-							if ($aSearch['sCountryCode']) $aTerms[] = "country_code = '".pg_escape_string($aSearch['sCountryCode'])."'";
-							if ($aSearch['sHouseNumber'])
-							{
-								$aTerms[] = "address_rank between 16 and 27";
-							}
-							else
-							{
-								if ($this->iMinAddressRank > 0)
-								{
-									$aTerms[] = "address_rank >= ".$this->iMinAddressRank;
-								}
-								if ($this->iMaxAddressRank < 30)
-								{
-									$aTerms[] = "address_rank <= ".$this->iMaxAddressRank;
-								}
-							}
-							if ($aSearch['fLon'] && $aSearch['fLat'])
-							{
-								$aTerms[] = "ST_DWithin(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326), ".$aSearch['fRadius'].")";
-								$aOrder[] = "ST_Distance(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326)) ASC";
-							}
-							if (sizeof($this->aExcludePlaceIDs))
-							{
-								$aTerms[] = "place_id not in (".join(',',$this->aExcludePlaceIDs).")";
-							}
-							if ($sCountryCodesSQL)
-							{
-								$aTerms[] = "country_code in ($sCountryCodesSQL)";
-							}
-
-							if ($bBoundingBoxSearch) $aTerms[] = "centroid && $this->sViewboxSmallSQL";
-							if ($sNearPointSQL) $aOrder[] = "ST_Distance($sNearPointSQL, centroid) asc";
-
-							if ($aSearch['sHouseNumber'])
-							{
-								$sImportanceSQL = '- abs(26 - address_rank) + 3';
-							}
-							else
-							{
-								$sImportanceSQL = '(case when importance = 0 OR importance IS NULL then 0.75-(search_rank::float/40) else importance end)';
-							}
-							if ($this->sViewboxSmallSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxSmallSQL, centroid) THEN 1 ELSE 0.5 END";
-							if ($this->sViewboxLargeSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxLargeSQL, centroid) THEN 1 ELSE 0.5 END";
-
-							$aOrder[] = "$sImportanceSQL DESC";
-							if (sizeof($aSearch['aFullNameAddress']))
-							{
-								$sExactMatchSQL = '(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s) as exactmatch';
-								$aOrder[] = 'exactmatch DESC';
-							} else {
-								$sExactMatchSQL = '0::int as exactmatch';
-							}
-
-							if (sizeof($aTerms))
-							{
-								$sSQL = "select place_id, ";
-								$sSQL .= $sExactMatchSQL;
-								$sSQL .= " from search_name";
-								$sSQL .= " where ".join(' and ',$aTerms);
-								$sSQL .= " order by ".join(', ',$aOrder);
-								if ($aSearch['sHouseNumber'] || $aSearch['sClass'])
-									$sSQL .= " limit 20";
-								elseif (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && $aSearch['sClass'])
-									$sSQL .= " limit 1";
-								else
-									$sSQL .= " limit ".$this->iLimit;
-
-								if (CONST_Debug) { var_dump($sSQL); }
-								$aViewBoxPlaceIDs = chksql($this->oDB->getAll($sSQL),
-								                           "Could not get places for search terms.");
-								//var_dump($aViewBoxPlaceIDs);
-								// Did we have an viewbox matches?
-								$aPlaceIDs = array();
-								$bViewBoxMatch = false;
-								foreach($aViewBoxPlaceIDs as $aViewBoxRow)
-								{
-									//if ($bViewBoxMatch == 1 && $aViewBoxRow['in_small'] == 'f') break;
-									//if ($bViewBoxMatch == 2 && $aViewBoxRow['in_large'] == 'f') break;
-									//if ($aViewBoxRow['in_small'] == 't') $bViewBoxMatch = 1;
-									//else if ($aViewBoxRow['in_large'] == 't') $bViewBoxMatch = 2;
-									$aPlaceIDs[] = $aViewBoxRow['place_id'];
-									$this->exactMatchCache[$aViewBoxRow['place_id']] = $aViewBoxRow['exactmatch'];
-								}
-							}
-							//var_Dump($aPlaceIDs);
-							//exit;
-
-							//now search for housenumber, if housenumber provided
-							if ($aSearch['sHouseNumber'] && sizeof($aPlaceIDs))
-							{
-								$searchedHousenumber = intval($aSearch['sHouseNumber']);
-								$aRoadPlaceIDs = $aPlaceIDs;
-								$sPlaceIDs = join(',',$aPlaceIDs);
-
-								// Now they are indexed, look for a house attached to a street we found
-								$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
-								$sSQL = "select place_id from placex where parent_place_id in (".$sPlaceIDs.") and transliteration(housenumber) ~* E'".$sHouseNumberRegex."'";
+								$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
+								if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
+								$sSQL .= " where st_contains($this->sViewboxSmallSQL, ct.centroid)";
+								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
 								if (sizeof($this->aExcludePlaceIDs))
 								{
 									$sSQL .= " and place_id not in (".join(',',$this->aExcludePlaceIDs).")";
 								}
+								if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
 								$sSQL .= " limit $this->iLimit";
 								if (CONST_Debug) var_dump($sSQL);
 								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-								
-								// if nothing found, search in the interpolation line table
-								if(!sizeof($aPlaceIDs))
-								{
-									// do we need to use transliteration and the regex for housenumbers???
-									//new query for lines, not housenumbers anymore
-									if($searchedHousenumber%2 == 0){
-										//if housenumber is even, look for housenumber in streets with interpolationtype even or all
-										$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-									}else{
-										//look for housenumber in streets with interpolationtype odd or all
-										$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-									}
 
-									if (sizeof($this->aExcludePlaceIDs))
-									{
-										$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
-									}
-									//$sSQL .= " limit $this->iLimit";
-									if (CONST_Debug) var_dump($sSQL);
-									//get place IDs
-									$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
-								}
-									
-								// If nothing found try the aux fallback table
-								if (CONST_Use_Aux_Location_data && !sizeof($aPlaceIDs))
+								// If excluded place IDs are given, it is fair to assume that
+								// there have been results in the small box, so no further
+								// expansion in that case.
+								// Also don't expand if bounded results were requested.
+								if (!sizeof($aPlaceIDs) && !sizeof($this->aExcludePlaceIDs) && !$this->bBoundedSearch)
 								{
-									$sSQL = "select place_id from location_property_aux where parent_place_id in (".$sPlaceIDs.") and housenumber = '".pg_escape_string($aSearch['sHouseNumber'])."'";
-									if (sizeof($this->aExcludePlaceIDs))
-									{
-										$sSQL .= " and parent_place_id not in (".join(',',$this->aExcludePlaceIDs).")";
-									}
-									//$sSQL .= " limit $this->iLimit";
+									$sSQL = "select place_id from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." ct";
+									if ($sCountryCodesSQL) $sSQL .= " join placex using (place_id)";
+									$sSQL .= " where st_contains($this->sViewboxLargeSQL, ct.centroid)";
+									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
+									if ($sViewboxCentreSQL) $sSQL .= " order by st_distance($sViewboxCentreSQL, ct.centroid) asc";
+									$sSQL .= " limit $this->iLimit";
 									if (CONST_Debug) var_dump($sSQL);
 									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 								}
+							}
+							else
+							{
+								$sSQL = "select place_id from placex where class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
+								$sSQL .= " and st_contains($this->sViewboxSmallSQL, geometry) and linked_place_id is null";
+								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
+								if ($sViewboxCentreSQL)	$sSQL .= " order by st_distance($sViewboxCentreSQL, centroid) asc";
+								$sSQL .= " limit $this->iLimit";
+								if (CONST_Debug) var_dump($sSQL);
+								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
+							}
+						}
+					}
+					// If a coordinate is given, the search must either
+					// be for a name or a special search. Ignore everythin else.
+					else if ($aSearch['fLon'] && !sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && !$aSearch['sClass'])
+					{
+						$aPlaceIDs = array();
+					}
+					else
+					{
+						$aPlaceIDs = array();
 
-								//if nothing was found in placex or location_property_aux, then search in Tiger data for this housenumber(location_property_tiger)
-								if (CONST_Use_US_Tiger_Data && !sizeof($aPlaceIDs))
-								{
-									//new query for lines, not housenumbers anymore
-									if($searchedHousenumber%2 == 0){
-										//if housenumber is even, look for housenumber in streets with interpolationtype even or all
-										$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-									}else{
-										//look for housenumber in streets with interpolationtype odd or all
-										$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
-									}
+						// First we need a position, either aName or fLat or both
+						$aTerms = array();
+						$aOrder = array();
 
-									if (sizeof($this->aExcludePlaceIDs))
-									{
-										$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
-									}
-									//$sSQL .= " limit $this->iLimit";
-									if (CONST_Debug) var_dump($sSQL);
-									//get place IDs
-									$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
+						if ($aSearch['sHouseNumber'] && sizeof($aSearch['aAddress']))
+						{
+							$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
+                                $aOrder[] = "";
+							$aOrder[0] = " (exists(select place_id from placex where parent_place_id = search_name.place_id";
+                                $aOrder[0] .= " and transliteration(housenumber) ~* E'".$sHouseNumberRegex."' limit 1) ";
+							// also housenumbers from interpolation lines table are needed
+							$aOrder[0] .= " or exists(select place_id from location_property_osmline where parent_place_id = search_name.place_id";
+                                $aOrder[0] .= " and ".intval($aSearch['sHouseNumber']).">=startnumber and ".intval($aSearch['sHouseNumber'])."<=endnumber limit 1))";
+							$aOrder[0] .= " desc";
+						}
+
+						// TODO: filter out the pointless search terms (2 letter name tokens and less)
+						// they might be right - but they are just too darned expensive to run
+						if (sizeof($aSearch['aName'])) $aTerms[] = "name_vector @> ARRAY[".join($aSearch['aName'],",")."]";
+						if (sizeof($aSearch['aNameNonSearch'])) $aTerms[] = "array_cat(name_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aNameNonSearch'],",")."]";
+						if (sizeof($aSearch['aAddress']) && $aSearch['aName'] != $aSearch['aAddress'])
+						{
+							// For infrequent name terms disable index usage for address
+							if (CONST_Search_NameOnlySearchFrequencyThreshold &&
+									sizeof($aSearch['aName']) == 1 &&
+									$aWordFrequencyScores[$aSearch['aName'][reset($aSearch['aName'])]] < CONST_Search_NameOnlySearchFrequencyThreshold)
+							{
+								$aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join(array_merge($aSearch['aAddress'],$aSearch['aAddressNonSearch']),",")."]";
+							}
+							else
+							{
+								$aTerms[] = "nameaddress_vector @> ARRAY[".join($aSearch['aAddress'],",")."]";
+								if (sizeof($aSearch['aAddressNonSearch'])) $aTerms[] = "array_cat(nameaddress_vector,ARRAY[]::integer[]) @> ARRAY[".join($aSearch['aAddressNonSearch'],",")."]";
+							}
+						}
+						if ($aSearch['sCountryCode']) $aTerms[] = "country_code = '".pg_escape_string($aSearch['sCountryCode'])."'";
+						if ($aSearch['sHouseNumber'])
+						{
+							$aTerms[] = "address_rank between 16 and 27";
+						}
+						else
+						{
+							if ($this->iMinAddressRank > 0)
+							{
+								$aTerms[] = "address_rank >= ".$this->iMinAddressRank;
+							}
+							if ($this->iMaxAddressRank < 30)
+							{
+								$aTerms[] = "address_rank <= ".$this->iMaxAddressRank;
+							}
+						}
+						if ($aSearch['fLon'] && $aSearch['fLat'])
+						{
+							$aTerms[] = "ST_DWithin(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326), ".$aSearch['fRadius'].")";
+							$aOrder[] = "ST_Distance(centroid, ST_SetSRID(ST_Point(".$aSearch['fLon'].",".$aSearch['fLat']."),4326)) ASC";
+						}
+						if (sizeof($this->aExcludePlaceIDs))
+						{
+							$aTerms[] = "place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+						}
+						if ($sCountryCodesSQL)
+						{
+							$aTerms[] = "country_code in ($sCountryCodesSQL)";
+						}
+
+						if ($bBoundingBoxSearch) $aTerms[] = "centroid && $this->sViewboxSmallSQL";
+						if ($sNearPointSQL) $aOrder[] = "ST_Distance($sNearPointSQL, centroid) asc";
+
+						if ($aSearch['sHouseNumber'])
+						{
+							$sImportanceSQL = '- abs(26 - address_rank) + 3';
+						}
+						else
+						{
+							$sImportanceSQL = '(case when importance = 0 OR importance IS NULL then 0.75-(search_rank::float/40) else importance end)';
+						}
+						if ($this->sViewboxSmallSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxSmallSQL, centroid) THEN 1 ELSE 0.5 END";
+						if ($this->sViewboxLargeSQL) $sImportanceSQL .= " * case when ST_Contains($this->sViewboxLargeSQL, centroid) THEN 1 ELSE 0.5 END";
+
+						$aOrder[] = "$sImportanceSQL DESC";
+						if (sizeof($aSearch['aFullNameAddress']))
+						{
+							$sExactMatchSQL = '(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s) as exactmatch';
+							$aOrder[] = 'exactmatch DESC';
+						} else {
+							$sExactMatchSQL = '0::int as exactmatch';
+						}
+
+						if (sizeof($aTerms))
+						{
+							$sSQL = "select place_id, ";
+							$sSQL .= $sExactMatchSQL;
+							$sSQL .= " from search_name";
+							$sSQL .= " where ".join(' and ',$aTerms);
+							$sSQL .= " order by ".join(', ',$aOrder);
+							if ($aSearch['sHouseNumber'] || $aSearch['sClass'])
+								$sSQL .= " limit 20";
+							elseif (!sizeof($aSearch['aName']) && !sizeof($aSearch['aAddress']) && $aSearch['sClass'])
+								$sSQL .= " limit 1";
+							else
+								$sSQL .= " limit ".$this->iLimit;
+
+							if (CONST_Debug) { var_dump($sSQL); }
+							$aViewBoxPlaceIDs = chksql($this->oDB->getAll($sSQL),
+							                           "Could not get places for search terms.");
+							//var_dump($aViewBoxPlaceIDs);
+							// Did we have an viewbox matches?
+							$aPlaceIDs = array();
+							$bViewBoxMatch = false;
+							foreach($aViewBoxPlaceIDs as $aViewBoxRow)
+							{
+								//if ($bViewBoxMatch == 1 && $aViewBoxRow['in_small'] == 'f') break;
+								//if ($bViewBoxMatch == 2 && $aViewBoxRow['in_large'] == 'f') break;
+								//if ($aViewBoxRow['in_small'] == 't') $bViewBoxMatch = 1;
+								//else if ($aViewBoxRow['in_large'] == 't') $bViewBoxMatch = 2;
+								$aPlaceIDs[] = $aViewBoxRow['place_id'];
+								$this->exactMatchCache[$aViewBoxRow['place_id']] = $aViewBoxRow['exactmatch'];
+							}
+						}
+						//var_Dump($aPlaceIDs);
+						//exit;
+
+						//now search for housenumber, if housenumber provided
+						if ($aSearch['sHouseNumber'] && sizeof($aPlaceIDs))
+						{
+							$searchedHousenumber = intval($aSearch['sHouseNumber']);
+							$aRoadPlaceIDs = $aPlaceIDs;
+							$sPlaceIDs = join(',',$aPlaceIDs);
+
+							// Now they are indexed, look for a house attached to a street we found
+							$sHouseNumberRegex = '\\\\m'.$aSearch['sHouseNumber'].'\\\\M';
+							$sSQL = "select place_id from placex where parent_place_id in (".$sPlaceIDs.") and transliteration(housenumber) ~* E'".$sHouseNumberRegex."'";
+							if (sizeof($this->aExcludePlaceIDs))
+							{
+								$sSQL .= " and place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+							}
+							$sSQL .= " limit $this->iLimit";
+							if (CONST_Debug) var_dump($sSQL);
+							$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
+							
+							// if nothing found, search in the interpolation line table
+							if(!sizeof($aPlaceIDs))
+							{
+								// do we need to use transliteration and the regex for housenumbers???
+								//new query for lines, not housenumbers anymore
+								if($searchedHousenumber%2 == 0){
+									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
+									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
+								}else{
+									//look for housenumber in streets with interpolationtype odd or all
+									$sSQL = "select distinct place_id from location_property_osmline where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
-								// Fallback to the road (if no housenumber was found)
-								if (!sizeof($aPlaceIDs) && preg_match('/[0-9]+/', $aSearch['sHouseNumber']))
+								if (sizeof($this->aExcludePlaceIDs))
 								{
-									$aPlaceIDs = $aRoadPlaceIDs;
-									//set to -1, if no housenumbers were found
-									$searchedHousenumber = -1;
+									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
 								}
-								//else: housenumber was found, remains saved in searchedHousenumber
+								//$sSQL .= " limit $this->iLimit";
+								if (CONST_Debug) var_dump($sSQL);
+								//get place IDs
+								$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
+							}
+								
+							// If nothing found try the aux fallback table
+							if (CONST_Use_Aux_Location_data && !sizeof($aPlaceIDs))
+							{
+								$sSQL = "select place_id from location_property_aux where parent_place_id in (".$sPlaceIDs.") and housenumber = '".pg_escape_string($aSearch['sHouseNumber'])."'";
+								if (sizeof($this->aExcludePlaceIDs))
+								{
+									$sSQL .= " and parent_place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+								}
+								//$sSQL .= " limit $this->iLimit";
+								if (CONST_Debug) var_dump($sSQL);
+								$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
 							}
 
-
-							if ($aSearch['sClass'] && sizeof($aPlaceIDs))
+							//if nothing was found in placex or location_property_aux, then search in Tiger data for this housenumber(location_property_tiger)
+							if (CONST_Use_US_Tiger_Data && !sizeof($aPlaceIDs))
 							{
-								$sPlaceIDs = join(',', $aPlaceIDs);
-								$aClassPlaceIDs = array();
-
-								if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'name')
-								{
-									// If they were searching for a named class (i.e. 'Kings Head pub') then we might have an extra match
-									$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
-									$sSQL .= " and linked_place_id is null";
-									if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
-									$sSQL .= " order by rank_search asc limit $this->iLimit";
-									if (CONST_Debug) var_dump($sSQL);
-									$aClassPlaceIDs = chksql($this->oDB->getCol($sSQL));
+								//new query for lines, not housenumbers anymore
+								if($searchedHousenumber%2 == 0){
+									//if housenumber is even, look for housenumber in streets with interpolationtype even or all
+									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='even' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
+								}else{
+									//look for housenumber in streets with interpolationtype odd or all
+									$sSQL = "select distinct place_id from location_property_tiger where parent_place_id in (".$sPlaceIDs.") and (interpolationtype='odd' or interpolationtype='all') and ".$searchedHousenumber.">=startnumber and ".$searchedHousenumber."<=endnumber";
 								}
 
-								if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'near') // & in
+								if (sizeof($this->aExcludePlaceIDs))
 								{
-									$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
-									$bCacheTable = chksql($this->oDB->getOne($sSQL));
+									$sSQL .= " and place_id not in (".join(',', $this->aExcludePlaceIDs).")";
+								}
+								//$sSQL .= " limit $this->iLimit";
+								if (CONST_Debug) var_dump($sSQL);
+								//get place IDs
+								$aPlaceIDs = chksql($this->oDB->getCol($sSQL, 0));
+							}
 
-									$sSQL = "select min(rank_search) from placex where place_id in ($sPlaceIDs)";
+							// Fallback to the road (if no housenumber was found)
+							if (!sizeof($aPlaceIDs) && preg_match('/[0-9]+/', $aSearch['sHouseNumber']))
+							{
+								$aPlaceIDs = $aRoadPlaceIDs;
+								//set to -1, if no housenumbers were found
+								$searchedHousenumber = -1;
+							}
+							//else: housenumber was found, remains saved in searchedHousenumber
+						}
 
+
+						if ($aSearch['sClass'] && sizeof($aPlaceIDs))
+						{
+							$sPlaceIDs = join(',', $aPlaceIDs);
+							$aClassPlaceIDs = array();
+
+							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'name')
+							{
+								// If they were searching for a named class (i.e. 'Kings Head pub') then we might have an extra match
+								$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and class='".$aSearch['sClass']."' and type='".$aSearch['sType']."'";
+								$sSQL .= " and linked_place_id is null";
+								if ($sCountryCodesSQL) $sSQL .= " and calculated_country_code in ($sCountryCodesSQL)";
+								$sSQL .= " order by rank_search asc limit $this->iLimit";
+								if (CONST_Debug) var_dump($sSQL);
+								$aClassPlaceIDs = chksql($this->oDB->getCol($sSQL));
+							}
+
+							if (!$aSearch['sOperator'] || $aSearch['sOperator'] == 'near') // & in
+							{
+								$sSQL = "select count(*) from pg_tables where tablename = 'place_classtype_".$aSearch['sClass']."_".$aSearch['sType']."'";
+								$bCacheTable = chksql($this->oDB->getOne($sSQL));
+
+								$sSQL = "select min(rank_search) from placex where place_id in ($sPlaceIDs)";
+
+								if (CONST_Debug) var_dump($sSQL);
+								$this->iMaxRank = ((int)chksql($this->oDB->getOne($sSQL)));
+
+								// For state / country level searches the normal radius search doesn't work very well
+								$sPlaceGeom = false;
+								if ($this->iMaxRank < 9 && $bCacheTable)
+								{
+									// Try and get a polygon to search in instead
+									$sSQL = "select geometry from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank + 5 and st_geometrytype(geometry) in ('ST_Polygon','ST_MultiPolygon') order by rank_search asc limit 1";
 									if (CONST_Debug) var_dump($sSQL);
-									$this->iMaxRank = ((int)chksql($this->oDB->getOne($sSQL)));
+									$sPlaceGeom = chksql($this->oDB->getOne($sSQL));
+								}
 
-									// For state / country level searches the normal radius search doesn't work very well
-									$sPlaceGeom = false;
-									if ($this->iMaxRank < 9 && $bCacheTable)
+								if ($sPlaceGeom)
+								{
+									$sPlaceIDs = false;
+								}
+								else
+								{
+									$this->iMaxRank += 5;
+									$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank";
+									if (CONST_Debug) var_dump($sSQL);
+									$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
+									$sPlaceIDs = join(',',$aPlaceIDs);
+								}
+
+								if ($sPlaceIDs || $sPlaceGeom)
+								{
+
+									$fRange = 0.01;
+									if ($bCacheTable)
 									{
-										// Try and get a polygon to search in instead
-										$sSQL = "select geometry from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank + 5 and st_geometrytype(geometry) in ('ST_Polygon','ST_MultiPolygon') order by rank_search asc limit 1";
+										// More efficient - can make the range bigger
+										$fRange = 0.05;
+
+										$sOrderBySQL = '';
+										if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.centroid)";
+										else if ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
+										else if ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
+
+										$sSQL = "select distinct l.place_id".($sOrderBySQL?','.$sOrderBySQL:'')." from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." as l";
+										if ($sCountryCodesSQL) $sSQL .= " join placex as lp using (place_id)";
+										if ($sPlaceIDs)
+										{
+											$sSQL .= ",placex as f where ";
+											$sSQL .= "f.place_id in ($sPlaceIDs) and ST_DWithin(l.centroid, f.centroid, $fRange) ";
+										}
+										if ($sPlaceGeom)
+										{
+											$sSQL .= " where ";
+											$sSQL .= "ST_Contains('".$sPlaceGeom."', l.centroid) ";
+										}
+										if (sizeof($this->aExcludePlaceIDs))
+										{
+											$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+										}
+										if ($sCountryCodesSQL) $sSQL .= " and lp.calculated_country_code in ($sCountryCodesSQL)";
+										if ($sOrderBySQL) $sSQL .= "order by ".$sOrderBySQL." asc";
+										if ($this->iOffset) $sSQL .= " offset $this->iOffset";
+										$sSQL .= " limit $this->iLimit";
 										if (CONST_Debug) var_dump($sSQL);
-										$sPlaceGeom = chksql($this->oDB->getOne($sSQL));
-									}
-
-									if ($sPlaceGeom)
-									{
-										$sPlaceIDs = false;
+										$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
 									}
 									else
 									{
-										$this->iMaxRank += 5;
-										$sSQL = "select place_id from placex where place_id in ($sPlaceIDs) and rank_search < $this->iMaxRank";
+										if (isset($aSearch['fRadius']) && $aSearch['fRadius']) $fRange = $aSearch['fRadius'];
+
+										$sOrderBySQL = '';
+										if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.geometry)";
+										else $sOrderBySQL = "ST_Distance(l.geometry, f.geometry)";
+
+										$sSQL = "select distinct l.place_id".($sOrderBysSQL?','.$sOrderBysSQL:'')." from placex as l,placex as f where ";
+										$sSQL .= "f.place_id in ( $sPlaceIDs) and ST_DWithin(l.geometry, f.centroid, $fRange) ";
+										$sSQL .= "and l.class='".$aSearch['sClass']."' and l.type='".$aSearch['sType']."' ";
+										if (sizeof($this->aExcludePlaceIDs))
+										{
+											$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
+										}
+										if ($sCountryCodesSQL) $sSQL .= " and l.calculated_country_code in ($sCountryCodesSQL)";
+										if ($sOrderBy) $sSQL .= "order by ".$OrderBysSQL." asc";
+										if ($this->iOffset) $sSQL .= " offset $this->iOffset";
+										$sSQL .= " limit $this->iLimit";
 										if (CONST_Debug) var_dump($sSQL);
-										$aPlaceIDs = chksql($this->oDB->getCol($sSQL));
-										$sPlaceIDs = join(',',$aPlaceIDs);
-									}
-
-									if ($sPlaceIDs || $sPlaceGeom)
-									{
-
-										$fRange = 0.01;
-										if ($bCacheTable)
-										{
-											// More efficient - can make the range bigger
-											$fRange = 0.05;
-
-											$sOrderBySQL = '';
-											if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.centroid)";
-											else if ($sPlaceIDs) $sOrderBySQL = "ST_Distance(l.centroid, f.geometry)";
-											else if ($sPlaceGeom) $sOrderBysSQL = "ST_Distance(st_centroid('".$sPlaceGeom."'), l.centroid)";
-
-											$sSQL = "select distinct l.place_id".($sOrderBySQL?','.$sOrderBySQL:'')." from place_classtype_".$aSearch['sClass']."_".$aSearch['sType']." as l";
-											if ($sCountryCodesSQL) $sSQL .= " join placex as lp using (place_id)";
-											if ($sPlaceIDs)
-											{
-												$sSQL .= ",placex as f where ";
-												$sSQL .= "f.place_id in ($sPlaceIDs) and ST_DWithin(l.centroid, f.centroid, $fRange) ";
-											}
-											if ($sPlaceGeom)
-											{
-												$sSQL .= " where ";
-												$sSQL .= "ST_Contains('".$sPlaceGeom."', l.centroid) ";
-											}
-											if (sizeof($this->aExcludePlaceIDs))
-											{
-												$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
-											}
-											if ($sCountryCodesSQL) $sSQL .= " and lp.calculated_country_code in ($sCountryCodesSQL)";
-											if ($sOrderBySQL) $sSQL .= "order by ".$sOrderBySQL." asc";
-											if ($this->iOffset) $sSQL .= " offset $this->iOffset";
-											$sSQL .= " limit $this->iLimit";
-											if (CONST_Debug) var_dump($sSQL);
-											$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
-										}
-										else
-										{
-											if (isset($aSearch['fRadius']) && $aSearch['fRadius']) $fRange = $aSearch['fRadius'];
-
-											$sOrderBySQL = '';
-											if ($sNearPointSQL) $sOrderBySQL = "ST_Distance($sNearPointSQL, l.geometry)";
-											else $sOrderBySQL = "ST_Distance(l.geometry, f.geometry)";
-
-											$sSQL = "select distinct l.place_id".($sOrderBysSQL?','.$sOrderBysSQL:'')." from placex as l,placex as f where ";
-											$sSQL .= "f.place_id in ( $sPlaceIDs) and ST_DWithin(l.geometry, f.centroid, $fRange) ";
-											$sSQL .= "and l.class='".$aSearch['sClass']."' and l.type='".$aSearch['sType']."' ";
-											if (sizeof($this->aExcludePlaceIDs))
-											{
-												$sSQL .= " and l.place_id not in (".join(',',$this->aExcludePlaceIDs).")";
-											}
-											if ($sCountryCodesSQL) $sSQL .= " and l.calculated_country_code in ($sCountryCodesSQL)";
-											if ($sOrderBy) $sSQL .= "order by ".$OrderBysSQL." asc";
-											if ($this->iOffset) $sSQL .= " offset $this->iOffset";
-											$sSQL .= " limit $this->iLimit";
-											if (CONST_Debug) var_dump($sSQL);
-											$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
-										}
+										$aClassPlaceIDs = array_merge($aClassPlaceIDs, chksql($this->oDB->getCol($sSQL)));
 									}
 								}
-
-								$aPlaceIDs = $aClassPlaceIDs;
-
 							}
 
+							$aPlaceIDs = $aClassPlaceIDs;
+
 						}
 
-						if (CONST_Debug) { echo "<br><b>Place IDs:</b> "; var_Dump($aPlaceIDs); }
-
-						foreach($aPlaceIDs as $iPlaceID)
-						{
-							// array for placeID => -1 | Tiger housenumber
-							$aResultPlaceIDs[$iPlaceID] = $searchedHousenumber;
-						}
-						if ($iQueryLoop > 20) break;
 					}
 
-					if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30))
+					if (CONST_Debug) { echo "<br><b>Place IDs:</b> "; var_Dump($aPlaceIDs); }
+
+					foreach($aPlaceIDs as $iPlaceID)
 					{
-						// Need to verify passes rank limits before dropping out of the loop (yuk!)
-						// reduces the number of place ids, like a filter
-						// rank_address is 30 for interpolated housenumbers
-						$sSQL = "select place_id from placex where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
-						$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
-						if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
-						if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
-						if (CONST_Use_US_Tiger_Data)
-						{
-							$sSQL .= ") UNION select place_id from location_property_tiger where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
-							$sSQL .= "and (30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
-							if ($this->aAddressRankList) $sSQL .= " OR 30 in (".join(',',$this->aAddressRankList).")";
-						}
-						$sSQL .= ") UNION select place_id from location_property_osmline where place_id in (".join(',',array_keys($aResultPlaceIDs)).")";
-						$sSQL .= " and (30 between $this->iMinAddressRank and $this->iMaxAddressRank)";
-						if (CONST_Debug) var_dump($sSQL);
-						$aFilteredPlaceIDs = chksql($this->oDB->getCol($sSQL));
-						$tempIDs = array();
-						foreach($aFilteredPlaceIDs as $placeID)
-						{
-							$tempIDs[$placeID] = $aResultPlaceIDs[$placeID];  //assign housenumber to placeID
-						}
-						$aResultPlaceIDs = $tempIDs;
+						// array for placeID => -1 | Tiger housenumber
+						$aResultPlaceIDs[$iPlaceID] = $searchedHousenumber;
 					}
-
-					//exit;
-					if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs)) break;
-					if ($iGroupLoop > 4) break;
-					if ($iQueryLoop > 30) break;
+					if ($iQueryLoop > 20) break;
 				}
 
-				// Did we find anything?
-				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs))
+				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs) && ($this->iMinAddressRank != 0 || $this->iMaxAddressRank != 30))
 				{
-					$aSearchResults = $this->getDetails($aResultPlaceIDs);
+					// Need to verify passes rank limits before dropping out of the loop (yuk!)
+					// reduces the number of place ids, like a filter
+					// rank_address is 30 for interpolated housenumbers
+					$sSQL = "select place_id from placex where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
+					$sSQL .= "and (placex.rank_address between $this->iMinAddressRank and $this->iMaxAddressRank ";
+					if (14 >= $this->iMinAddressRank && 14 <= $this->iMaxAddressRank) $sSQL .= " OR (extratags->'place') = 'city'";
+					if ($this->aAddressRankList) $sSQL .= " OR placex.rank_address in (".join(',',$this->aAddressRankList).")";
+					if (CONST_Use_US_Tiger_Data)
+					{
+						$sSQL .= ") UNION select place_id from location_property_tiger where place_id in (".join(',',array_keys($aResultPlaceIDs)).") ";
+						$sSQL .= "and (30 between $this->iMinAddressRank and $this->iMaxAddressRank ";
+						if ($this->aAddressRankList) $sSQL .= " OR 30 in (".join(',',$this->aAddressRankList).")";
+					}
+					$sSQL .= ") UNION select place_id from location_property_osmline where place_id in (".join(',',array_keys($aResultPlaceIDs)).")";
+					$sSQL .= " and (30 between $this->iMinAddressRank and $this->iMaxAddressRank)";
+					if (CONST_Debug) var_dump($sSQL);
+					$aFilteredPlaceIDs = chksql($this->oDB->getCol($sSQL));
+					$tempIDs = array();
+					foreach($aFilteredPlaceIDs as $placeID)
+					{
+						$tempIDs[$placeID] = $aResultPlaceIDs[$placeID];  //assign housenumber to placeID
+					}
+					$aResultPlaceIDs = $tempIDs;
 				}
 
+				//exit;
+				if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs)) break;
+				if ($iGroupLoop > 4) break;
+				if ($iQueryLoop > 30) break;
+			}
+
+			// Did we find anything?
+			if (isset($aResultPlaceIDs) && sizeof($aResultPlaceIDs))
+			{
+				$aSearchResults = $this->getDetails($aResultPlaceIDs);
+			}
+
+		}
+		else
+		{
+			// Just interpret as a reverse geocode
+			$oReverse = new ReverseGeocode($this->oDB);
+			$oReverse->setZoom(18);
+
+			$aLookup = $oReverse->lookup((float)$this->aNearPoint[0],
+			                             (float)$this->aNearPoint[1],
+			                             false);
+
+			if (CONST_Debug) var_dump("Reverse search", $aLookup);
+
+			if ($aLookup['place_id'])
+				$aSearchResults = $this->getDetails(array($aLookup['place_id'] => -1));
+			else
+				$aSearchResults = array();
+		}
+
+		// No results? Done
+		if (!sizeof($aSearchResults))
+		{
+			if ($this->bFallback)
+			{
+				if ($this->fallbackStructuredQuery())
+				{
+					return $this->lookup();
+				}
+			}
+
+			return array();
+		}
+
+		$aClassType = getClassTypesWithImportance();
+		$aRecheckWords = preg_split('/\b[\s,\\-]*/u',$sQuery);
+		foreach($aRecheckWords as $i => $sWord)
+		{
+			if (!preg_match('/\pL/', $sWord)) unset($aRecheckWords[$i]);
+		}
+
+		if (CONST_Debug) { echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords); }
+
+		$oPlaceLookup = new PlaceLookup($this->oDB);
+		$oPlaceLookup->setIncludePolygonAsPoints($this->bIncludePolygonAsPoints);
+		$oPlaceLookup->setIncludePolygonAsText($this->bIncludePolygonAsText);
+		$oPlaceLookup->setIncludePolygonAsGeoJSON($this->bIncludePolygonAsGeoJSON);
+		$oPlaceLookup->setIncludePolygonAsKML($this->bIncludePolygonAsKML);
+		$oPlaceLookup->setIncludePolygonAsSVG($this->bIncludePolygonAsSVG);
+		$oPlaceLookup->setPolygonSimplificationThreshold($this->fPolygonSimplificationThreshold);
+
+		foreach($aSearchResults as $iResNum => $aResult)
+		{
+			// Default
+			$fDiameter = getResultDiameter($aResult);
+
+			$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter/2);
+			if ($aOutlineResult)
+			{
+				$aResult = array_merge($aResult, $aOutlineResult);
+			}
+			
+			if ($aResult['extra_place'] == 'city')
+			{
+				$aResult['class'] = 'place';
+				$aResult['type'] = 'city';
+				$aResult['rank_search'] = 16;
+			}
+
+			// Is there an icon set for this type of result?
+			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
+					&& $aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
+			{
+				$aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aClassType[$aResult['class'].':'.$aResult['type']]['icon'].'.p.20.png';
+			}
+
+			if (isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
+					&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
+			{
+				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'];
+			}
+			elseif (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
+					&& $aClassType[$aResult['class'].':'.$aResult['type']]['label'])
+			{
+				$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type']]['label'];
+			}
+			// if tag '&addressdetails=1' is set in query
+			if ($this->bIncludeAddressDetails)
+			{
+				// getAddressDetails() is defined in lib.php and uses the SQL function get_addressdata in functions.sql
+				$aResult['address'] = getAddressDetails($this->oDB, $sLanguagePrefArraySQL, $aResult['place_id'], $aResult['country_code'], $aResultPlaceIDs[$aResult['place_id']]);
+				if ($aResult['extra_place'] == 'city' && !isset($aResult['address']['city']))
+				{
+					$aResult['address'] = array_merge(array('city' => array_shift(array_values($aResult['address']))), $aResult['address']);
+				}
+			}
+			if ($this->bIncludeExtraTags)
+			{
+				if ($aResult['extra'])
+				{
+					$aResult['sExtraTags'] = json_decode($aResult['extra']);
+				}
+				else
+				{
+					$aResult['sExtraTags'] = (object) array();
+				}
+			}
+
+			if ($this->bIncludeNameDetails)
+			{
+				if ($aResult['names'])
+				{
+					$aResult['sNameDetails'] = json_decode($aResult['names']);
+				}
+				else
+				{
+					$aResult['sNameDetails'] = (object) array();
+				}
+			}
+
+			// Adjust importance for the number of exact string matches in the result
+			$aResult['importance'] = max(0.001,$aResult['importance']);
+			$iCountWords = 0;
+			$sAddress = $aResult['langaddress'];
+			foreach($aRecheckWords as $i => $sWord)
+			{
+				if (stripos($sAddress, $sWord)!==false)
+				{
+					$iCountWords++;
+					if (preg_match("/(^|,)\s*".preg_quote($sWord, '/')."\s*(,|$)/", $sAddress)) $iCountWords += 0.1;
+				}
+			}
+
+			$aResult['importance'] = $aResult['importance'] + ($iCountWords*0.1); // 0.1 is a completely arbitrary number but something in the range 0.1 to 0.5 would seem right
+
+			$aResult['name'] = $aResult['langaddress'];
+			// secondary ordering (for results with same importance (the smaller the better):
+			//   - approximate importance of address parts
+			$aResult['foundorder'] = -$aResult['addressimportance']/10;
+			//   - number of exact matches from the query
+			if (isset($this->exactMatchCache[$aResult['place_id']]))
+				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
+			else if (isset($this->exactMatchCache[$aResult['parent_place_id']]))
+				$aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
+			//  - importance of the class/type
+			if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
+				&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
+			{
+				$aResult['foundorder'] += 0.0001 * $aClassType[$aResult['class'].':'.$aResult['type']]['importance'];
 			}
 			else
 			{
-				// Just interpret as a reverse geocode
-				$oReverse = new ReverseGeocode($this->oDB);
-				$oReverse->setZoom(18);
-
-				$aLookup = $oReverse->lookup((float)$this->aNearPoint[0],
-				                             (float)$this->aNearPoint[1],
-				                             false);
-
-				if (CONST_Debug) var_dump("Reverse search", $aLookup);
-
-				if ($aLookup['place_id'])
-					$aSearchResults = $this->getDetails(array($aLookup['place_id'] => -1));
-				else
-					$aSearchResults = array();
+				$aResult['foundorder'] += 0.01;
 			}
+			if (CONST_Debug) { var_dump($aResult); }
+			$aSearchResults[$iResNum] = $aResult;
+		}
+		uasort($aSearchResults, 'byImportance');
 
-			// No results? Done
-			if (!sizeof($aSearchResults))
+		$aOSMIDDone = array();
+		$aClassTypeNameDone = array();
+		$aToFilter = $aSearchResults;
+		$aSearchResults = array();
+
+		$bFirst = true;
+		foreach($aToFilter as $iResNum => $aResult)
+		{
+			$this->aExcludePlaceIDs[$aResult['place_id']] = $aResult['place_id'];
+			if ($bFirst)
 			{
-				if ($this->bFallback)
-				{
-					if ($this->fallbackStructuredQuery())
-					{
-						return $this->lookup();
-					}
-				}
-
-				return array();
+				$fLat = $aResult['lat'];
+				$fLon = $aResult['lon'];
+				if (isset($aResult['zoom'])) $iZoom = $aResult['zoom'];
+				$bFirst = false;
 			}
-
-			$aClassType = getClassTypesWithImportance();
-			$aRecheckWords = preg_split('/\b[\s,\\-]*/u',$sQuery);
-			foreach($aRecheckWords as $i => $sWord)
+			if (!$this->bDeDupe || (!isset($aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']])
+						&& !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']])))
 			{
-				if (!preg_match('/\pL/', $sWord)) unset($aRecheckWords[$i]);
+				$aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']] = true;
+				$aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']] = true;
+				$aSearchResults[] = $aResult;
 			}
 
-			if (CONST_Debug) { echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords); }
+			// Absolute limit on number of results
+			if (sizeof($aSearchResults) >= $this->iFinalLimit) break;
+		}
 
-			$oPlaceLookup = new PlaceLookup($this->oDB);
-			$oPlaceLookup->setIncludePolygonAsPoints($this->bIncludePolygonAsPoints);
-			$oPlaceLookup->setIncludePolygonAsText($this->bIncludePolygonAsText);
-			$oPlaceLookup->setIncludePolygonAsGeoJSON($this->bIncludePolygonAsGeoJSON);
-			$oPlaceLookup->setIncludePolygonAsKML($this->bIncludePolygonAsKML);
-			$oPlaceLookup->setIncludePolygonAsSVG($this->bIncludePolygonAsSVG);
-			$oPlaceLookup->setPolygonSimplificationThreshold($this->fPolygonSimplificationThreshold);
+		return $aSearchResults;
 
-			foreach($aSearchResults as $iResNum => $aResult)
-			{
-				// Default
-				$fDiameter = getResultDiameter($aResult);
-
-				$aOutlineResult = $oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter/2);
-				if ($aOutlineResult)
-				{
-					$aResult = array_merge($aResult, $aOutlineResult);
-				}
-				
-				if ($aResult['extra_place'] == 'city')
-				{
-					$aResult['class'] = 'place';
-					$aResult['type'] = 'city';
-					$aResult['rank_search'] = 16;
-				}
-
-				// Is there an icon set for this type of result?
-				if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
-						&& $aClassType[$aResult['class'].':'.$aResult['type']]['icon'])
-				{
-					$aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aClassType[$aResult['class'].':'.$aResult['type']]['icon'].'.p.20.png';
-				}
-
-				if (isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
-						&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'])
-				{
-					$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['label'];
-				}
-				elseif (isset($aClassType[$aResult['class'].':'.$aResult['type']]['label'])
-						&& $aClassType[$aResult['class'].':'.$aResult['type']]['label'])
-				{
-					$aResult['label'] = $aClassType[$aResult['class'].':'.$aResult['type']]['label'];
-				}
-				// if tag '&addressdetails=1' is set in query
-				if ($this->bIncludeAddressDetails)
-				{
-					// getAddressDetails() is defined in lib.php and uses the SQL function get_addressdata in functions.sql
-					$aResult['address'] = getAddressDetails($this->oDB, $sLanguagePrefArraySQL, $aResult['place_id'], $aResult['country_code'], $aResultPlaceIDs[$aResult['place_id']]);
-					if ($aResult['extra_place'] == 'city' && !isset($aResult['address']['city']))
-					{
-						$aResult['address'] = array_merge(array('city' => array_shift(array_values($aResult['address']))), $aResult['address']);
-					}
-				}
-				if ($this->bIncludeExtraTags)
-				{
-					if ($aResult['extra'])
-					{
-						$aResult['sExtraTags'] = json_decode($aResult['extra']);
-					}
-					else
-					{
-						$aResult['sExtraTags'] = (object) array();
-					}
-				}
-
-				if ($this->bIncludeNameDetails)
-				{
-					if ($aResult['names'])
-					{
-						$aResult['sNameDetails'] = json_decode($aResult['names']);
-					}
-					else
-					{
-						$aResult['sNameDetails'] = (object) array();
-					}
-				}
-
-				// Adjust importance for the number of exact string matches in the result
-				$aResult['importance'] = max(0.001,$aResult['importance']);
-				$iCountWords = 0;
-				$sAddress = $aResult['langaddress'];
-				foreach($aRecheckWords as $i => $sWord)
-				{
-					if (stripos($sAddress, $sWord)!==false)
-					{
-						$iCountWords++;
-						if (preg_match("/(^|,)\s*".preg_quote($sWord, '/')."\s*(,|$)/", $sAddress)) $iCountWords += 0.1;
-					}
-				}
-
-				$aResult['importance'] = $aResult['importance'] + ($iCountWords*0.1); // 0.1 is a completely arbitrary number but something in the range 0.1 to 0.5 would seem right
-
-				$aResult['name'] = $aResult['langaddress'];
-				// secondary ordering (for results with same importance (the smaller the better):
-				//   - approximate importance of address parts
-				$aResult['foundorder'] = -$aResult['addressimportance']/10;
-				//   - number of exact matches from the query
-				if (isset($this->exactMatchCache[$aResult['place_id']]))
-					$aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
-				else if (isset($this->exactMatchCache[$aResult['parent_place_id']]))
-					$aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
-				//  - importance of the class/type
-				if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
-					&& $aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
-				{
-					$aResult['foundorder'] += 0.0001 * $aClassType[$aResult['class'].':'.$aResult['type']]['importance'];
-				}
-				else
-				{
-					$aResult['foundorder'] += 0.01;
-				}
-				if (CONST_Debug) { var_dump($aResult); }
-				$aSearchResults[$iResNum] = $aResult;
-			}
-			uasort($aSearchResults, 'byImportance');
-
-			$aOSMIDDone = array();
-			$aClassTypeNameDone = array();
-			$aToFilter = $aSearchResults;
-			$aSearchResults = array();
-
-			$bFirst = true;
-			foreach($aToFilter as $iResNum => $aResult)
-			{
-				$this->aExcludePlaceIDs[$aResult['place_id']] = $aResult['place_id'];
-				if ($bFirst)
-				{
-					$fLat = $aResult['lat'];
-					$fLon = $aResult['lon'];
-					if (isset($aResult['zoom'])) $iZoom = $aResult['zoom'];
-					$bFirst = false;
-				}
-				if (!$this->bDeDupe || (!isset($aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']])
-							&& !isset($aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']])))
-				{
-					$aOSMIDDone[$aResult['osm_type'].$aResult['osm_id']] = true;
-					$aClassTypeNameDone[$aResult['osm_type'].$aResult['class'].$aResult['type'].$aResult['name'].$aResult['admin_level']] = true;
-					$aSearchResults[] = $aResult;
-				}
-
-				// Absolute limit on number of results
-				if (sizeof($aSearchResults) >= $this->iFinalLimit) break;
-			}
-
-			return $aSearchResults;
-
-		} // end lookup()
+	} // end lookup()
 
 
-	} // end class
+} // end class
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -96,12 +96,11 @@ class PlaceLookup
 	{
 		if (!$iPlaceID) return null;
 
-		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
+		$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
 		$bIsTiger = CONST_Use_US_Tiger_Data && $sType == 'tiger';
 		$bIsInterpolation = $sType == 'interpolation';
 
-		if ($bIsTiger)
-		{
+		if ($bIsTiger) {
 			$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
 			$sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
 			$sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
@@ -117,9 +116,7 @@ class PlaceLookup
 			$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
 			$sSQL .= " END as housenumber";
 			$sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
-		}
-		else if ($bIsInterpolation)
-		{
+		} elseif ($bIsInterpolation) {
 			$sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
 			$sSQL .= " calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
 			$sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code, ";
@@ -138,9 +135,7 @@ class PlaceLookup
 			// testcase: interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
 			// but this will never happen, because if the searched point is that close to the endnumber, the endnumber house will be directly taken from placex (in ReverseGeocode.php line 220)
 			// and not interpolated
-		}
-		else
-		{
+		} else {
 			$sSQL = "select placex.place_id, partition, osm_type, osm_id, class, type, admin_level, housenumber, street, isin, postcode, country_code, parent_place_id, linked_place_id, rank_address, rank_search, ";
 			$sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
 			$sSQL .= " get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
@@ -157,34 +152,24 @@ class PlaceLookup
 
 		if (!$aPlace['place_id']) return null;
 
-		if ($this->bAddressDetails)
-		{
+		if ($this->bAddressDetails) {
 			// to get addressdetails for tiger data, the housenumber is needed
 			$iHousenumber = ($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1;
-			$aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'],
-			                                             $iHousenumber);
+			$aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'], $iHousenumber);
 		}
 
-		if ($this->bExtraTags)
-		{
-			if ($aPlace['extra'])
-			{
+		if ($this->bExtraTags) {
+			if ($aPlace['extra']) {
 				$aPlace['sExtraTags'] = json_decode($aPlace['extra']);
-			}
-			else
-			{
+			} else {
 				$aPlace['sExtraTags'] = (object) array();
 			}
 		}
 
-		if ($this->bNameDetails)
-		{
-			if ($aPlace['names'])
-			{
+		if ($this->bNameDetails) {
+			if ($aPlace['names']) {
 				$aPlace['sNameDetails'] = json_decode($aPlace['names']);
-			}
-			else
-			{
+			} else {
 				$aPlace['sNameDetails'] = (object) array();
 			}
 		}
@@ -192,16 +177,15 @@ class PlaceLookup
 		$aClassType = getClassTypes();
 		$sAddressType = '';
 		$sClassType = $aPlace['class'].':'.$aPlace['type'].':'.$aPlace['admin_level'];
-		if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel']))
-		{
+		if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel'])) {
 			$sAddressType = $aClassType[$aClassType]['simplelabel'];
-		}
-		else
-		{
+		} else {
 			$sClassType = $aPlace['class'].':'.$aPlace['type'];
-			if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel']))
+			if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel'])) {
 				$sAddressType = $aClassType[$sClassType]['simplelabel'];
-			else $sAddressType = $aPlace['class'];
+			} else {
+				$sAddressType = $aPlace['class'];
+			}
 		}
 
 		$aPlace['addresstype'] = $sAddressType;
@@ -211,7 +195,7 @@ class PlaceLookup
 
 	function getAddressDetails($iPlaceID, $bAll = false, $housenumber = -1)
 	{
-		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
+		$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $this->aLangPrefOrder))."]";
 
 		$sSQL = "select *,get_name_by_language(name,$sLanguagePrefArraySQL) as localname from get_addressdata(".$iPlaceID.",".$housenumber.")";
 		if (!$bAll) $sSQL .= " WHERE isaddress OR type = 'country_code'";
@@ -227,28 +211,26 @@ class PlaceLookup
 		$aAddress = array();
 		$aFallback = array();
 		$aClassType = getClassTypes();
-		foreach($aAddressLines as $aLine)
-		{
+		foreach ($aAddressLines as $aLine) {
 			$bFallback = false;
 			$aTypeLabel = false;
-			if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-			elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-			elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
-			{
+
+			if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) {
+				$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
+			} elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
+				$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
+			} elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))])) {
 				$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
 				$bFallback = true;
-			}
-			else
-			{
+			} else {
 				$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
 				$bFallback = true;
 			}
-			if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
-			{
+
+			if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber']))) {
 				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
-				$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
-				{
+				$sTypeLabel = str_replace(' ', '_', $sTypeLabel);
+				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place') {
 					$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
 				}
 				$aFallback[$sTypeLabel] = $bFallback;
@@ -268,14 +250,12 @@ class PlaceLookup
 	//   astext
 	//   lat
 	//   lon
-	function getOutlines($iPlaceID, $fLon=null, $fLat=null, $fRadius=null)
+	function getOutlines($iPlaceID, $fLon = null, $fLat = null, $fRadius = null)
 	{
-
 		$aOutlineResult = array();
 		if (!$iPlaceID) return $aOutlineResult;
 
-		if (CONST_Search_AreaPolygons)
-		{
+		if (CONST_Search_AreaPolygons) {
 			// Get the bounding box and outline polygon
 			$sSQL  = "select place_id,0 as numfeatures,st_area(geometry) as area,";
 			$sSQL .= "ST_Y(centroid) as centrelat,ST_X(centroid) as centrelon,";
@@ -286,22 +266,16 @@ class PlaceLookup
 			if ($this->bIncludePolygonAsSVG) $sSQL .= ",ST_AsSVG(geometry) as assvg";
 			if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ",ST_AsText(geometry) as astext";
 			$sFrom = " from placex where place_id = ".$iPlaceID;
-			if ($this->fPolygonSimplificationThreshold > 0)
-			{
+			if ($this->fPolygonSimplificationThreshold > 0) {
 				$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry".$sFrom.") as plx";
-			}
-			else
-			{
+			} else {
 				$sSQL .= $sFrom;
 			}
 
-			$aPointPolygon = chksql($this->oDB->getRow($sSQL),
-			                        "Could not get outline");
+			$aPointPolygon = chksql($this->oDB->getRow($sSQL), "Could not get outline");
 
-			if ($aPointPolygon['place_id'])
-			{
-				if ($aPointPolygon['centrelon'] !== null && $aPointPolygon['centrelat'] !== null )
-				{
+			if ($aPointPolygon['place_id']) {
+				if ($aPointPolygon['centrelon'] !== null && $aPointPolygon['centrelat'] !== null) {
 					$aOutlineResult['lat'] = $aPointPolygon['centrelat'];
 					$aOutlineResult['lon'] = $aPointPolygon['centrelon'];
 				}
@@ -313,13 +287,12 @@ class PlaceLookup
 				if ($this->bIncludePolygonAsPoints) $aOutlineResult['aPolyPoints'] = geometryText2Points($aPointPolygon['astext'], $fRadius);
 
 
-				if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001)
-				{
+				if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001) {
 					$aPointPolygon['minlat'] = $aPointPolygon['minlat'] - $fRadius;
 					$aPointPolygon['maxlat'] = $aPointPolygon['maxlat'] + $fRadius;
 				}
-				if (abs($aPointPolygon['minlon'] - $aPointPolygon['maxlon']) < 0.0000001)
-				{
+
+				if (abs($aPointPolygon['minlon'] - $aPointPolygon['maxlon']) < 0.0000001) {
 					$aPointPolygon['minlon'] = $aPointPolygon['minlon'] - $fRadius;
 					$aPointPolygon['maxlon'] = $aPointPolygon['maxlon'] + $fRadius;
 				}
@@ -334,11 +307,8 @@ class PlaceLookup
 		} // CONST_Search_AreaPolygons
 
 		// as a fallback we generate a bounding box without knowing the size of the geometry
-		if ( (!isset($aOutlineResult['aBoundingBox'])) && isset($fLon) )
-		{
-
-			if ($this->bIncludePolygonAsPoints)
-			{
+		if ((!isset($aOutlineResult['aBoundingBox'])) && isset($fLon)) {
+			if ($this->bIncludePolygonAsPoints) {
 				$sGeometryText = 'POINT('.$fLon.','.$fLat.')';
 				$aOutlineResult['aPolyPoints'] = geometryText2Points($sGeometryText, $fRadius);
 			}
@@ -359,4 +329,3 @@ class PlaceLookup
 		return $aOutlineResult;
 	}
 }
-?>

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -21,76 +21,103 @@ class PlaceLookup
 	function PlaceLookup(&$oDB)
 	{
 		$this->oDB =& $oDB;
-	}
+
+	}//end PlaceLookup()
+
 
 	function setLanguagePreference($aLangPrefOrder)
 	{
 		$this->aLangPrefOrder = $aLangPrefOrder;
-	}
+
+	}//end setLanguagePreference()
+
 
 	function setIncludeAddressDetails($bAddressDetails = true)
 	{
 		$this->bAddressDetails = $bAddressDetails;
-	}
+
+	}//end setIncludeAddressDetails()
+
 
 	function setIncludeExtraTags($bExtraTags = false)
 	{
 		$this->bExtraTags = $bExtraTags;
-	}
+
+	}//end setIncludeExtraTags()
+
 
 	function setIncludeNameDetails($bNameDetails = false)
 	{
 		$this->bNameDetails = $bNameDetails;
-	}
+
+	}//end setIncludeNameDetails()
 
 
 	function setIncludePolygonAsPoints($b = true)
 	{
 		$this->bIncludePolygonAsPoints = $b;
-	}
+
+	}//end setIncludePolygonAsPoints()
+
 
 	function getIncludePolygonAsPoints()
 	{
 		return $this->bIncludePolygonAsPoints;
-	}
+
+	}//end getIncludePolygonAsPoints()
+
 
 	function setIncludePolygonAsText($b = true)
 	{
 		$this->bIncludePolygonAsText = $b;
-	}
+
+	}//end setIncludePolygonAsText()
+
 
 	function getIncludePolygonAsText()
 	{
 		return $this->bIncludePolygonAsText;
-	}
+
+	}//end getIncludePolygonAsText()
+
 
 	function setIncludePolygonAsGeoJSON($b = true)
 	{
 		$this->bIncludePolygonAsGeoJSON = $b;
-	}
+
+	}//end setIncludePolygonAsGeoJSON()
+
 
 	function setIncludePolygonAsKML($b = true)
 	{
 		$this->bIncludePolygonAsKML = $b;
-	}
+
+	}//end setIncludePolygonAsKML()
+
 
 	function setIncludePolygonAsSVG($b = true)
 	{
 		$this->bIncludePolygonAsSVG = $b;
-	}
+
+	}//end setIncludePolygonAsSVG()
+
 
 	function setPolygonSimplificationThreshold($f)
 	{
 		$this->fPolygonSimplificationThreshold = $f;
-	}
+
+	}//end setPolygonSimplificationThreshold()
+
 
 	function lookupOSMID($sType, $iID)
 	{
-		$sSQL = "select place_id from placex where osm_type = '".pg_escape_string($sType)."' and osm_id = ".(int)$iID." order by type = 'postcode' asc";
+		$sSQL = "select place_id from placex where osm_type = '".pg_escape_string($sType)."' and osm_id = ".(int) $iID." order by type = 'postcode' asc";
 		$iPlaceID = chksql($this->oDB->getOne($sSQL));
 
-		return $this->lookup((int)$iPlaceID);
-	}
+		return $this->lookup((int) $iPlaceID);
+
+	}//end lookupOSMID()
+
 
 	function lookup($iPlaceID, $sType = '', $fInterpolFraction = 0.0)
 	{
@@ -116,7 +143,7 @@ class PlaceLookup
 			$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
 			$sSQL .= " END as housenumber";
 			$sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
-		} elseif ($bIsInterpolation) {
+		} else if ($bIsInterpolation) {
 			$sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
 			$sSQL .= " calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
 			$sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code, ";
@@ -146,7 +173,7 @@ class PlaceLookup
 			$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
 			$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
 			$sSQL .= " from placex where place_id = ".$iPlaceID;
-		}
+		}//end if
 
 		$aPlace = chksql($this->oDB->getRow($sSQL), "Could not lookup place");
 
@@ -154,7 +181,7 @@ class PlaceLookup
 
 		if ($this->bAddressDetails) {
 			// to get addressdetails for tiger data, the housenumber is needed
-			$iHousenumber = ($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1;
+			$iHousenumber = (($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1);
 			$aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'], $iHousenumber);
 		}
 
@@ -189,9 +216,10 @@ class PlaceLookup
 		}
 
 		$aPlace['addresstype'] = $sAddressType;
-
 		return $aPlace;
-	}
+
+	}//end lookup()
+
 
 	function getAddressDetails($iPlaceID, $bAll = false, $housenumber = -1)
 	{
@@ -202,7 +230,9 @@ class PlaceLookup
 		$sSQL .= " order by rank_address desc,isaddress desc";
 
 		return chksql($this->oDB->getAll($sSQL));
-	}
+
+	}//end getAddressDetails()
+
 
 	function getAddressNames($iPlaceID, $housenumber = -1)
 	{
@@ -217,39 +247,42 @@ class PlaceLookup
 
 			if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) {
 				$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-			} elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
+			} else if (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
 				$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-			} elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))])) {
-				$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
+			} else if (isset($aClassType['boundary:administrative:'.((int) ($aLine['rank_address'] / 2))])) {
+				$aTypeLabel = $aClassType['boundary:administrative:'.((int) ($aLine['rank_address'] / 2))];
 				$bFallback = true;
 			} else {
-				$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
+				$aTypeLabel = array('simplelabel' => 'address'.$aLine['rank_address']);
 				$bFallback = true;
 			}
 
 			if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber']))) {
-				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
+				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel']) ? $aTypeLabel['simplelabel'] : $aTypeLabel['label']);
 				$sTypeLabel = str_replace(' ', '_', $sTypeLabel);
 				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place') {
-					$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
+					$aAddress[$sTypeLabel] = $aLine['localname'] ? $aLine['localname'] : $aLine['housenumber'];
 				}
+
 				$aFallback[$sTypeLabel] = $bFallback;
 			}
-		}
+		}//end foreach
 		return $aAddress;
-	}
+
+	}//end getAddressNames()
 
 
-
-	// returns an array which will contain the keys
-	//   aBoundingBox
-	// and may also contain one or more of the keys
-	//   asgeojson
-	//   askml
-	//   assvg
-	//   astext
-	//   lat
-	//   lon
+	/**
+	 * Returns an array which will contain the keys
+	 *   aBoundingBox
+	 * and may also contain one or more of the keys
+	 *   asgeojson
+	 *   askml
+	 *   assvg
+	 *   astext
+	 *   lat
+	 *   lon
+	 */
 	function getOutlines($iPlaceID, $fLon = null, $fLat = null, $fRadius = null)
 	{
 		$aOutlineResult = array();
@@ -286,25 +319,24 @@ class PlaceLookup
 				if ($this->bIncludePolygonAsText) $aOutlineResult['astext'] = $aPointPolygon['astext'];
 				if ($this->bIncludePolygonAsPoints) $aOutlineResult['aPolyPoints'] = geometryText2Points($aPointPolygon['astext'], $fRadius);
 
-
-				if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001) {
-					$aPointPolygon['minlat'] = $aPointPolygon['minlat'] - $fRadius;
-					$aPointPolygon['maxlat'] = $aPointPolygon['maxlat'] + $fRadius;
+				if (abs(($aPointPolygon['minlat'] - $aPointPolygon['maxlat'])) < 0.0000001) {
+					$aPointPolygon['minlat'] = ($aPointPolygon['minlat'] - $fRadius);
+					$aPointPolygon['maxlat'] = ($aPointPolygon['maxlat'] + $fRadius);
 				}
 
-				if (abs($aPointPolygon['minlon'] - $aPointPolygon['maxlon']) < 0.0000001) {
-					$aPointPolygon['minlon'] = $aPointPolygon['minlon'] - $fRadius;
-					$aPointPolygon['maxlon'] = $aPointPolygon['maxlon'] + $fRadius;
+				if (abs(($aPointPolygon['minlon'] - $aPointPolygon['maxlon'])) < 0.0000001) {
+					$aPointPolygon['minlon'] = ($aPointPolygon['minlon'] - $fRadius);
+					$aPointPolygon['maxlon'] = ($aPointPolygon['maxlon'] + $fRadius);
 				}
 
 				$aOutlineResult['aBoundingBox'] = array(
-				                                  (string)$aPointPolygon['minlat'],
-				                                  (string)$aPointPolygon['maxlat'],
-				                                  (string)$aPointPolygon['minlon'],
-				                                  (string)$aPointPolygon['maxlon']
-				                                 );
-			}
-		} // CONST_Search_AreaPolygons
+				                                   (string) $aPointPolygon['minlat'],
+				                                   (string) $aPointPolygon['maxlat'],
+				                                   (string) $aPointPolygon['minlon'],
+				                                   (string) $aPointPolygon['maxlon']
+				                                  );
+			}//end if
+		}//end if
 
 		// as a fallback we generate a bounding box without knowing the size of the geometry
 		if ((!isset($aOutlineResult['aBoundingBox'])) && isset($fLon)) {
@@ -314,18 +346,22 @@ class PlaceLookup
 			}
 
 			$aBounds = array();
-			$aBounds['minlat'] = $fLat - $fRadius;
-			$aBounds['maxlat'] = $fLat + $fRadius;
-			$aBounds['minlon'] = $fLon - $fRadius;
-			$aBounds['maxlon'] = $fLon + $fRadius;
+			$aBounds['minlat'] = ($fLat - $fRadius);
+			$aBounds['maxlat'] = ($fLat + $fRadius);
+			$aBounds['minlon'] = ($fLon - $fRadius);
+			$aBounds['maxlon'] = ($fLon + $fRadius);
 
 			$aOutlineResult['aBoundingBox'] = array(
-			                                  (string)$aBounds['minlat'],
-			                                  (string)$aBounds['maxlat'],
-			                                  (string)$aBounds['minlon'],
-			                                  (string)$aBounds['maxlon']
-			                                 );
+			                                   (string) $aBounds['minlat'],
+			                                   (string) $aBounds['maxlat'],
+			                                   (string) $aBounds['minlon'],
+			                                   (string) $aBounds['maxlon']
+			                                  );
 		}
+
 		return $aOutlineResult;
-	}
-}
+
+	}//end getOutlines()
+
+
+}//end class

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -1,361 +1,362 @@
 <?php
-	class PlaceLookup
+
+class PlaceLookup
+{
+	protected $oDB;
+
+	protected $aLangPrefOrder = array();
+
+	protected $bAddressDetails = false;
+	protected $bExtraTags = false;
+	protected $bNameDetails = false;
+
+	protected $bIncludePolygonAsPoints = false;
+	protected $bIncludePolygonAsText = false;
+	protected $bIncludePolygonAsGeoJSON = false;
+	protected $bIncludePolygonAsKML = false;
+	protected $bIncludePolygonAsSVG = false;
+	protected $fPolygonSimplificationThreshold = 0.0;
+
+
+	function PlaceLookup(&$oDB)
 	{
-		protected $oDB;
+		$this->oDB =& $oDB;
+	}
 
-		protected $aLangPrefOrder = array();
+	function setLanguagePreference($aLangPrefOrder)
+	{
+		$this->aLangPrefOrder = $aLangPrefOrder;
+	}
 
-		protected $bAddressDetails = false;
-		protected $bExtraTags = false;
-		protected $bNameDetails = false;
+	function setIncludeAddressDetails($bAddressDetails = true)
+	{
+		$this->bAddressDetails = $bAddressDetails;
+	}
 
-		protected $bIncludePolygonAsPoints = false;
-		protected $bIncludePolygonAsText = false;
-		protected $bIncludePolygonAsGeoJSON = false;
-		protected $bIncludePolygonAsKML = false;
-		protected $bIncludePolygonAsSVG = false;
-		protected $fPolygonSimplificationThreshold = 0.0;
+	function setIncludeExtraTags($bExtraTags = false)
+	{
+		$this->bExtraTags = $bExtraTags;
+	}
+
+	function setIncludeNameDetails($bNameDetails = false)
+	{
+		$this->bNameDetails = $bNameDetails;
+	}
 
 
-		function PlaceLookup(&$oDB)
+	function setIncludePolygonAsPoints($b = true)
+	{
+		$this->bIncludePolygonAsPoints = $b;
+	}
+
+	function getIncludePolygonAsPoints()
+	{
+		return $this->bIncludePolygonAsPoints;
+	}
+
+	function setIncludePolygonAsText($b = true)
+	{
+		$this->bIncludePolygonAsText = $b;
+	}
+
+	function getIncludePolygonAsText()
+	{
+		return $this->bIncludePolygonAsText;
+	}
+
+	function setIncludePolygonAsGeoJSON($b = true)
+	{
+		$this->bIncludePolygonAsGeoJSON = $b;
+	}
+
+	function setIncludePolygonAsKML($b = true)
+	{
+		$this->bIncludePolygonAsKML = $b;
+	}
+
+	function setIncludePolygonAsSVG($b = true)
+	{
+		$this->bIncludePolygonAsSVG = $b;
+	}
+
+	function setPolygonSimplificationThreshold($f)
+	{
+		$this->fPolygonSimplificationThreshold = $f;
+	}
+
+	function lookupOSMID($sType, $iID)
+	{
+		$sSQL = "select place_id from placex where osm_type = '".pg_escape_string($sType)."' and osm_id = ".(int)$iID." order by type = 'postcode' asc";
+		$iPlaceID = chksql($this->oDB->getOne($sSQL));
+
+		return $this->lookup((int)$iPlaceID);
+	}
+
+	function lookup($iPlaceID, $sType = '', $fInterpolFraction = 0.0)
+	{
+		if (!$iPlaceID) return null;
+
+		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
+		$bIsTiger = CONST_Use_US_Tiger_Data && $sType == 'tiger';
+		$bIsInterpolation = $sType == 'interpolation';
+
+		if ($bIsTiger)
 		{
-			$this->oDB =& $oDB;
+			$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
+			$sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
+			$sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
+			$sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
+			$sSQL .= " null as placename,";
+			$sSQL .= " null as ref,";
+			if ($this->bExtraTags) $sSQL .= " null as extra,";
+			if ($this->bNameDetails) $sSQL .= " null as names,";
+			$sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
+			$sSQL .= " (select *, ";
+			$sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
+			$sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
+			$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
+			$sSQL .= " END as housenumber";
+			$sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
+		}
+		else if ($bIsInterpolation)
+		{
+			$sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
+			$sSQL .= " calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
+			$sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code, ";
+			$sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
+			$sSQL .= " null as placename,";
+			$sSQL .= " null as ref,";
+			if ($this->bExtraTags) $sSQL .= " null as extra,";
+			if ($this->bNameDetails) $sSQL .= " null as names,";
+			$sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
+			$sSQL .= " (select *, ";
+			$sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
+			$sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
+			$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
+			$sSQL .= " END as housenumber";
+			$sSQL .= " from location_property_osmline where place_id = ".$iPlaceID.") as blub1) as blub2";
+			// testcase: interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
+			// but this will never happen, because if the searched point is that close to the endnumber, the endnumber house will be directly taken from placex (in ReverseGeocode.php line 220)
+			// and not interpolated
+		}
+		else
+		{
+			$sSQL = "select placex.place_id, partition, osm_type, osm_id, class, type, admin_level, housenumber, street, isin, postcode, country_code, parent_place_id, linked_place_id, rank_address, rank_search, ";
+			$sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
+			$sSQL .= " get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
+			$sSQL .= " get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
+			$sSQL .= " get_name_by_language(name, ARRAY['ref']) as ref,";
+			if ($this->bExtraTags) $sSQL .= " hstore_to_json(extratags) as extra,";
+			if ($this->bNameDetails) $sSQL .= " hstore_to_json(name) as names,";
+			$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
+			$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
+			$sSQL .= " from placex where place_id = ".$iPlaceID;
 		}
 
-		function setLanguagePreference($aLangPrefOrder)
+		$aPlace = chksql($this->oDB->getRow($sSQL), "Could not lookup place");
+
+		if (!$aPlace['place_id']) return null;
+
+		if ($this->bAddressDetails)
 		{
-			$this->aLangPrefOrder = $aLangPrefOrder;
+			// to get addressdetails for tiger data, the housenumber is needed
+			$iHousenumber = ($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1;
+			$aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'],
+			                                             $iHousenumber);
 		}
 
-		function setIncludeAddressDetails($bAddressDetails = true)
+		if ($this->bExtraTags)
 		{
-			$this->bAddressDetails = $bAddressDetails;
-		}
-
-		function setIncludeExtraTags($bExtraTags = false)
-		{
-			$this->bExtraTags = $bExtraTags;
-		}
-
-		function setIncludeNameDetails($bNameDetails = false)
-		{
-			$this->bNameDetails = $bNameDetails;
-		}
-
-
-		function setIncludePolygonAsPoints($b = true)
-		{
-			$this->bIncludePolygonAsPoints = $b;
-		}
-
-		function getIncludePolygonAsPoints()
-		{
-			return $this->bIncludePolygonAsPoints;
-		}
-
-		function setIncludePolygonAsText($b = true)
-		{
-			$this->bIncludePolygonAsText = $b;
-		}
-
-		function getIncludePolygonAsText()
-		{
-			return $this->bIncludePolygonAsText;
-		}
-
-		function setIncludePolygonAsGeoJSON($b = true)
-		{
-			$this->bIncludePolygonAsGeoJSON = $b;
-		}
-
-		function setIncludePolygonAsKML($b = true)
-		{
-			$this->bIncludePolygonAsKML = $b;
-		}
-
-		function setIncludePolygonAsSVG($b = true)
-		{
-			$this->bIncludePolygonAsSVG = $b;
-		}
-
-		function setPolygonSimplificationThreshold($f)
-		{
-			$this->fPolygonSimplificationThreshold = $f;
-		}
-
-		function lookupOSMID($sType, $iID)
-		{
-			$sSQL = "select place_id from placex where osm_type = '".pg_escape_string($sType)."' and osm_id = ".(int)$iID." order by type = 'postcode' asc";
-			$iPlaceID = chksql($this->oDB->getOne($sSQL));
-
-			return $this->lookup((int)$iPlaceID);
-		}
-
-		function lookup($iPlaceID, $sType = '', $fInterpolFraction = 0.0)
-		{
-			if (!$iPlaceID) return null;
-
-			$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
-			$bIsTiger = CONST_Use_US_Tiger_Data && $sType == 'tiger';
-			$bIsInterpolation = $sType == 'interpolation';
-
-			if ($bIsTiger)
+			if ($aPlace['extra'])
 			{
-				$sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
-				$sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
-				$sSQL .= " coalesce(null,0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, 'us' as calculated_country_code, ";
-				$sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
-				$sSQL .= " null as placename,";
-				$sSQL .= " null as ref,";
-				if ($this->bExtraTags) $sSQL .= " null as extra,";
-				if ($this->bNameDetails) $sSQL .= " null as names,";
-				$sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
-				$sSQL .= " (select *, ";
-				$sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-				$sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-				$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-				$sSQL .= " END as housenumber";
-				$sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
-			}
-			else if ($bIsInterpolation)
-			{
-				$sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
-				$sSQL .= " calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
-				$sSQL .= " (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code, ";
-				$sSQL .= " get_address_by_language(place_id, housenumber, $sLanguagePrefArraySQL) as langaddress,";
-				$sSQL .= " null as placename,";
-				$sSQL .= " null as ref,";
-				if ($this->bExtraTags) $sSQL .= " null as extra,";
-				if ($this->bNameDetails) $sSQL .= " null as names,";
-				$sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
-				$sSQL .= " (select *, ";
-				$sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-				$sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-				$sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-				$sSQL .= " END as housenumber";
-				$sSQL .= " from location_property_osmline where place_id = ".$iPlaceID.") as blub1) as blub2";
-				// testcase: interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
-				// but this will never happen, because if the searched point is that close to the endnumber, the endnumber house will be directly taken from placex (in ReverseGeocode.php line 220)
-				// and not interpolated
+				$aPlace['sExtraTags'] = json_decode($aPlace['extra']);
 			}
 			else
 			{
-				$sSQL = "select placex.place_id, partition, osm_type, osm_id, class, type, admin_level, housenumber, street, isin, postcode, country_code, parent_place_id, linked_place_id, rank_address, rank_search, ";
-				$sSQL .= " coalesce(importance,0.75-(rank_search::float/40)) as importance, indexed_status, indexed_date, wikipedia, calculated_country_code, ";
-				$sSQL .= " get_address_by_language(place_id, -1, $sLanguagePrefArraySQL) as langaddress,";
-				$sSQL .= " get_name_by_language(name, $sLanguagePrefArraySQL) as placename,";
-				$sSQL .= " get_name_by_language(name, ARRAY['ref']) as ref,";
-				if ($this->bExtraTags) $sSQL .= " hstore_to_json(extratags) as extra,";
-				if ($this->bNameDetails) $sSQL .= " hstore_to_json(name) as names,";
-				$sSQL .= " (case when centroid is null then st_y(st_centroid(geometry)) else st_y(centroid) end) as lat,";
-				$sSQL .= " (case when centroid is null then st_x(st_centroid(geometry)) else st_x(centroid) end) as lon";
-				$sSQL .= " from placex where place_id = ".$iPlaceID;
+				$aPlace['sExtraTags'] = (object) array();
 			}
+		}
 
-			$aPlace = chksql($this->oDB->getRow($sSQL), "Could not lookup place");
-
-			if (!$aPlace['place_id']) return null;
-
-			if ($this->bAddressDetails)
+		if ($this->bNameDetails)
+		{
+			if ($aPlace['names'])
 			{
-				// to get addressdetails for tiger data, the housenumber is needed
-				$iHousenumber = ($bIsTiger || $bIsInterpolation) ? $aPlace['housenumber'] : -1;
-				$aPlace['aAddress'] = $this->getAddressNames($aPlace['place_id'],
-				                                             $iHousenumber);
+				$aPlace['sNameDetails'] = json_decode($aPlace['names']);
 			}
-
-			if ($this->bExtraTags)
+			else
 			{
-				if ($aPlace['extra'])
-				{
-					$aPlace['sExtraTags'] = json_decode($aPlace['extra']);
-				}
-				else
-				{
-					$aPlace['sExtraTags'] = (object) array();
-				}
+				$aPlace['sNameDetails'] = (object) array();
 			}
+		}
 
-			if ($this->bNameDetails)
-			{
-				if ($aPlace['names'])
-				{
-					$aPlace['sNameDetails'] = json_decode($aPlace['names']);
-				}
-				else
-				{
-					$aPlace['sNameDetails'] = (object) array();
-				}
-			}
-
-			$aClassType = getClassTypes();
-			$sAddressType = '';
-			$sClassType = $aPlace['class'].':'.$aPlace['type'].':'.$aPlace['admin_level'];
+		$aClassType = getClassTypes();
+		$sAddressType = '';
+		$sClassType = $aPlace['class'].':'.$aPlace['type'].':'.$aPlace['admin_level'];
+		if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel']))
+		{
+			$sAddressType = $aClassType[$aClassType]['simplelabel'];
+		}
+		else
+		{
+			$sClassType = $aPlace['class'].':'.$aPlace['type'];
 			if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel']))
+				$sAddressType = $aClassType[$sClassType]['simplelabel'];
+			else $sAddressType = $aPlace['class'];
+		}
+
+		$aPlace['addresstype'] = $sAddressType;
+
+		return $aPlace;
+	}
+
+	function getAddressDetails($iPlaceID, $bAll = false, $housenumber = -1)
+	{
+		$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
+
+		$sSQL = "select *,get_name_by_language(name,$sLanguagePrefArraySQL) as localname from get_addressdata(".$iPlaceID.",".$housenumber.")";
+		if (!$bAll) $sSQL .= " WHERE isaddress OR type = 'country_code'";
+		$sSQL .= " order by rank_address desc,isaddress desc";
+
+		return chksql($this->oDB->getAll($sSQL));
+	}
+
+	function getAddressNames($iPlaceID, $housenumber = -1)
+	{
+		$aAddressLines = $this->getAddressDetails($iPlaceID, false, $housenumber);
+
+		$aAddress = array();
+		$aFallback = array();
+		$aClassType = getClassTypes();
+		foreach($aAddressLines as $aLine)
+		{
+			$bFallback = false;
+			$aTypeLabel = false;
+			if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
+			elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
+			elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
 			{
-				$sAddressType = $aClassType[$aClassType]['simplelabel'];
+				$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
+				$bFallback = true;
 			}
 			else
 			{
-				$sClassType = $aPlace['class'].':'.$aPlace['type'];
-				if (isset($aClassType[$sClassType]) && isset($aClassType[$sClassType]['simplelabel']))
-					$sAddressType = $aClassType[$sClassType]['simplelabel'];
-				else $sAddressType = $aPlace['class'];
+				$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
+				$bFallback = true;
+			}
+			if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
+			{
+				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
+				$sTypeLabel = str_replace(' ','_',$sTypeLabel);
+				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
+				{
+					$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
+				}
+				$aFallback[$sTypeLabel] = $bFallback;
+			}
+		}
+		return $aAddress;
+	}
+
+
+
+	// returns an array which will contain the keys
+	//   aBoundingBox
+	// and may also contain one or more of the keys
+	//   asgeojson
+	//   askml
+	//   assvg
+	//   astext
+	//   lat
+	//   lon
+	function getOutlines($iPlaceID, $fLon=null, $fLat=null, $fRadius=null)
+	{
+
+		$aOutlineResult = array();
+		if (!$iPlaceID) return $aOutlineResult;
+
+		if (CONST_Search_AreaPolygons)
+		{
+			// Get the bounding box and outline polygon
+			$sSQL  = "select place_id,0 as numfeatures,st_area(geometry) as area,";
+			$sSQL .= "ST_Y(centroid) as centrelat,ST_X(centroid) as centrelon,";
+			$sSQL .= "ST_YMin(geometry) as minlat,ST_YMax(geometry) as maxlat,";
+			$sSQL .= "ST_XMin(geometry) as minlon,ST_XMax(geometry) as maxlon";
+			if ($this->bIncludePolygonAsGeoJSON) $sSQL .= ",ST_AsGeoJSON(geometry) as asgeojson";
+			if ($this->bIncludePolygonAsKML) $sSQL .= ",ST_AsKML(geometry) as askml";
+			if ($this->bIncludePolygonAsSVG) $sSQL .= ",ST_AsSVG(geometry) as assvg";
+			if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ",ST_AsText(geometry) as astext";
+			$sFrom = " from placex where place_id = ".$iPlaceID;
+			if ($this->fPolygonSimplificationThreshold > 0)
+			{
+				$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry".$sFrom.") as plx";
+			}
+			else
+			{
+				$sSQL .= $sFrom;
 			}
 
-			$aPlace['addresstype'] = $sAddressType;
+			$aPointPolygon = chksql($this->oDB->getRow($sSQL),
+			                        "Could not get outline");
 
-			return $aPlace;
-		}
-
-		function getAddressDetails($iPlaceID, $bAll = false, $housenumber = -1)
-		{
-			$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted", $this->aLangPrefOrder))."]";
-
-			$sSQL = "select *,get_name_by_language(name,$sLanguagePrefArraySQL) as localname from get_addressdata(".$iPlaceID.",".$housenumber.")";
-			if (!$bAll) $sSQL .= " WHERE isaddress OR type = 'country_code'";
-			$sSQL .= " order by rank_address desc,isaddress desc";
-
-			return chksql($this->oDB->getAll($sSQL));
-		}
-
-		function getAddressNames($iPlaceID, $housenumber = -1)
-		{
-			$aAddressLines = $this->getAddressDetails($iPlaceID, false, $housenumber);
-
-			$aAddress = array();
-			$aFallback = array();
-			$aClassType = getClassTypes();
-			foreach($aAddressLines as $aLine)
+			if ($aPointPolygon['place_id'])
 			{
-				$bFallback = false;
-				$aTypeLabel = false;
-				if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-				elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-				elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
+				if ($aPointPolygon['centrelon'] !== null && $aPointPolygon['centrelat'] !== null )
 				{
-					$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
-					$bFallback = true;
-				}
-				else
-				{
-					$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
-					$bFallback = true;
-				}
-				if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
-				{
-					$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
-					$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-					if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
-					{
-						$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
-					}
-					$aFallback[$sTypeLabel] = $bFallback;
-				}
-			}
-			return $aAddress;
-		}
-
-
-
-		// returns an array which will contain the keys
-		//   aBoundingBox
-		// and may also contain one or more of the keys
-		//   asgeojson
-		//   askml
-		//   assvg
-		//   astext
-		//   lat
-		//   lon
-		function getOutlines($iPlaceID, $fLon=null, $fLat=null, $fRadius=null)
-		{
-
-			$aOutlineResult = array();
-			if (!$iPlaceID) return $aOutlineResult;
-
-			if (CONST_Search_AreaPolygons)
-			{
-				// Get the bounding box and outline polygon
-				$sSQL  = "select place_id,0 as numfeatures,st_area(geometry) as area,";
-				$sSQL .= "ST_Y(centroid) as centrelat,ST_X(centroid) as centrelon,";
-				$sSQL .= "ST_YMin(geometry) as minlat,ST_YMax(geometry) as maxlat,";
-				$sSQL .= "ST_XMin(geometry) as minlon,ST_XMax(geometry) as maxlon";
-				if ($this->bIncludePolygonAsGeoJSON) $sSQL .= ",ST_AsGeoJSON(geometry) as asgeojson";
-				if ($this->bIncludePolygonAsKML) $sSQL .= ",ST_AsKML(geometry) as askml";
-				if ($this->bIncludePolygonAsSVG) $sSQL .= ",ST_AsSVG(geometry) as assvg";
-				if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ",ST_AsText(geometry) as astext";
-				$sFrom = " from placex where place_id = ".$iPlaceID;
-				if ($this->fPolygonSimplificationThreshold > 0)
-				{
-					$sSQL .= " from (select place_id,centroid,ST_SimplifyPreserveTopology(geometry,".$this->fPolygonSimplificationThreshold.") as geometry".$sFrom.") as plx";
-				}
-				else
-				{
-					$sSQL .= $sFrom;
+					$aOutlineResult['lat'] = $aPointPolygon['centrelat'];
+					$aOutlineResult['lon'] = $aPointPolygon['centrelon'];
 				}
 
-				$aPointPolygon = chksql($this->oDB->getRow($sSQL),
-				                        "Could not get outline");
+				if ($this->bIncludePolygonAsGeoJSON) $aOutlineResult['asgeojson'] = $aPointPolygon['asgeojson'];
+				if ($this->bIncludePolygonAsKML) $aOutlineResult['askml'] = $aPointPolygon['askml'];
+				if ($this->bIncludePolygonAsSVG) $aOutlineResult['assvg'] = $aPointPolygon['assvg'];
+				if ($this->bIncludePolygonAsText) $aOutlineResult['astext'] = $aPointPolygon['astext'];
+				if ($this->bIncludePolygonAsPoints) $aOutlineResult['aPolyPoints'] = geometryText2Points($aPointPolygon['astext'], $fRadius);
 
-				if ($aPointPolygon['place_id'])
+
+				if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001)
 				{
-					if ($aPointPolygon['centrelon'] !== null && $aPointPolygon['centrelat'] !== null )
-					{
-						$aOutlineResult['lat'] = $aPointPolygon['centrelat'];
-						$aOutlineResult['lon'] = $aPointPolygon['centrelon'];
-					}
-
-					if ($this->bIncludePolygonAsGeoJSON) $aOutlineResult['asgeojson'] = $aPointPolygon['asgeojson'];
-					if ($this->bIncludePolygonAsKML) $aOutlineResult['askml'] = $aPointPolygon['askml'];
-					if ($this->bIncludePolygonAsSVG) $aOutlineResult['assvg'] = $aPointPolygon['assvg'];
-					if ($this->bIncludePolygonAsText) $aOutlineResult['astext'] = $aPointPolygon['astext'];
-					if ($this->bIncludePolygonAsPoints) $aOutlineResult['aPolyPoints'] = geometryText2Points($aPointPolygon['astext'], $fRadius);
-
-
-					if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001)
-					{
-						$aPointPolygon['minlat'] = $aPointPolygon['minlat'] - $fRadius;
-						$aPointPolygon['maxlat'] = $aPointPolygon['maxlat'] + $fRadius;
-					}
-					if (abs($aPointPolygon['minlon'] - $aPointPolygon['maxlon']) < 0.0000001)
-					{
-						$aPointPolygon['minlon'] = $aPointPolygon['minlon'] - $fRadius;
-						$aPointPolygon['maxlon'] = $aPointPolygon['maxlon'] + $fRadius;
-					}
-
-					$aOutlineResult['aBoundingBox'] = array(
-					                                  (string)$aPointPolygon['minlat'],
-					                                  (string)$aPointPolygon['maxlat'],
-					                                  (string)$aPointPolygon['minlon'],
-					                                  (string)$aPointPolygon['maxlon']
-					                                 );
+					$aPointPolygon['minlat'] = $aPointPolygon['minlat'] - $fRadius;
+					$aPointPolygon['maxlat'] = $aPointPolygon['maxlat'] + $fRadius;
 				}
-			} // CONST_Search_AreaPolygons
-
-			// as a fallback we generate a bounding box without knowing the size of the geometry
-			if ( (!isset($aOutlineResult['aBoundingBox'])) && isset($fLon) )
-			{
-
-				if ($this->bIncludePolygonAsPoints)
+				if (abs($aPointPolygon['minlon'] - $aPointPolygon['maxlon']) < 0.0000001)
 				{
-					$sGeometryText = 'POINT('.$fLon.','.$fLat.')';
-					$aOutlineResult['aPolyPoints'] = geometryText2Points($sGeometryText, $fRadius);
+					$aPointPolygon['minlon'] = $aPointPolygon['minlon'] - $fRadius;
+					$aPointPolygon['maxlon'] = $aPointPolygon['maxlon'] + $fRadius;
 				}
-
-				$aBounds = array();
-				$aBounds['minlat'] = $fLat - $fRadius;
-				$aBounds['maxlat'] = $fLat + $fRadius;
-				$aBounds['minlon'] = $fLon - $fRadius;
-				$aBounds['maxlon'] = $fLon + $fRadius;
 
 				$aOutlineResult['aBoundingBox'] = array(
-				                                  (string)$aBounds['minlat'],
-				                                  (string)$aBounds['maxlat'],
-				                                  (string)$aBounds['minlon'],
-				                                  (string)$aBounds['maxlon']
+				                                  (string)$aPointPolygon['minlat'],
+				                                  (string)$aPointPolygon['maxlat'],
+				                                  (string)$aPointPolygon['minlon'],
+				                                  (string)$aPointPolygon['maxlon']
 				                                 );
 			}
-			return $aOutlineResult;
+		} // CONST_Search_AreaPolygons
+
+		// as a fallback we generate a bounding box without knowing the size of the geometry
+		if ( (!isset($aOutlineResult['aBoundingBox'])) && isset($fLon) )
+		{
+
+			if ($this->bIncludePolygonAsPoints)
+			{
+				$sGeometryText = 'POINT('.$fLon.','.$fLat.')';
+				$aOutlineResult['aPolyPoints'] = geometryText2Points($sGeometryText, $fRadius);
+			}
+
+			$aBounds = array();
+			$aBounds['minlat'] = $fLat - $fRadius;
+			$aBounds['maxlat'] = $fLat + $fRadius;
+			$aBounds['minlon'] = $fLon - $fRadius;
+			$aBounds['maxlon'] = $fLon + $fRadius;
+
+			$aOutlineResult['aBoundingBox'] = array(
+			                                  (string)$aBounds['minlat'],
+			                                  (string)$aBounds['maxlat'],
+			                                  (string)$aBounds['minlon'],
+			                                  (string)$aBounds['maxlon']
+			                                 );
 		}
+		return $aOutlineResult;
 	}
+}
 ?>

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -1,144 +1,134 @@
 <?php
-	class ReverseGeocode
+
+class ReverseGeocode
+{
+	protected $oDB;
+	protected $iMaxRank = 28;
+
+	function ReverseGeocode(&$oDB)
 	{
-		protected $oDB;
-		protected $iMaxRank = 28;
+		$this->oDB =& $oDB;
+	}
 
-		function ReverseGeocode(&$oDB)
+	function setZoom($iZoom)
+	{
+		// Zoom to rank, this could probably be calculated but a lookup gives fine control
+		$aZoomRank = array(
+			0 => 2, // Continent / Sea
+			1 => 2,
+			2 => 2,
+			3 => 4, // Country
+			4 => 4,
+			5 => 8, // State
+			6 => 10, // Region
+			7 => 10,
+			8 => 12, // County
+			9 => 12,
+			10 => 17, // City
+			11 => 17,
+			12 => 18, // Town / Village
+			13 => 18,
+			14 => 22, // Suburb
+			15 => 22,
+			16 => 26, // Street, TODO: major street?
+			17 => 26,
+			18 => 30, // or >, Building
+			19 => 30, // or >, Building
+			);
+		$this->iMaxRank = (isset($iZoom) && isset($aZoomRank[$iZoom]))?$aZoomRank[$iZoom]:28;
+	}
+
+	// returns { place_id =>, type => '(osm|tiger)' }
+	// fails if no place was found
+	function lookup($fLat, $fLon, $bDoInterpolation = true)
+	{
+		$sPointSQL = 'ST_SetSRID(ST_Point('.$fLon.','.$fLat.'),4326)';
+		$iMaxRank = $this->iMaxRank;
+
+		// Find the nearest point
+		$fSearchDiam = 0.0004;
+		$iPlaceID = null;
+		$aArea = false;
+		$fMaxAreaDistance = 1;
+		$bIsInUnitedStates = false;
+		$bPlaceIsTiger = false;
+		$bPlaceIsLine = false;
+		while(!$iPlaceID && $fSearchDiam < $fMaxAreaDistance)
 		{
-			$this->oDB =& $oDB;
+			$fSearchDiam = $fSearchDiam * 2;
+
+			// If we have to expand the search area by a large amount then we need a larger feature
+			// then there is a limit to how small the feature should be
+			if ($fSearchDiam > 2 && $iMaxRank > 4) $iMaxRank = 4;
+			if ($fSearchDiam > 1 && $iMaxRank > 9) $iMaxRank = 8;
+			if ($fSearchDiam > 0.8 && $iMaxRank > 10) $iMaxRank = 10;
+			if ($fSearchDiam > 0.6 && $iMaxRank > 12) $iMaxRank = 12;
+			if ($fSearchDiam > 0.2 && $iMaxRank > 17) $iMaxRank = 17;
+			if ($fSearchDiam > 0.1 && $iMaxRank > 18) $iMaxRank = 18;
+			if ($fSearchDiam > 0.008 && $iMaxRank > 22) $iMaxRank = 22;
+			if ($fSearchDiam > 0.001 && $iMaxRank > 26) $iMaxRank = 26;
+
+			$sSQL = 'select place_id,parent_place_id,rank_search,calculated_country_code';
+			$sSQL .= ' FROM placex';
+			$sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
+			$sSQL .= ' and rank_search != 28 and rank_search >= '.$iMaxRank;
+			$sSQL .= ' and (name is not null or housenumber is not null)';
+			$sSQL .= ' and class not in (\'waterway\',\'railway\',\'tunnel\',\'bridge\',\'man_made\')';
+			$sSQL .= ' and indexed_status = 0 ';
+			$sSQL .= ' and (ST_GeometryType(geometry) not in (\'ST_Polygon\',\'ST_MultiPolygon\') ';
+			$sSQL .= ' OR ST_DWithin('.$sPointSQL.', centroid, '.$fSearchDiam.'))';
+			$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', geometry) ASC limit 1';
+			if (CONST_Debug) var_dump($sSQL);
+			$aPlace = chksql($this->oDB->getRow($sSQL),
+			                 "Could not determine closest place.");
+			$iPlaceID = $aPlace['place_id'];
+			$iParentPlaceID = $aPlace['parent_place_id'];
+			$bIsInUnitedStates = ($aPlace['calculated_country_code'] == 'us');
 		}
-
-		function setZoom($iZoom)
+		// if a street or house was found, look in interpolation lines table
+		if ($bDoInterpolation && $this->iMaxRank >= 28 && $aPlace && $aPlace['rank_search'] >= 26)
 		{
-			// Zoom to rank, this could probably be calculated but a lookup gives fine control
-			$aZoomRank = array(
-				0 => 2, // Continent / Sea
-				1 => 2,
-				2 => 2,
-				3 => 4, // Country
-				4 => 4,
-				5 => 8, // State
-				6 => 10, // Region
-				7 => 10,
-				8 => 12, // County
-				9 => 12,
-				10 => 17, // City
-				11 => 17,
-				12 => 18, // Town / Village
-				13 => 18,
-				14 => 22, // Suburb
-				15 => 22,
-				16 => 26, // Street, TODO: major street?
-				17 => 26,
-				18 => 30, // or >, Building
-				19 => 30, // or >, Building
-				);
-			$this->iMaxRank = (isset($iZoom) && isset($aZoomRank[$iZoom]))?$aZoomRank[$iZoom]:28;
-		}
-
-		// returns { place_id =>, type => '(osm|tiger)' }
-		// fails if no place was found
-		function lookup($fLat, $fLon, $bDoInterpolation = true)
-		{
-			$sPointSQL = 'ST_SetSRID(ST_Point('.$fLon.','.$fLat.'),4326)';
-			$iMaxRank = $this->iMaxRank;
-
-			// Find the nearest point
-			$fSearchDiam = 0.0004;
-			$iPlaceID = null;
-			$aArea = false;
-			$fMaxAreaDistance = 1;
-			$bIsInUnitedStates = false;
-			$bPlaceIsTiger = false;
-			$bPlaceIsLine = false;
-			while(!$iPlaceID && $fSearchDiam < $fMaxAreaDistance)
+			// if a house was found, search the interpolation line that is at least as close as the house
+			$sSQL = 'SELECT place_id, parent_place_id, 30 as rank_search, ST_line_locate_point(linegeo,'.$sPointSQL.') as fraction';
+			$sSQL .= ' FROM location_property_osmline';
+			$sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', linegeo, '.$fSearchDiam.')';
+			$sSQL .= ' and indexed_status = 0 ';
+			$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', linegeo) ASC limit 1';
+			
+			if (CONST_Debug)
 			{
-				$fSearchDiam = $fSearchDiam * 2;
+				$sSQL = preg_replace('/limit 1/', 'limit 100', $sSQL);
+				var_dump($sSQL);
 
-				// If we have to expand the search area by a large amount then we need a larger feature
-				// then there is a limit to how small the feature should be
-				if ($fSearchDiam > 2 && $iMaxRank > 4) $iMaxRank = 4;
-				if ($fSearchDiam > 1 && $iMaxRank > 9) $iMaxRank = 8;
-				if ($fSearchDiam > 0.8 && $iMaxRank > 10) $iMaxRank = 10;
-				if ($fSearchDiam > 0.6 && $iMaxRank > 12) $iMaxRank = 12;
-				if ($fSearchDiam > 0.2 && $iMaxRank > 17) $iMaxRank = 17;
-				if ($fSearchDiam > 0.1 && $iMaxRank > 18) $iMaxRank = 18;
-				if ($fSearchDiam > 0.008 && $iMaxRank > 22) $iMaxRank = 22;
-				if ($fSearchDiam > 0.001 && $iMaxRank > 26) $iMaxRank = 26;
-
-				$sSQL = 'select place_id,parent_place_id,rank_search,calculated_country_code';
-				$sSQL .= ' FROM placex';
-				$sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', geometry, '.$fSearchDiam.')';
-				$sSQL .= ' and rank_search != 28 and rank_search >= '.$iMaxRank;
-				$sSQL .= ' and (name is not null or housenumber is not null)';
-				$sSQL .= ' and class not in (\'waterway\',\'railway\',\'tunnel\',\'bridge\',\'man_made\')';
-				$sSQL .= ' and indexed_status = 0 ';
-				$sSQL .= ' and (ST_GeometryType(geometry) not in (\'ST_Polygon\',\'ST_MultiPolygon\') ';
-				$sSQL .= ' OR ST_DWithin('.$sPointSQL.', centroid, '.$fSearchDiam.'))';
-				$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', geometry) ASC limit 1';
-				if (CONST_Debug) var_dump($sSQL);
-				$aPlace = chksql($this->oDB->getRow($sSQL),
-				                 "Could not determine closest place.");
-				$iPlaceID = $aPlace['place_id'];
-				$iParentPlaceID = $aPlace['parent_place_id'];
-				$bIsInUnitedStates = ($aPlace['calculated_country_code'] == 'us');
-			}
-			// if a street or house was found, look in interpolation lines table
-			if ($bDoInterpolation && $this->iMaxRank >= 28 && $aPlace && $aPlace['rank_search'] >= 26)
-			{
-				// if a house was found, search the interpolation line that is at least as close as the house
-				$sSQL = 'SELECT place_id, parent_place_id, 30 as rank_search, ST_line_locate_point(linegeo,'.$sPointSQL.') as fraction';
-				$sSQL .= ' FROM location_property_osmline';
-				$sSQL .= ' WHERE ST_DWithin('.$sPointSQL.', linegeo, '.$fSearchDiam.')';
-				$sSQL .= ' and indexed_status = 0 ';
-				$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', linegeo) ASC limit 1';
-				
-				if (CONST_Debug)
+				$aAllHouses = chksql($this->oDB->getAll($sSQL));
+				foreach($aAllHouses as $i)
 				{
-					$sSQL = preg_replace('/limit 1/', 'limit 100', $sSQL);
-					var_dump($sSQL);
-
-					$aAllHouses = chksql($this->oDB->getAll($sSQL));
-					foreach($aAllHouses as $i)
-					{
-						echo $i['housenumber'] . ' | ' . $i['distance'] * 1000 . ' | ' . $i['lat'] . ' | ' . $i['lon']. ' | '. "<br>\n";
-					}
+					echo $i['housenumber'] . ' | ' . $i['distance'] * 1000 . ' | ' . $i['lat'] . ' | ' . $i['lon']. ' | '. "<br>\n";
 				}
-				$aPlaceLine = chksql($this->oDB->getRow($sSQL),
-				                     "Could not determine closest housenumber on an osm interpolation line.");
-				if ($aPlaceLine)
+			}
+			$aPlaceLine = chksql($this->oDB->getRow($sSQL),
+			                     "Could not determine closest housenumber on an osm interpolation line.");
+			if ($aPlaceLine)
+			{
+				if (CONST_Debug) var_dump('found housenumber in interpolation lines table', $aPlaceLine);
+				if ($aPlace['rank_search'] == 30)
 				{
-					if (CONST_Debug) var_dump('found housenumber in interpolation lines table', $aPlaceLine);
-					if ($aPlace['rank_search'] == 30)
+					// if a house was already found in placex, we have to find out, 
+					// if the placex house or the interpolated house are closer to the searched point
+					// distance between point and placex house
+					$sSQL = 'SELECT ST_distance('.$sPointSQL.', house.geometry) as distance FROM placex as house WHERE house.place_id='.$iPlaceID;
+					$aDistancePlacex = chksql($this->oDB->getRow($sSQL),
+					                          "Could not determine distance between searched point and placex house.");
+					$fDistancePlacex = $aDistancePlacex['distance'];
+					// distance between point and interpolated house (fraction on interpolation line)
+					$sSQL = 'SELECT ST_distance('.$sPointSQL.', ST_LineInterpolatePoint(linegeo, '.$aPlaceLine['fraction'].')) as distance';
+					$sSQL .= ' FROM location_property_osmline WHERE place_id = '.$aPlaceLine['place_id'];
+					$aDistanceInterpolation = chksql($this->oDB->getRow($sSQL),
+					                                 "Could not determine distance between searched point and interpolated house.");
+					$fDistanceInterpolation = $aDistanceInterpolation['distance'];
+					if ($fDistanceInterpolation < $fDistancePlacex)
 					{
-						// if a house was already found in placex, we have to find out, 
-						// if the placex house or the interpolated house are closer to the searched point
-						// distance between point and placex house
-						$sSQL = 'SELECT ST_distance('.$sPointSQL.', house.geometry) as distance FROM placex as house WHERE house.place_id='.$iPlaceID;
-						$aDistancePlacex = chksql($this->oDB->getRow($sSQL),
-						                          "Could not determine distance between searched point and placex house.");
-						$fDistancePlacex = $aDistancePlacex['distance'];
-						// distance between point and interpolated house (fraction on interpolation line)
-						$sSQL = 'SELECT ST_distance('.$sPointSQL.', ST_LineInterpolatePoint(linegeo, '.$aPlaceLine['fraction'].')) as distance';
-						$sSQL .= ' FROM location_property_osmline WHERE place_id = '.$aPlaceLine['place_id'];
-						$aDistanceInterpolation = chksql($this->oDB->getRow($sSQL),
-						                                 "Could not determine distance between searched point and interpolated house.");
-						$fDistanceInterpolation = $aDistanceInterpolation['distance'];
-						if ($fDistanceInterpolation < $fDistancePlacex)
-						{
-							// interpolation is closer to point than placex house
-							$bPlaceIsLine = true;
-							$aPlace = $aPlaceLine;
-							$iPlaceID = $aPlaceLine['place_id'];
-							$iParentPlaceID = $aPlaceLine['parent_place_id']; // the street
-							$fFraction = $aPlaceLine['fraction'];
-							$iMaxRank = 30;
-						}
-						// else: nothing to do, take placex house from above
-					}
-					else
-					{
+						// interpolation is closer to point than placex house
 						$bPlaceIsLine = true;
 						$aPlace = $aPlaceLine;
 						$iPlaceID = $aPlaceLine['place_id'];
@@ -146,68 +136,79 @@
 						$fFraction = $aPlaceLine['fraction'];
 						$iMaxRank = 30;
 					}
+					// else: nothing to do, take placex house from above
 				}
-			}
-			
-			// Only street found? If it's in the US we can check TIGER data for nearest housenumber
-			if (CONST_Use_US_Tiger_Data && $bDoInterpolation && $bIsInUnitedStates && $this->iMaxRank >= 28 && $iPlaceID && ($aPlace['rank_search'] == 26 || $aPlace['rank_search'] == 27 ))
-			{
-				$fSearchDiam = 0.001;
-				$sSQL = 'SELECT place_id,parent_place_id,30 as rank_search, ST_line_locate_point(linegeo,'.$sPointSQL.') as fraction';
-				//if (CONST_Debug) { $sSQL .= ', housenumber, ST_distance('.$sPointSQL.', centroid) as distance, st_y(centroid) as lat, st_x(centroid) as lon'; }
-				$sSQL .= ' FROM location_property_tiger WHERE parent_place_id = '.$iPlaceID;
-				$sSQL .= ' AND ST_DWithin('.$sPointSQL.', linegeo, '.$fSearchDiam.')';  //no centroid anymore in Tiger data, now we have lines
-				$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', linegeo) ASC limit 1';
-
-				if (CONST_Debug)
+				else
 				{
-					$sSQL = preg_replace('/limit 1/', 'limit 100', $sSQL);
-					var_dump($sSQL);
-
-					$aAllHouses = chksql($this->oDB->getAll($sSQL));
-					foreach($aAllHouses as $i)
-					{
-						echo $i['housenumber'] . ' | ' . $i['distance'] * 1000 . ' | ' . $i['lat'] . ' | ' . $i['lon']. ' | '. "<br>\n";
-					}
-				}
-
-				$aPlaceTiger = chksql($this->oDB->getRow($sSQL),
-				                      "Could not determine closest Tiger place.");
-				if ($aPlaceTiger)
-				{
-					if (CONST_Debug) var_dump('found Tiger housenumber', $aPlaceTiger);
-					$bPlaceIsTiger = true;
-					$aPlace = $aPlaceTiger;
-					$iPlaceID = $aPlaceTiger['place_id'];
-					$iParentPlaceID = $aPlaceTiger['parent_place_id']; // the street
-					$fFraction = $aPlaceTiger['fraction'];
+					$bPlaceIsLine = true;
+					$aPlace = $aPlaceLine;
+					$iPlaceID = $aPlaceLine['place_id'];
+					$iParentPlaceID = $aPlaceLine['parent_place_id']; // the street
+					$fFraction = $aPlaceLine['fraction'];
 					$iMaxRank = 30;
 				}
 			}
-
-			// The point we found might be too small - use the address to find what it is a child of
-			if ($iPlaceID && $iMaxRank < 28)
-			{
-				if (($aPlace['rank_search'] > 28 || $bPlaceIsTiger || $bPlaceIsLine) && $iParentPlaceID)
-				{
-					$iPlaceID = $iParentPlaceID;
-				}
-				$sSQL  = 'select address_place_id';
-				$sSQL .= ' FROM place_addressline';
-				$sSQL .= " WHERE place_id = $iPlaceID";
-				$sSQL .= " ORDER BY abs(cached_rank_address - $iMaxRank) asc,cached_rank_address desc,isaddress desc,distance desc";
-				$sSQL .= ' LIMIT 1';
-				$iPlaceID = chksql($this->oDB->getOne($sSQL),
-				                   "Could not get parent for place.");
-				if (!$iPlaceID)
-				{
-					$iPlaceID = $aPlace['place_id'];
-				}
-			}
-			return array('place_id' => $iPlaceID,
-						'type' => $bPlaceIsTiger ? 'tiger' : ($bPlaceIsLine ? 'interpolation' : 'osm'),
-						'fraction' => ($bPlaceIsTiger || $bPlaceIsLine) ? $fFraction : -1);
 		}
 		
+		// Only street found? If it's in the US we can check TIGER data for nearest housenumber
+		if (CONST_Use_US_Tiger_Data && $bDoInterpolation && $bIsInUnitedStates && $this->iMaxRank >= 28 && $iPlaceID && ($aPlace['rank_search'] == 26 || $aPlace['rank_search'] == 27 ))
+		{
+			$fSearchDiam = 0.001;
+			$sSQL = 'SELECT place_id,parent_place_id,30 as rank_search, ST_line_locate_point(linegeo,'.$sPointSQL.') as fraction';
+			//if (CONST_Debug) { $sSQL .= ', housenumber, ST_distance('.$sPointSQL.', centroid) as distance, st_y(centroid) as lat, st_x(centroid) as lon'; }
+			$sSQL .= ' FROM location_property_tiger WHERE parent_place_id = '.$iPlaceID;
+			$sSQL .= ' AND ST_DWithin('.$sPointSQL.', linegeo, '.$fSearchDiam.')';  //no centroid anymore in Tiger data, now we have lines
+			$sSQL .= ' ORDER BY ST_distance('.$sPointSQL.', linegeo) ASC limit 1';
+
+			if (CONST_Debug)
+			{
+				$sSQL = preg_replace('/limit 1/', 'limit 100', $sSQL);
+				var_dump($sSQL);
+
+				$aAllHouses = chksql($this->oDB->getAll($sSQL));
+				foreach($aAllHouses as $i)
+				{
+					echo $i['housenumber'] . ' | ' . $i['distance'] * 1000 . ' | ' . $i['lat'] . ' | ' . $i['lon']. ' | '. "<br>\n";
+				}
+			}
+
+			$aPlaceTiger = chksql($this->oDB->getRow($sSQL),
+			                      "Could not determine closest Tiger place.");
+			if ($aPlaceTiger)
+			{
+				if (CONST_Debug) var_dump('found Tiger housenumber', $aPlaceTiger);
+				$bPlaceIsTiger = true;
+				$aPlace = $aPlaceTiger;
+				$iPlaceID = $aPlaceTiger['place_id'];
+				$iParentPlaceID = $aPlaceTiger['parent_place_id']; // the street
+				$fFraction = $aPlaceTiger['fraction'];
+				$iMaxRank = 30;
+			}
+		}
+
+		// The point we found might be too small - use the address to find what it is a child of
+		if ($iPlaceID && $iMaxRank < 28)
+		{
+			if (($aPlace['rank_search'] > 28 || $bPlaceIsTiger || $bPlaceIsLine) && $iParentPlaceID)
+			{
+				$iPlaceID = $iParentPlaceID;
+			}
+			$sSQL  = 'select address_place_id';
+			$sSQL .= ' FROM place_addressline';
+			$sSQL .= " WHERE place_id = $iPlaceID";
+			$sSQL .= " ORDER BY abs(cached_rank_address - $iMaxRank) asc,cached_rank_address desc,isaddress desc,distance desc";
+			$sSQL .= ' LIMIT 1';
+			$iPlaceID = chksql($this->oDB->getOne($sSQL),
+			                   "Could not get parent for place.");
+			if (!$iPlaceID)
+			{
+				$iPlaceID = $aPlace['place_id'];
+			}
+		}
+		return array('place_id' => $iPlaceID,
+					'type' => $bPlaceIsTiger ? 'tiger' : ($bPlaceIsLine ? 'interpolation' : 'osm'),
+					'fraction' => ($bPlaceIsTiger || $bPlaceIsLine) ? $fFraction : -1);
 	}
+	
+}
 ?>

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -5,10 +5,8 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 	$aQuick = array();
 	$aCounts = array();
 
-	foreach($aSpec as $aLine)
-	{
-		if (is_array($aLine))
-		{
+	foreach ($aSpec as $aLine) {
+		if (is_array($aLine)) {
 			if ($aLine[0]) $aQuick['--'.$aLine[0]] = $aLine;
 			if ($aLine[1]) $aQuick['-'.$aLine[1]] = $aLine;
 			$aCounts[$aLine[0]] = 0;
@@ -18,73 +16,57 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 	$aResult = array();
 	$bUnknown = false;
 	$iSize = sizeof($aArg);
-	for ($i = 1; $i < $iSize; $i++)
-	{
-		if (isset($aQuick[$aArg[$i]]))
-		{
+	for ($i = 1; $i < $iSize; $i++) {
+		if (isset($aQuick[$aArg[$i]])) {
 			$aLine = $aQuick[$aArg[$i]];
 			$aCounts[$aLine[0]]++;
 			$xVal = null;
-			if ($aLine[4] == $aLine[5])
-			{
-				if ($aLine[4])
-				{
+			if ($aLine[4] == $aLine[5]) {
+				if ($aLine[4]) {
 					$xVal = array();
-					for($n = $aLine[4]; $i < $iSize && $n; $n--)
-					{
+					for ($n = $aLine[4]; $i < $iSize && $n; $n--) {
 						$i++;
 						if ($i >= $iSize || $aArg[$i][0] == '-') showUsage($aSpec, $bExitOnError, 'Parameter of  \''.$aLine[0].'\' is missing');
 
-						switch ($aLine[6])
-						{
-						case 'realpath':
-							$xVal[] = realpath($aArg[$i]);
-							break;
-						case 'realdir':
-							$sPath = realpath(dirname($aArg[$i]));
-							if ($sPath)
-								$xVal[] = $sPath . '/' . basename($aArg[$i]);
-							else
-								$xVal[] = $sPath;
-							break;
-						case 'bool':
-							$xVal[] = (bool)$aArg[$i];
-							break;
-						case 'int':
-							$xVal[] = (int)$aArg[$i];
-							break;
-						case 'float':
-							$xVal[] = (float)$aArg[$i];
-							break;
-						default:
-							$xVal[] = $aArg[$i];
-							break;
+						switch ($aLine[6]) {
+							case 'realpath':
+								$xVal[] = realpath($aArg[$i]);
+								break;
+							case 'realdir':
+								$sPath = realpath(dirname($aArg[$i]));
+								if ($sPath)
+									$xVal[] = $sPath . '/' . basename($aArg[$i]);
+								else $xVal[] = $sPath;
+								break;
+							case 'bool':
+								$xVal[] = (bool)$aArg[$i];
+								break;
+							case 'int':
+								$xVal[] = (int)$aArg[$i];
+								break;
+							case 'float':
+								$xVal[] = (float)$aArg[$i];
+								break;
+							default:
+								$xVal[] = $aArg[$i];
+								break;
 						}
 					}
 					if ($aLine[4] == 1) $xVal = $xVal[0];
-				}
-				else
-				{
+				} else {
 					$xVal = true;
 				}
-			}
-			else
-			{
+			} else {
 				fail('Variable numbers of params not yet supported');
 			}
 
-			if ($aLine[3] > 1)
-			{
+			if ($aLine[3] > 1) {
 				if (!array_key_exists($aLine[0], $aResult)) $aResult[$aLine[0]] = array();
 				$aResult[$aLine[0]][] = $xVal;
-			}
-			else
-			{
+			} else {
 				$aResult[$aLine[0]] = $xVal;
 			}
-		}
-		else
-		{
+		} else {
 			$bUnknown = $aArg[$i];
 		}
 	}
@@ -92,18 +74,15 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 	if (array_key_exists('help', $aResult)) showUsage($aSpec);
 	if ($bUnknown && $bExitOnUnknown) showUsage($aSpec, $bExitOnError, 'Unknown option \''.$bUnknown.'\'');
 
-	foreach($aSpec as $aLine)
-	{
-		if (is_array($aLine))
-		{
+	foreach ($aSpec as $aLine) {
+		if (is_array($aLine)) {
 			if ($aCounts[$aLine[0]] < $aLine[2]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is missing');
 			if ($aCounts[$aLine[0]] > $aLine[3]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is pressent too many times');
-			switch ($aLine[6])
-			{
-			case 'bool':
-				if (!array_key_exists($aLine[0], $aResult))
-					$aResult[$aLine[0]] = false;
-				break;
+			switch ($aLine[6]) {
+				case 'bool':
+					if (!array_key_exists($aLine[0], $aResult))
+						$aResult[$aLine[0]] = false;
+					break;
 			}
 		}
 	}
@@ -112,31 +91,25 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 
 function showUsage($aSpec, $bExit = false, $sError = false)
 {
-	if ($sError)
-	{
+	if ($sError) {
 		echo basename($_SERVER['argv'][0]).': '.$sError."\n";
 		echo 'Try `'.basename($_SERVER['argv'][0]).' --help` for more information.'."\n";
 		exit;
 	}
 	echo "Usage: ".basename($_SERVER['argv'][0])."\n";
 	$bFirst = true;
-	foreach($aSpec as $aLine)
-	{
-		if (is_array($aLine))
-		{
-			if ($bFirst)
-			{
+	foreach ($aSpec as $aLine) {
+		if (is_array($aLine)) {
+			if ($bFirst) {
 				$bFirst = false;
 				echo "\n";
 			}
 			$aNames = array();
 			if ($aLine[1]) $aNames[] = '-'.$aLine[1];
 			if ($aLine[0]) $aNames[] = '--'.$aLine[0];
-			$sName = join(', ',$aNames);
-			echo '  '.$sName.str_repeat(' ',30-strlen($sName)).$aLine[7]."\n";
-		}
-		else
-		{
+			$sName = join(', ', $aNames);
+			echo '  '.$sName.str_repeat(' ', 30-strlen($sName)).$aLine[7]."\n";
+		} else {
 			echo $aLine."\n";
 		}
 	}
@@ -146,8 +119,7 @@ function showUsage($aSpec, $bExit = false, $sError = false)
 
 function chksql($oSql, $sMsg = false)
 {
-	if (PEAR::isError($oSql))
-	{
+	if (PEAR::isError($oSql)) {
 		fail($sMsg || $oSql->getMessage(), $oSql->userinfo);
 	}
 

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -1,155 +1,155 @@
 <?php
 
-	function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnknown = false)
+function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnknown = false)
+{
+	$aQuick = array();
+	$aCounts = array();
+
+	foreach($aSpec as $aLine)
 	{
-		$aQuick = array();
-		$aCounts = array();
-
-		foreach($aSpec as $aLine)
+		if (is_array($aLine))
 		{
-			if (is_array($aLine))
-			{
-				if ($aLine[0]) $aQuick['--'.$aLine[0]] = $aLine;
-				if ($aLine[1]) $aQuick['-'.$aLine[1]] = $aLine;
-				$aCounts[$aLine[0]] = 0;
-			}
+			if ($aLine[0]) $aQuick['--'.$aLine[0]] = $aLine;
+			if ($aLine[1]) $aQuick['-'.$aLine[1]] = $aLine;
+			$aCounts[$aLine[0]] = 0;
 		}
-
-		$aResult = array();
-		$bUnknown = false;
-		$iSize = sizeof($aArg);
-		for ($i = 1; $i < $iSize; $i++)
-		{
-			if (isset($aQuick[$aArg[$i]]))
-			{
-				$aLine = $aQuick[$aArg[$i]];
-				$aCounts[$aLine[0]]++;
-				$xVal = null;
-				if ($aLine[4] == $aLine[5])
-				{
-					if ($aLine[4])
-					{
-						$xVal = array();
-						for($n = $aLine[4]; $i < $iSize && $n; $n--)
-						{
-							$i++;
-							if ($i >= $iSize || $aArg[$i][0] == '-') showUsage($aSpec, $bExitOnError, 'Parameter of  \''.$aLine[0].'\' is missing');
-
-							switch ($aLine[6])
-							{
-							case 'realpath':
-								$xVal[] = realpath($aArg[$i]);
-								break;
-							case 'realdir':
-								$sPath = realpath(dirname($aArg[$i]));
-								if ($sPath)
-									$xVal[] = $sPath . '/' . basename($aArg[$i]);
-								else
-									$xVal[] = $sPath;
-								break;
-							case 'bool':
-								$xVal[] = (bool)$aArg[$i];
-								break;
-							case 'int':
-								$xVal[] = (int)$aArg[$i];
-								break;
-							case 'float':
-								$xVal[] = (float)$aArg[$i];
-								break;
-							default:
-								$xVal[] = $aArg[$i];
-								break;
-							}
-						}
-						if ($aLine[4] == 1) $xVal = $xVal[0];
-					}
-					else
-					{
-						$xVal = true;
-					}
-				}
-				else
-				{
-					fail('Variable numbers of params not yet supported');
-				}
-
-				if ($aLine[3] > 1)
-				{
-					if (!array_key_exists($aLine[0], $aResult)) $aResult[$aLine[0]] = array();
-					$aResult[$aLine[0]][] = $xVal;
-				}
-				else
-				{
-					$aResult[$aLine[0]] = $xVal;
-				}
-			}
-			else
-			{
-				$bUnknown = $aArg[$i];
-			}
-		}
-
-		if (array_key_exists('help', $aResult)) showUsage($aSpec);
-		if ($bUnknown && $bExitOnUnknown) showUsage($aSpec, $bExitOnError, 'Unknown option \''.$bUnknown.'\'');
-
-		foreach($aSpec as $aLine)
-		{
-			if (is_array($aLine))
-			{
-				if ($aCounts[$aLine[0]] < $aLine[2]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is missing');
-				if ($aCounts[$aLine[0]] > $aLine[3]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is pressent too many times');
-				switch ($aLine[6])
-				{
-				case 'bool':
-					if (!array_key_exists($aLine[0], $aResult))
-						$aResult[$aLine[0]] = false;
-					break;
-				}
-			}
-		}
-		return $bUnknown;
 	}
 
-	function showUsage($aSpec, $bExit = false, $sError = false)
+	$aResult = array();
+	$bUnknown = false;
+	$iSize = sizeof($aArg);
+	for ($i = 1; $i < $iSize; $i++)
 	{
-		if ($sError)
+		if (isset($aQuick[$aArg[$i]]))
 		{
-			echo basename($_SERVER['argv'][0]).': '.$sError."\n";
-			echo 'Try `'.basename($_SERVER['argv'][0]).' --help` for more information.'."\n";
-			exit;
-		}
-		echo "Usage: ".basename($_SERVER['argv'][0])."\n";
-		$bFirst = true;
-		foreach($aSpec as $aLine)
-		{
-			if (is_array($aLine))
+			$aLine = $aQuick[$aArg[$i]];
+			$aCounts[$aLine[0]]++;
+			$xVal = null;
+			if ($aLine[4] == $aLine[5])
 			{
-				if ($bFirst)
+				if ($aLine[4])
 				{
-					$bFirst = false;
-					echo "\n";
+					$xVal = array();
+					for($n = $aLine[4]; $i < $iSize && $n; $n--)
+					{
+						$i++;
+						if ($i >= $iSize || $aArg[$i][0] == '-') showUsage($aSpec, $bExitOnError, 'Parameter of  \''.$aLine[0].'\' is missing');
+
+						switch ($aLine[6])
+						{
+						case 'realpath':
+							$xVal[] = realpath($aArg[$i]);
+							break;
+						case 'realdir':
+							$sPath = realpath(dirname($aArg[$i]));
+							if ($sPath)
+								$xVal[] = $sPath . '/' . basename($aArg[$i]);
+							else
+								$xVal[] = $sPath;
+							break;
+						case 'bool':
+							$xVal[] = (bool)$aArg[$i];
+							break;
+						case 'int':
+							$xVal[] = (int)$aArg[$i];
+							break;
+						case 'float':
+							$xVal[] = (float)$aArg[$i];
+							break;
+						default:
+							$xVal[] = $aArg[$i];
+							break;
+						}
+					}
+					if ($aLine[4] == 1) $xVal = $xVal[0];
 				}
-				$aNames = array();
-				if ($aLine[1]) $aNames[] = '-'.$aLine[1];
-				if ($aLine[0]) $aNames[] = '--'.$aLine[0];
-				$sName = join(', ',$aNames);
-				echo '  '.$sName.str_repeat(' ',30-strlen($sName)).$aLine[7]."\n";
+				else
+				{
+					$xVal = true;
+				}
 			}
 			else
 			{
-				echo $aLine."\n";
+				fail('Variable numbers of params not yet supported');
+			}
+
+			if ($aLine[3] > 1)
+			{
+				if (!array_key_exists($aLine[0], $aResult)) $aResult[$aLine[0]] = array();
+				$aResult[$aLine[0]][] = $xVal;
+			}
+			else
+			{
+				$aResult[$aLine[0]] = $xVal;
 			}
 		}
-		echo "\n";
+		else
+		{
+			$bUnknown = $aArg[$i];
+		}
+	}
+
+	if (array_key_exists('help', $aResult)) showUsage($aSpec);
+	if ($bUnknown && $bExitOnUnknown) showUsage($aSpec, $bExitOnError, 'Unknown option \''.$bUnknown.'\'');
+
+	foreach($aSpec as $aLine)
+	{
+		if (is_array($aLine))
+		{
+			if ($aCounts[$aLine[0]] < $aLine[2]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is missing');
+			if ($aCounts[$aLine[0]] > $aLine[3]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is pressent too many times');
+			switch ($aLine[6])
+			{
+			case 'bool':
+				if (!array_key_exists($aLine[0], $aResult))
+					$aResult[$aLine[0]] = false;
+				break;
+			}
+		}
+	}
+	return $bUnknown;
+}
+
+function showUsage($aSpec, $bExit = false, $sError = false)
+{
+	if ($sError)
+	{
+		echo basename($_SERVER['argv'][0]).': '.$sError."\n";
+		echo 'Try `'.basename($_SERVER['argv'][0]).' --help` for more information.'."\n";
 		exit;
 	}
-
-	function chksql($oSql, $sMsg = false)
+	echo "Usage: ".basename($_SERVER['argv'][0])."\n";
+	$bFirst = true;
+	foreach($aSpec as $aLine)
 	{
-		if (PEAR::isError($oSql))
+		if (is_array($aLine))
 		{
-			fail($sMsg || $oSql->getMessage(), $oSql->userinfo);
+			if ($bFirst)
+			{
+				$bFirst = false;
+				echo "\n";
+			}
+			$aNames = array();
+			if ($aLine[1]) $aNames[] = '-'.$aLine[1];
+			if ($aLine[0]) $aNames[] = '--'.$aLine[0];
+			$sName = join(', ',$aNames);
+			echo '  '.$sName.str_repeat(' ',30-strlen($sName)).$aLine[7]."\n";
 		}
-
-		return $oSql;
+		else
+		{
+			echo $aLine."\n";
+		}
 	}
+	echo "\n";
+	exit;
+}
+
+function chksql($oSql, $sMsg = false)
+{
+	if (PEAR::isError($oSql))
+	{
+		fail($sMsg || $oSql->getMessage(), $oSql->userinfo);
+	}
+
+	return $oSql;
+}

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnknown = false)
 {
 	$aQuick = array();
@@ -29,36 +30,37 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 						if ($i >= $iSize || $aArg[$i][0] == '-') showUsage($aSpec, $bExitOnError, 'Parameter of  \''.$aLine[0].'\' is missing');
 
 						switch ($aLine[6]) {
-							case 'realpath':
-								$xVal[] = realpath($aArg[$i]);
-								break;
-							case 'realdir':
-								$sPath = realpath(dirname($aArg[$i]));
-								if ($sPath)
-									$xVal[] = $sPath . '/' . basename($aArg[$i]);
-								else $xVal[] = $sPath;
-								break;
-							case 'bool':
-								$xVal[] = (bool)$aArg[$i];
-								break;
-							case 'int':
-								$xVal[] = (int)$aArg[$i];
-								break;
-							case 'float':
-								$xVal[] = (float)$aArg[$i];
-								break;
-							default:
-								$xVal[] = $aArg[$i];
-								break;
-						}
-					}
+						case 'realpath':
+							$xVal[] = realpath($aArg[$i]);
+							break;
+						case 'realdir':
+							$sPath = realpath(dirname($aArg[$i]));
+							if ($sPath)
+								$xVal[] = $sPath.'/'.basename($aArg[$i]);
+							else $xVal[] = $sPath;
+							break;
+						case 'bool':
+							$xVal[] = (bool) $aArg[$i];
+							break;
+						case 'int':
+							$xVal[] = (int) $aArg[$i];
+							break;
+						case 'float':
+							$xVal[] = (float) $aArg[$i];
+							break;
+						default:
+							$xVal[] = $aArg[$i];
+							break;
+						}//end switch
+					}//end for
+
 					if ($aLine[4] == 1) $xVal = $xVal[0];
 				} else {
 					$xVal = true;
-				}
+				}//end if
 			} else {
 				fail('Variable numbers of params not yet supported');
-			}
+			}//end if
 
 			if ($aLine[3] > 1) {
 				if (!array_key_exists($aLine[0], $aResult)) $aResult[$aLine[0]] = array();
@@ -68,8 +70,8 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 			}
 		} else {
 			$bUnknown = $aArg[$i];
-		}
-	}
+		}//end if
+	}//end for
 
 	if (array_key_exists('help', $aResult)) showUsage($aSpec);
 	if ($bUnknown && $bExitOnUnknown) showUsage($aSpec, $bExitOnError, 'Unknown option \''.$bUnknown.'\'');
@@ -79,15 +81,18 @@ function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnkn
 			if ($aCounts[$aLine[0]] < $aLine[2]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is missing');
 			if ($aCounts[$aLine[0]] > $aLine[3]) showUsage($aSpec, $bExitOnError, 'Option \''.$aLine[0].'\' is pressent too many times');
 			switch ($aLine[6]) {
-				case 'bool':
-					if (!array_key_exists($aLine[0], $aResult))
-						$aResult[$aLine[0]] = false;
-					break;
+			case 'bool':
+				if (!array_key_exists($aLine[0], $aResult))
+					$aResult[$aLine[0]] = false;
+				break;
 			}
 		}
 	}
+
 	return $bUnknown;
-}
+
+}//end getCmdOpt()
+
 
 function showUsage($aSpec, $bExit = false, $sError = false)
 {
@@ -96,6 +101,7 @@ function showUsage($aSpec, $bExit = false, $sError = false)
 		echo 'Try `'.basename($_SERVER['argv'][0]).' --help` for more information.'."\n";
 		exit;
 	}
+
 	echo "Usage: ".basename($_SERVER['argv'][0])."\n";
 	$bFirst = true;
 	foreach ($aSpec as $aLine) {
@@ -104,18 +110,22 @@ function showUsage($aSpec, $bExit = false, $sError = false)
 				$bFirst = false;
 				echo "\n";
 			}
+
 			$aNames = array();
 			if ($aLine[1]) $aNames[] = '-'.$aLine[1];
 			if ($aLine[0]) $aNames[] = '--'.$aLine[0];
 			$sName = join(', ', $aNames);
-			echo '  '.$sName.str_repeat(' ', 30-strlen($sName)).$aLine[7]."\n";
+			echo '  '.$sName.str_repeat(' ', (30 - strlen($sName))).$aLine[7]."\n";
 		} else {
 			echo $aLine."\n";
 		}
 	}
+
 	echo "\n";
 	exit;
-}
+
+}//end showUsage()
+
 
 function chksql($oSql, $sMsg = false)
 {
@@ -124,4 +134,5 @@ function chksql($oSql, $sMsg = false)
 	}
 
 	return $oSql;
-}
+
+}//end chksql()

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,34 +1,35 @@
 <?php
-	require_once('DB.php');
 
-	function &getDB($bNew = false, $bPersistent = false)
-	{
-		// Get the database object
-		$oDB = chksql(DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
-		              "Failed to establish database connection");
-		$oDB->setFetchMode(DB_FETCHMODE_ASSOC);
-		$oDB->query("SET DateStyle TO 'sql,european'");
-		$oDB->query("SET client_encoding TO 'utf-8'");
-		$iMaxExecution = ini_get('max_execution_time') * 1000;
-		if ($iMaxExecution > 0) $oDB->query("SET statement_timeout TO $iMaxExecution");
-		return $oDB;
-	}
+require_once('DB.php');
 
-	function getDBQuoted($s)
-	{
-		return "'".pg_escape_string($s)."'";
-	}
+function &getDB($bNew = false, $bPersistent = false)
+{
+	// Get the database object
+	$oDB = chksql(DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
+	              "Failed to establish database connection");
+	$oDB->setFetchMode(DB_FETCHMODE_ASSOC);
+	$oDB->query("SET DateStyle TO 'sql,european'");
+	$oDB->query("SET client_encoding TO 'utf-8'");
+	$iMaxExecution = ini_get('max_execution_time') * 1000;
+	if ($iMaxExecution > 0) $oDB->query("SET statement_timeout TO $iMaxExecution");
+	return $oDB;
+}
 
-	function getPostgresVersion(&$oDB)
-	{
-		$sVersionString = $oDB->getOne('select version()');
-		preg_match('#PostgreSQL ([0-9]+)[.]([0-9]+)[^0-9]#', $sVersionString, $aMatches);
-		return (float) ($aMatches[1].'.'.$aMatches[2]);
-	}
+function getDBQuoted($s)
+{
+	return "'".pg_escape_string($s)."'";
+}
 
-	function getPostgisVersion(&$oDB)
-	{
-		$sVersionString = $oDB->getOne('select postgis_full_version()');
-		preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)( r([0-9]+))?"#', $sVersionString, $aMatches);
-		return (float) ($aMatches[1].'.'.$aMatches[2]);
-	}
+function getPostgresVersion(&$oDB)
+{
+	$sVersionString = $oDB->getOne('select version()');
+	preg_match('#PostgreSQL ([0-9]+)[.]([0-9]+)[^0-9]#', $sVersionString, $aMatches);
+	return (float) ($aMatches[1].'.'.$aMatches[2]);
+}
+
+function getPostgisVersion(&$oDB)
+{
+	$sVersionString = $oDB->getOne('select postgis_full_version()');
+	preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)( r([0-9]+))?"#', $sVersionString, $aMatches);
+	return (float) ($aMatches[1].'.'.$aMatches[2]);
+}

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,37 +1,45 @@
 <?php
 
-require_once('DB.php');
+require_once 'DB.php';
+
 
 function &getDB($bNew = false, $bPersistent = false)
 {
 	// Get the database object
 	$oDB = chksql(
-		DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
+		DB::connect(CONST_Database_DSN.($bNew ? '?new_link=true' : ''), $bPersistent),
 		"Failed to establish database connection"
 	);
 	$oDB->setFetchMode(DB_FETCHMODE_ASSOC);
 	$oDB->query("SET DateStyle TO 'sql,european'");
 	$oDB->query("SET client_encoding TO 'utf-8'");
-	$iMaxExecution = ini_get('max_execution_time') * 1000;
+	$iMaxExecution = (ini_get('max_execution_time') * 1000);
 	if ($iMaxExecution > 0) $oDB->query("SET statement_timeout TO $iMaxExecution");
 	return $oDB;
-}
+
+}//end getDB()
+
 
 function getDBQuoted($s)
 {
 	return "'".pg_escape_string($s)."'";
-}
+
+}//end getDBQuoted()
+
 
 function getPostgresVersion(&$oDB)
 {
 	$sVersionString = $oDB->getOne('select version()');
 	preg_match('#PostgreSQL ([0-9]+)[.]([0-9]+)[^0-9]#', $sVersionString, $aMatches);
 	return (float) ($aMatches[1].'.'.$aMatches[2]);
-}
+
+}//end getPostgresVersion()
+
 
 function getPostgisVersion(&$oDB)
 {
 	$sVersionString = $oDB->getOne('select postgis_full_version()');
 	preg_match('#POSTGIS="([0-9]+)[.]([0-9]+)[.]([0-9]+)( r([0-9]+))?"#', $sVersionString, $aMatches);
 	return (float) ($aMatches[1].'.'.$aMatches[2]);
-}
+
+}//end getPostgisVersion()

--- a/lib/db.php
+++ b/lib/db.php
@@ -5,8 +5,10 @@ require_once('DB.php');
 function &getDB($bNew = false, $bPersistent = false)
 {
 	// Get the database object
-	$oDB = chksql(DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
-	              "Failed to establish database connection");
+	$oDB = chksql(
+		DB::connect(CONST_Database_DSN.($bNew?'?new_link=true':''), $bPersistent),
+		"Failed to establish database connection"
+	);
 	$oDB->setFetchMode(DB_FETCHMODE_ASSOC);
 	$oDB->query("SET DateStyle TO 'sql,european'");
 	$oDB->query("SET client_encoding TO 'utf-8'");

--- a/lib/init-cmd.php
+++ b/lib/init-cmd.php
@@ -1,27 +1,28 @@
 <?php
 
-require_once('init.php');
-require_once('cmd.php');
+require_once 'init.php';
+require_once 'cmd.php';
 
 // handle http proxy when using file_get_contents
 if (CONST_HTTP_Proxy) {
-	$proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
+	$proxy = 'tcp://'.CONST_HTTP_Proxy_Host.':'.CONST_HTTP_Proxy_Port;
 	$aHeaders = array();
 	if (CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
-		$auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
+		$auth = base64_encode(CONST_HTTP_Proxy_Login.':'.CONST_HTTP_Proxy_Password);
 		$aHeaders = array("Proxy-Authorization: Basic $auth");
 	}
+
 	$aContext = array(
-		'http' => array(
-			'proxy' => $proxy,
-			'request_fulluri' => true,
-			'header' => $aHeaders
-		),
-		'https' => array(
-			'proxy' => $proxy,
-			'request_fulluri' => true,
-			'header' => $aHeaders
-		)
-	);
+	             'http' => array(
+	                        'proxy' => $proxy,
+	                        'request_fulluri' => true,
+	                        'header' => $aHeaders
+	                       ),
+	             'https' => array(
+	                         'proxy' => $proxy,
+	                         'request_fulluri' => true,
+	                         'header' => $aHeaders
+	                        )
+	            );
 	stream_context_set_default($aContext);
-}
+}//end if

--- a/lib/init-cmd.php
+++ b/lib/init-cmd.php
@@ -5,23 +5,23 @@ require_once('cmd.php');
 
 // handle http proxy when using file_get_contents
 if (CONST_HTTP_Proxy) {
-  $proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
-  $aHeaders = array();
-  if(CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
-    $auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
-    $aHeaders = array("Proxy-Authorization: Basic $auth");
-  }
-  $aContext = array(
-    'http' => array(
-      'proxy' => $proxy,
-      'request_fulluri' => true,
-      'header' => $aHeaders
-    ),
-    'https' => array(
-      'proxy' => $proxy,
-      'request_fulluri' => true,
-      'header' => $aHeaders
-    )
-  );
-  stream_context_set_default($aContext);
+	$proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
+	$aHeaders = array();
+	if(CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
+		$auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
+		$aHeaders = array("Proxy-Authorization: Basic $auth");
+	}
+	$aContext = array(
+		'http' => array(
+			'proxy' => $proxy,
+			'request_fulluri' => true,
+			'header' => $aHeaders
+		),
+		'https' => array(
+			'proxy' => $proxy,
+			'request_fulluri' => true,
+			'header' => $aHeaders
+		)
+	);
+	stream_context_set_default($aContext);
 }

--- a/lib/init-cmd.php
+++ b/lib/init-cmd.php
@@ -1,26 +1,27 @@
 <?php
-	require_once('init.php');
-	require_once('cmd.php');
 
-	// handle http proxy when using file_get_contents
-	if (CONST_HTTP_Proxy) {
-	  $proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
-	  $aHeaders = array();
-	  if(CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
-	    $auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
-	    $aHeaders = array("Proxy-Authorization: Basic $auth");
-	  }
-	  $aContext = array(
-	    'http' => array(
-	      'proxy' => $proxy,
-	      'request_fulluri' => true,
-	      'header' => $aHeaders
-	    ),
-	    'https' => array(
-	      'proxy' => $proxy,
-	      'request_fulluri' => true,
-	      'header' => $aHeaders
-	    )
-	  );
-	  stream_context_set_default($aContext);
-	}
+require_once('init.php');
+require_once('cmd.php');
+
+// handle http proxy when using file_get_contents
+if (CONST_HTTP_Proxy) {
+  $proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
+  $aHeaders = array();
+  if(CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
+    $auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
+    $aHeaders = array("Proxy-Authorization: Basic $auth");
+  }
+  $aContext = array(
+    'http' => array(
+      'proxy' => $proxy,
+      'request_fulluri' => true,
+      'header' => $aHeaders
+    ),
+    'https' => array(
+      'proxy' => $proxy,
+      'request_fulluri' => true,
+      'header' => $aHeaders
+    )
+  );
+  stream_context_set_default($aContext);
+}

--- a/lib/init-cmd.php
+++ b/lib/init-cmd.php
@@ -7,7 +7,7 @@ require_once('cmd.php');
 if (CONST_HTTP_Proxy) {
 	$proxy = 'tcp://' . CONST_HTTP_Proxy_Host . ':' . CONST_HTTP_Proxy_Port;
 	$aHeaders = array();
-	if(CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
+	if (CONST_HTTP_Proxy_Login != null && CONST_HTTP_Proxy_Login != '' && CONST_HTTP_Proxy_Password != null && CONST_HTTP_Proxy_Password != '') {
 		$auth = base64_encode(CONST_HTTP_Proxy_Login . ':' . CONST_HTTP_Proxy_Password);
 		$aHeaders = array("Proxy-Authorization: Basic $auth");
 	}

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -1,17 +1,18 @@
 <?php
-	require_once('init.php');
-	require_once('website.php');
 
-	if (CONST_NoAccessControl)
+require_once('init.php');
+require_once('website.php');
+
+if (CONST_NoAccessControl)
+{
+	header("Access-Control-Allow-Origin: *");
+	header("Access-Control-Allow-Methods: OPTIONS,GET");
+	if (!empty($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
 	{
-		header("Access-Control-Allow-Origin: *");
-		header("Access-Control-Allow-Methods: OPTIONS,GET");
-		if (!empty($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
-		{
-			header("Access-Control-Allow-Headers: ".$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']);
-		}
+		header("Access-Control-Allow-Headers: ".$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']);
 	}
-	if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') exit;
+}
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') exit;
 
-	header('Content-type: text/html; charset=utf-8');
+header('Content-type: text/html; charset=utf-8');
 

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -3,16 +3,14 @@
 require_once('init.php');
 require_once('website.php');
 
-if (CONST_NoAccessControl)
-{
+if (CONST_NoAccessControl) {
 	header("Access-Control-Allow-Origin: *");
 	header("Access-Control-Allow-Methods: OPTIONS,GET");
-	if (!empty($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
-	{
+	if (!empty($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 		header("Access-Control-Allow-Headers: ".$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']);
 	}
 }
+
 if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') exit;
 
 header('Content-type: text/html; charset=utf-8');
-

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once('init.php');
-require_once('website.php');
+require_once 'init.php';
+require_once 'website.php';
 
 if (CONST_NoAccessControl) {
 	header("Access-Control-Allow-Origin: *");

--- a/lib/init.php
+++ b/lib/init.php
@@ -1,10 +1,10 @@
 <?php
 
-	require_once(CONST_BasePath.'/lib/lib.php');
-	require_once(CONST_BasePath.'/lib/db.php');
+require_once(CONST_BasePath.'/lib/lib.php');
+require_once(CONST_BasePath.'/lib/db.php');
 
-	if (get_magic_quotes_gpc())
-	{
-		echo "Please disable magic quotes in your php.ini configuration\n";
-		exit;
-	}
+if (get_magic_quotes_gpc())
+{
+	echo "Please disable magic quotes in your php.ini configuration\n";
+	exit;
+}

--- a/lib/init.php
+++ b/lib/init.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once(CONST_BasePath.'/lib/lib.php');
-require_once(CONST_BasePath.'/lib/db.php');
+require_once CONST_BasePath.'/lib/lib.php';
+require_once CONST_BasePath.'/lib/db.php';
 
 if (get_magic_quotes_gpc()) {
 	echo "Please disable magic quotes in your php.ini configuration\n";

--- a/lib/init.php
+++ b/lib/init.php
@@ -3,8 +3,7 @@
 require_once(CONST_BasePath.'/lib/lib.php');
 require_once(CONST_BasePath.'/lib/db.php');
 
-if (get_magic_quotes_gpc())
-{
+if (get_magic_quotes_gpc()) {
 	echo "Please disable magic quotes in your php.ini configuration\n";
 	exit;
 }

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -1,12 +1,14 @@
 <?php
 
+
 function fail($sError, $sUserError = false)
 {
 	if (!$sUserError) $sUserError = $sError;
 	error_log('ERROR: '.$sError);
 	echo $sUserError."\n";
 	exit(-1);
-}
+
+}//end fail()
 
 
 function getProcessorCount()
@@ -14,40 +16,45 @@ function getProcessorCount()
 	$sCPU = file_get_contents('/proc/cpuinfo');
 	preg_match_all('#processor\s+: [0-9]+#', $sCPU, $aMatches);
 	return sizeof($aMatches[0]);
-}
+
+}//end getProcessorCount()
 
 
 function getTotalMemoryMB()
 {
 	$sCPU = file_get_contents('/proc/meminfo');
 	preg_match('#MemTotal: +([0-9]+) kB#', $sCPU, $aMatches);
-	return (int)($aMatches[1]/1024);
-}
+	return (int) ($aMatches[1] / 1024);
+
+}//end getTotalMemoryMB()
 
 
 function getCacheMemoryMB()
 {
 	$sCPU = file_get_contents('/proc/meminfo');
 	preg_match('#Cached: +([0-9]+) kB#', $sCPU, $aMatches);
-	return (int)($aMatches[1]/1024);
-}
+	return (int) ($aMatches[1] / 1024);
+
+}//end getCacheMemoryMB()
 
 
 function bySearchRank($a, $b)
 {
 	if ($a['iSearchRank'] == $b['iSearchRank'])
-		return strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']);
-	return ($a['iSearchRank'] < $b['iSearchRank']?-1:1);
-}
+		return (strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']));
+	return ($a['iSearchRank'] < $b['iSearchRank'] ? -1 : 1);
+
+}//end bySearchRank()
 
 
 function byImportance($a, $b)
 {
 	if ($a['importance'] != $b['importance'])
-		return ($a['importance'] > $b['importance']?-1:1);
+		return ($a['importance'] > $b['importance'] ? -1 : 1);
 
-	return ($a['foundorder'] < $b['foundorder']?-1:1);
-}
+	return ($a['foundorder'] < $b['foundorder'] ? -1 : 1);
+
+}//end byImportance()
 
 
 function getPreferredLanguages($sLangString = false)
@@ -57,7 +64,7 @@ function getPreferredLanguages($sLangString = false)
 		if (isset($_GET['accept-language']) && $_GET['accept-language']) {
 			$_SERVER["HTTP_ACCEPT_LANGUAGE"] = $_GET['accept-language'];
 			$sLangString = $_GET['accept-language'];
-		} elseif (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) {
+		} else if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) {
 			$sLangString = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
 		}
 	}
@@ -66,13 +73,15 @@ function getPreferredLanguages($sLangString = false)
 	if ($sLangString) {
 		if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER)) {
 			foreach ($aLanguagesParse as $iLang => $aLanguage) {
-				$aLanguages[$aLanguage[1]] = isset($aLanguage[5])?(float)$aLanguage[5]:1 - ($iLang/100);
-				if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = $aLanguages[$aLanguage[1]]/10;
+				$aLanguages[$aLanguage[1]] = (isset($aLanguage[5]) ? (float) $aLanguage[5] : 1 - ($iLang / 100));
+				if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = ($aLanguages[$aLanguage[1]] / 10);
 			}
+
 			arsort($aLanguages);
 		}
 	}
-	if (!sizeof($aLanguages) && CONST_Default_Language) $aLanguages = array(CONST_Default_Language=>1);
+
+	if (!sizeof($aLanguages) && CONST_Default_Language) $aLanguages = array(CONST_Default_Language => 1);
 
 	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['short_name:'.$sLangauge] = 'short_name:'.$sLangauge;
@@ -89,6 +98,7 @@ function getPreferredLanguages($sLangString = false)
 	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['official_name:'.$sLangauge] = 'official_name:'.$sLangauge;
 	}
+
 	$aLangPrefOrder['short_name'] = 'short_name';
 	$aLangPrefOrder['name'] = 'name';
 	$aLangPrefOrder['place_name'] = 'place_name';
@@ -96,7 +106,8 @@ function getPreferredLanguages($sLangString = false)
 	$aLangPrefOrder['ref'] = 'ref';
 	$aLangPrefOrder['type'] = 'type';
 	return $aLangPrefOrder;
-}
+
+}//end getPreferredLanguages()
 
 
 function getWordSets($aWords, $iDepth)
@@ -106,15 +117,18 @@ function getWordSets($aWords, $iDepth)
 	if ($iDepth < 8) {
 		while (sizeof($aWords) > 1) {
 			$sWord = array_shift($aWords);
-			$sFirstToken .= ($sFirstToken?' ':'').$sWord;
-			$aRest = getWordSets($aWords, $iDepth+1);
+			$sFirstToken .= ($sFirstToken ? ' ' : '').$sWord;
+			$aRest = getWordSets($aWords, ($iDepth + 1));
 			foreach ($aRest as $aSet) {
 				$aResult[] = array_merge(array($sFirstToken), $aSet);
 			}
 		}
 	}
+
 	return $aResult;
-}
+
+}//end getWordSets()
+
 
 function getInverseWordSets($aWords, $iDepth)
 {
@@ -123,15 +137,17 @@ function getInverseWordSets($aWords, $iDepth)
 	if ($iDepth < 8) {
 		while (sizeof($aWords) > 1) {
 			$sWord = array_pop($aWords);
-			$sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
-			$aRest = getInverseWordSets($aWords, $iDepth+1);
+			$sFirstToken = $sWord.($sFirstToken ? ' ' : '').$sFirstToken;
+			$aRest = getInverseWordSets($aWords, ($iDepth + 1));
 			foreach ($aRest as $aSet) {
 				$aResult[] = array_merge(array($sFirstToken), $aSet);
 			}
 		}
 	}
+
 	return $aResult;
-}
+
+}//end getInverseWordSets()
 
 
 function getTokensFromSets($aSets)
@@ -143,13 +159,11 @@ function getTokensFromSets($aSets)
 			$aTokens[$sWord] = $sWord;
 		}
 	}
+
 	return $aTokens;
-}
 
+}//end getTokensFromSets()
 
-/*
-   GB Postcode functions
- */
 
 function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
 {
@@ -167,315 +181,316 @@ function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
 	}
 
 	return false;
-}
+
+}//end gbPostcodeCalculate()
 
 
 function getClassTypes()
 {
 	return array(
-		'boundary:administrative:1' => array('label'=>'Continent','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:2' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:country' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>6, 'defdiameter' => 15,),
-		'boundary:administrative:3' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:4' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:state' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 5.12,),
-		'boundary:administrative:5' => array('label'=>'State District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:6' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:7' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:county' => array('label'=>'County','frequency'=>108,'icon'=>'poi_boundary_administrative','defzoom'=>10, 'defdiameter' => 1.28,),
-		'boundary:administrative:8' => array('label'=>'City','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:city' => array('label'=>'City','frequency'=>66,'icon'=>'poi_place_city','defzoom'=>12, 'defdiameter' => 0.32,),
-		'boundary:administrative:9' => array('label'=>'City District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:10' => array('label'=>'Suburb','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:administrative:11' => array('label'=>'Neighbourhood','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:region' => array('label'=>'Region','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 0.04,),
-		'place:island' => array('label'=>'Island','frequency'=>288,'icon'=>'','defzoom'=>11, 'defdiameter' => 0.64,),
-		'boundary:administrative' => array('label'=>'Administrative','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'boundary:postal_code' => array('label'=>'Postcode','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
-		'place:town' => array('label'=>'Town','frequency'=>1497,'icon'=>'poi_place_town','defzoom'=>14, 'defdiameter' => 0.08,),
-		'place:village' => array('label'=>'Village','frequency'=>11230,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
-		'place:hamlet' => array('label'=>'Hamlet','frequency'=>7075,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
-		'place:suburb' => array('label'=>'Suburb','frequency'=>2528,'icon'=>'poi_place_village', 'defdiameter' => 0.04,),
-		'place:locality' => array('label'=>'Locality','frequency'=>4113,'icon'=>'poi_place_village', 'defdiameter' => 0.02,),
-		'landuse:farm' => array('label'=>'Farm','frequency'=>1201,'icon'=>'', 'defdiameter' => 0.02,),
-		'place:farm' => array('label'=>'Farm','frequency'=>1162,'icon'=>'', 'defdiameter' => 0.02,),
+	        'boundary:administrative:1' => array('label' => 'Continent','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:2' => array('label' => 'Country','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:country' => array('label' => 'Country','frequency' => 0,'icon' => 'poi_boundary_administrative','defzoom' => 6, 'defdiameter' => 15),
+	        'boundary:administrative:3' => array('label' => 'State','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:4' => array('label' => 'State','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:state' => array('label' => 'State','frequency' => 0,'icon' => 'poi_boundary_administrative','defzoom' => 8, 'defdiameter' => 5.12),
+	        'boundary:administrative:5' => array('label' => 'State District','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:6' => array('label' => 'County','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:7' => array('label' => 'County','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:county' => array('label' => 'County','frequency' => 108,'icon' => 'poi_boundary_administrative','defzoom' => 10, 'defdiameter' => 1.28),
+	        'boundary:administrative:8' => array('label' => 'City','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:city' => array('label' => 'City','frequency' => 66,'icon' => 'poi_place_city','defzoom' => 12, 'defdiameter' => 0.32),
+	        'boundary:administrative:9' => array('label' => 'City District','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:10' => array('label' => 'Suburb','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:administrative:11' => array('label' => 'Neighbourhood','frequency' => 0,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:region' => array('label' => 'Region','frequency' => 0,'icon' => 'poi_boundary_administrative','defzoom' => 8, 'defdiameter' => 0.04),
+	        'place:island' => array('label' => 'Island','frequency' => 288,'icon' => '','defzoom' => 11, 'defdiameter' => 0.64),
+	        'boundary:administrative' => array('label' => 'Administrative','frequency' => 413,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'boundary:postal_code' => array('label' => 'Postcode','frequency' => 413,'icon' => 'poi_boundary_administrative', 'defdiameter' => 0.32),
+	        'place:town' => array('label' => 'Town','frequency' => 1497,'icon' => 'poi_place_town','defzoom' => 14, 'defdiameter' => 0.08),
+	        'place:village' => array('label' => 'Village','frequency' => 11230,'icon' => 'poi_place_village','defzoom' => 15, 'defdiameter' => 0.04),
+	        'place:hamlet' => array('label' => 'Hamlet','frequency' => 7075,'icon' => 'poi_place_village','defzoom' => 15, 'defdiameter' => 0.04),
+	        'place:suburb' => array('label' => 'Suburb','frequency' => 2528,'icon' => 'poi_place_village', 'defdiameter' => 0.04),
+	        'place:locality' => array('label' => 'Locality','frequency' => 4113,'icon' => 'poi_place_village', 'defdiameter' => 0.02),
+	        'landuse:farm' => array('label' => 'Farm','frequency' => 1201,'icon' => '', 'defdiameter' => 0.02),
+	        'place:farm' => array('label' => 'Farm','frequency' => 1162,'icon' => '', 'defdiameter' => 0.02),
 
-		'highway:motorway_junction' => array('label'=>'Motorway Junction','frequency'=>1126,'icon'=>'','simplelabel'=>'Junction',),
-		'highway:motorway' => array('label'=>'Motorway','frequency'=>4627,'icon'=>'','simplelabel'=>'Road',),
-		'highway:trunk' => array('label'=>'Trunk','frequency'=>23084,'icon'=>'','simplelabel'=>'Road',),
-		'highway:primary' => array('label'=>'Primary','frequency'=>32138,'icon'=>'','simplelabel'=>'Road',),
-		'highway:secondary' => array('label'=>'Secondary','frequency'=>25807,'icon'=>'','simplelabel'=>'Road',),
-		'highway:tertiary' => array('label'=>'Tertiary','frequency'=>29829,'icon'=>'','simplelabel'=>'Road',),
-		'highway:residential' => array('label'=>'Residential','frequency'=>361498,'icon'=>'','simplelabel'=>'Road',),
-		'highway:unclassified' => array('label'=>'Unclassified','frequency'=>66441,'icon'=>'','simplelabel'=>'Road',),
-		'highway:living_street' => array('label'=>'Living Street','frequency'=>710,'icon'=>'','simplelabel'=>'Road',),
-		'highway:service' => array('label'=>'Service','frequency'=>9963,'icon'=>'','simplelabel'=>'Road',),
-		'highway:track' => array('label'=>'Track','frequency'=>2565,'icon'=>'','simplelabel'=>'Road',),
-		'highway:road' => array('label'=>'Road','frequency'=>591,'icon'=>'','simplelabel'=>'Road',),
-		'highway:byway' => array('label'=>'Byway','frequency'=>346,'icon'=>'','simplelabel'=>'Road',),
-		'highway:bridleway' => array('label'=>'Bridleway','frequency'=>1556,'icon'=>'',),
-		'highway:cycleway' => array('label'=>'Cycleway','frequency'=>2419,'icon'=>'',),
-		'highway:pedestrian' => array('label'=>'Pedestrian','frequency'=>2757,'icon'=>'',),
-		'highway:footway' => array('label'=>'Footway','frequency'=>15008,'icon'=>'',),
-		'highway:steps' => array('label'=>'Steps','frequency'=>444,'icon'=>'','simplelabel'=>'Footway',),
-		'highway:motorway_link' => array('label'=>'Motorway Link','frequency'=>795,'icon'=>'','simplelabel'=>'Road',),
-		'highway:trunk_link' => array('label'=>'Trunk Link','frequency'=>1258,'icon'=>'','simplelabel'=>'Road',),
-		'highway:primary_link' => array('label'=>'Primary Link','frequency'=>313,'icon'=>'','simplelabel'=>'Road',),
+	        'highway:motorway_junction' => array('label' => 'Motorway Junction','frequency' => 1126,'icon' => '','simplelabel' => 'Junction'),
+	        'highway:motorway' => array('label' => 'Motorway','frequency' => 4627,'icon' => '','simplelabel' => 'Road'),
+	        'highway:trunk' => array('label' => 'Trunk','frequency' => 23084,'icon' => '','simplelabel' => 'Road'),
+	        'highway:primary' => array('label' => 'Primary','frequency' => 32138,'icon' => '','simplelabel' => 'Road'),
+	        'highway:secondary' => array('label' => 'Secondary','frequency' => 25807,'icon' => '','simplelabel' => 'Road'),
+	        'highway:tertiary' => array('label' => 'Tertiary','frequency' => 29829,'icon' => '','simplelabel' => 'Road'),
+	        'highway:residential' => array('label' => 'Residential','frequency' => 361498,'icon' => '','simplelabel' => 'Road'),
+	        'highway:unclassified' => array('label' => 'Unclassified','frequency' => 66441,'icon' => '','simplelabel' => 'Road'),
+	        'highway:living_street' => array('label' => 'Living Street','frequency' => 710,'icon' => '','simplelabel' => 'Road'),
+	        'highway:service' => array('label' => 'Service','frequency' => 9963,'icon' => '','simplelabel' => 'Road'),
+	        'highway:track' => array('label' => 'Track','frequency' => 2565,'icon' => '','simplelabel' => 'Road'),
+	        'highway:road' => array('label' => 'Road','frequency' => 591,'icon' => '','simplelabel' => 'Road'),
+	        'highway:byway' => array('label' => 'Byway','frequency' => 346,'icon' => '','simplelabel' => 'Road'),
+	        'highway:bridleway' => array('label' => 'Bridleway','frequency' => 1556,'icon' => ''),
+	        'highway:cycleway' => array('label' => 'Cycleway','frequency' => 2419,'icon' => ''),
+	        'highway:pedestrian' => array('label' => 'Pedestrian','frequency' => 2757,'icon' => ''),
+	        'highway:footway' => array('label' => 'Footway','frequency' => 15008,'icon' => ''),
+	        'highway:steps' => array('label' => 'Steps','frequency' => 444,'icon' => '','simplelabel' => 'Footway'),
+	        'highway:motorway_link' => array('label' => 'Motorway Link','frequency' => 795,'icon' => '','simplelabel' => 'Road'),
+	        'highway:trunk_link' => array('label' => 'Trunk Link','frequency' => 1258,'icon' => '','simplelabel' => 'Road'),
+	        'highway:primary_link' => array('label' => 'Primary Link','frequency' => 313,'icon' => '','simplelabel' => 'Road'),
 
-		'landuse:industrial' => array('label'=>'Industrial','frequency'=>1062,'icon'=>'',),
-		'landuse:residential' => array('label'=>'Residential','frequency'=>886,'icon'=>'',),
-		'landuse:retail' => array('label'=>'Retail','frequency'=>754,'icon'=>'',),
-		'landuse:commercial' => array('label'=>'Commercial','frequency'=>657,'icon'=>'',),
+	        'landuse:industrial' => array('label' => 'Industrial','frequency' => 1062,'icon' => ''),
+	        'landuse:residential' => array('label' => 'Residential','frequency' => 886,'icon' => ''),
+	        'landuse:retail' => array('label' => 'Retail','frequency' => 754,'icon' => ''),
+	        'landuse:commercial' => array('label' => 'Commercial','frequency' => 657,'icon' => ''),
 
-		'place:airport' => array('label'=>'Airport','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
-		'aeroway:aerodrome' => array('label'=>'Aerodrome','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
-		'aeroway' => array('label'=>'Aeroway','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
-		'railway:station' => array('label'=>'Station','frequency'=>3431,'icon'=>'transport_train_station2', 'defdiameter' => 0.01,),
-		'amenity:place_of_worship' => array('label'=>'Place Of Worship','frequency'=>9049,'icon'=>'place_of_worship_unknown3',),
-		'amenity:pub' => array('label'=>'Pub','frequency'=>18969,'icon'=>'food_pub',),
-		'amenity:bar' => array('label'=>'Bar','frequency'=>164,'icon'=>'food_bar',),
-		'amenity:university' => array('label'=>'University','frequency'=>607,'icon'=>'education_university',),
-		'tourism:museum' => array('label'=>'Museum','frequency'=>543,'icon'=>'tourist_museum',),
-		'amenity:arts_centre' => array('label'=>'Arts Centre','frequency'=>136,'icon'=>'tourist_art_gallery2',),
-		'tourism:zoo' => array('label'=>'Zoo','frequency'=>47,'icon'=>'tourist_zoo',),
-		'tourism:theme_park' => array('label'=>'Theme Park','frequency'=>24,'icon'=>'poi_point_of_interest',),
-		'tourism:attraction' => array('label'=>'Attraction','frequency'=>1463,'icon'=>'poi_point_of_interest',),
-		'leisure:golf_course' => array('label'=>'Golf Course','frequency'=>712,'icon'=>'sport_golf',),
-		'historic:castle' => array('label'=>'Castle','frequency'=>316,'icon'=>'tourist_castle',),
-		'amenity:hospital' => array('label'=>'Hospital','frequency'=>879,'icon'=>'health_hospital',),
-		'amenity:school' => array('label'=>'School','frequency'=>8192,'icon'=>'education_school',),
-		'amenity:theatre' => array('label'=>'Theatre','frequency'=>371,'icon'=>'tourist_theatre',),
-		'amenity:public_building' => array('label'=>'Public Building','frequency'=>985,'icon'=>'',),
-		'amenity:library' => array('label'=>'Library','frequency'=>794,'icon'=>'amenity_library',),
-		'amenity:townhall' => array('label'=>'Townhall','frequency'=>242,'icon'=>'',),
-		'amenity:community_centre' => array('label'=>'Community Centre','frequency'=>157,'icon'=>'',),
-		'amenity:fire_station' => array('label'=>'Fire Station','frequency'=>221,'icon'=>'amenity_firestation3',),
-		'amenity:police' => array('label'=>'Police','frequency'=>334,'icon'=>'amenity_police2',),
-		'amenity:bank' => array('label'=>'Bank','frequency'=>1248,'icon'=>'money_bank2',),
-		'amenity:post_office' => array('label'=>'Post Office','frequency'=>859,'icon'=>'amenity_post_office',),
-		'leisure:park' => array('label'=>'Park','frequency'=>2378,'icon'=>'',),
-		'amenity:park' => array('label'=>'Park','frequency'=>53,'icon'=>'',),
-		'landuse:park' => array('label'=>'Park','frequency'=>50,'icon'=>'',),
-		'landuse:recreation_ground' => array('label'=>'Recreation Ground','frequency'=>517,'icon'=>'',),
-		'tourism:hotel' => array('label'=>'Hotel','frequency'=>2150,'icon'=>'accommodation_hotel2',),
-		'tourism:motel' => array('label'=>'Motel','frequency'=>43,'icon'=>'',),
-		'amenity:cinema' => array('label'=>'Cinema','frequency'=>277,'icon'=>'tourist_cinema',),
-		'tourism:artwork' => array('label'=>'Artwork','frequency'=>171,'icon'=>'tourist_art_gallery2',),
-		'historic:archaeological_site' => array('label'=>'Archaeological Site','frequency'=>407,'icon'=>'tourist_archaeological2',),
-		'amenity:doctors' => array('label'=>'Doctors','frequency'=>581,'icon'=>'health_doctors',),
-		'leisure:sports_centre' => array('label'=>'Sports Centre','frequency'=>767,'icon'=>'sport_leisure_centre',),
-		'leisure:swimming_pool' => array('label'=>'Swimming Pool','frequency'=>24,'icon'=>'sport_swimming_outdoor',),
-		'shop:supermarket' => array('label'=>'Supermarket','frequency'=>2673,'icon'=>'shopping_supermarket',),
-		'shop:convenience' => array('label'=>'Convenience','frequency'=>1469,'icon'=>'shopping_convenience',),
-		'amenity:restaurant' => array('label'=>'Restaurant','frequency'=>3179,'icon'=>'food_restaurant',),
-		'amenity:fast_food' => array('label'=>'Fast Food','frequency'=>2289,'icon'=>'food_fastfood',),
-		'amenity:cafe' => array('label'=>'Cafe','frequency'=>1780,'icon'=>'food_cafe',),
-		'tourism:guest_house' => array('label'=>'Guest House','frequency'=>223,'icon'=>'accommodation_bed_and_breakfast',),
-		'amenity:pharmacy' => array('label'=>'Pharmacy','frequency'=>733,'icon'=>'health_pharmacy_dispensing',),
-		'amenity:fuel' => array('label'=>'Fuel','frequency'=>1308,'icon'=>'transport_fuel',),
-		'natural:peak' => array('label'=>'Peak','frequency'=>3212,'icon'=>'poi_peak',),
-		'waterway:waterfall' => array('label'=>'Waterfall','frequency'=>24,'icon'=>'',),
-		'natural:wood' => array('label'=>'Wood','frequency'=>1845,'icon'=>'landuse_coniferous_and_deciduous',),
-		'natural:water' => array('label'=>'Water','frequency'=>1790,'icon'=>'',),
-		'landuse:forest' => array('label'=>'Forest','frequency'=>467,'icon'=>'',),
-		'landuse:cemetery' => array('label'=>'Cemetery','frequency'=>463,'icon'=>'',),
-		'landuse:allotments' => array('label'=>'Allotments','frequency'=>408,'icon'=>'',),
-		'landuse:farmyard' => array('label'=>'Farmyard','frequency'=>397,'icon'=>'',),
-		'railway:rail' => array('label'=>'Rail','frequency'=>4894,'icon'=>'',),
-		'waterway:canal' => array('label'=>'Canal','frequency'=>1723,'icon'=>'',),
-		'waterway:river' => array('label'=>'River','frequency'=>4089,'icon'=>'',),
-		'waterway:stream' => array('label'=>'Stream','frequency'=>2684,'icon'=>'',),
-		'shop:bicycle' => array('label'=>'Bicycle','frequency'=>349,'icon'=>'shopping_bicycle',),
-		'shop:clothes' => array('label'=>'Clothes','frequency'=>315,'icon'=>'shopping_clothes',),
-		'shop:hairdresser' => array('label'=>'Hairdresser','frequency'=>312,'icon'=>'shopping_hairdresser',),
-		'shop:doityourself' => array('label'=>'Doityourself','frequency'=>247,'icon'=>'shopping_diy',),
-		'shop:estate_agent' => array('label'=>'Estate Agent','frequency'=>162,'icon'=>'shopping_estateagent2',),
-		'shop:car' => array('label'=>'Car','frequency'=>159,'icon'=>'shopping_car',),
-		'shop:garden_centre' => array('label'=>'Garden Centre','frequency'=>143,'icon'=>'shopping_garden_centre',),
-		'shop:car_repair' => array('label'=>'Car Repair','frequency'=>141,'icon'=>'shopping_car_repair',),
-		'shop:newsagent' => array('label'=>'Newsagent','frequency'=>132,'icon'=>'',),
-		'shop:bakery' => array('label'=>'Bakery','frequency'=>129,'icon'=>'shopping_bakery',),
-		'shop:furniture' => array('label'=>'Furniture','frequency'=>124,'icon'=>'',),
-		'shop:butcher' => array('label'=>'Butcher','frequency'=>105,'icon'=>'shopping_butcher',),
-		'shop:apparel' => array('label'=>'Apparel','frequency'=>98,'icon'=>'shopping_clothes',),
-		'shop:electronics' => array('label'=>'Electronics','frequency'=>96,'icon'=>'',),
-		'shop:department_store' => array('label'=>'Department Store','frequency'=>86,'icon'=>'',),
-		'shop:books' => array('label'=>'Books','frequency'=>85,'icon'=>'',),
-		'shop:yes' => array('label'=>'Shop','frequency'=>68,'icon'=>'',),
-		'shop:outdoor' => array('label'=>'Outdoor','frequency'=>67,'icon'=>'',),
-		'shop:mall' => array('label'=>'Mall','frequency'=>63,'icon'=>'',),
-		'shop:florist' => array('label'=>'Florist','frequency'=>61,'icon'=>'',),
-		'shop:charity' => array('label'=>'Charity','frequency'=>60,'icon'=>'',),
-		'shop:hardware' => array('label'=>'Hardware','frequency'=>59,'icon'=>'',),
-		'shop:laundry' => array('label'=>'Laundry','frequency'=>51,'icon'=>'shopping_laundrette',),
-		'shop:shoes' => array('label'=>'Shoes','frequency'=>49,'icon'=>'',),
-		'shop:beverages' => array('label'=>'Beverages','frequency'=>48,'icon'=>'shopping_alcohol',),
-		'shop:dry_cleaning' => array('label'=>'Dry Cleaning','frequency'=>46,'icon'=>'',),
-		'shop:carpet' => array('label'=>'Carpet','frequency'=>45,'icon'=>'',),
-		'shop:computer' => array('label'=>'Computer','frequency'=>44,'icon'=>'',),
-		'shop:alcohol' => array('label'=>'Alcohol','frequency'=>44,'icon'=>'shopping_alcohol',),
-		'shop:optician' => array('label'=>'Optician','frequency'=>55,'icon'=>'health_opticians',),
-		'shop:chemist' => array('label'=>'Chemist','frequency'=>42,'icon'=>'health_pharmacy',),
-		'shop:gallery' => array('label'=>'Gallery','frequency'=>38,'icon'=>'tourist_art_gallery2',),
-		'shop:mobile_phone' => array('label'=>'Mobile Phone','frequency'=>37,'icon'=>'',),
-		'shop:sports' => array('label'=>'Sports','frequency'=>37,'icon'=>'',),
-		'shop:jewelry' => array('label'=>'Jewelry','frequency'=>32,'icon'=>'shopping_jewelry',),
-		'shop:pet' => array('label'=>'Pet','frequency'=>29,'icon'=>'',),
-		'shop:beauty' => array('label'=>'Beauty','frequency'=>28,'icon'=>'',),
-		'shop:stationery' => array('label'=>'Stationery','frequency'=>25,'icon'=>'',),
-		'shop:shopping_centre' => array('label'=>'Shopping Centre','frequency'=>25,'icon'=>'',),
-		'shop:general' => array('label'=>'General','frequency'=>25,'icon'=>'',),
-		'shop:electrical' => array('label'=>'Electrical','frequency'=>25,'icon'=>'',),
-		'shop:toys' => array('label'=>'Toys','frequency'=>23,'icon'=>'',),
-		'shop:jeweller' => array('label'=>'Jeweller','frequency'=>23,'icon'=>'',),
-		'shop:betting' => array('label'=>'Betting','frequency'=>23,'icon'=>'',),
-		'shop:household' => array('label'=>'Household','frequency'=>21,'icon'=>'',),
-		'shop:travel_agency' => array('label'=>'Travel Agency','frequency'=>21,'icon'=>'',),
-		'shop:hifi' => array('label'=>'Hifi','frequency'=>21,'icon'=>'',),
-		'amenity:shop' => array('label'=>'Shop','frequency'=>61,'icon'=>'',),
-		'tourism:information' => array('label'=>'Information','frequency'=>224,'icon'=>'amenity_information',),
+	        'place:airport' => array('label' => 'Airport','frequency' => 36,'icon' => 'transport_airport2', 'defdiameter' => 0.03),
+	        'aeroway:aerodrome' => array('label' => 'Aerodrome','frequency' => 36,'icon' => 'transport_airport2', 'defdiameter' => 0.03),
+	        'aeroway' => array('label' => 'Aeroway','frequency' => 36,'icon' => 'transport_airport2', 'defdiameter' => 0.03),
+	        'railway:station' => array('label' => 'Station','frequency' => 3431,'icon' => 'transport_train_station2', 'defdiameter' => 0.01),
+	        'amenity:place_of_worship' => array('label' => 'Place Of Worship','frequency' => 9049,'icon' => 'place_of_worship_unknown3'),
+	        'amenity:pub' => array('label' => 'Pub','frequency' => 18969,'icon' => 'food_pub'),
+	        'amenity:bar' => array('label' => 'Bar','frequency' => 164,'icon' => 'food_bar'),
+	        'amenity:university' => array('label' => 'University','frequency' => 607,'icon' => 'education_university'),
+	        'tourism:museum' => array('label' => 'Museum','frequency' => 543,'icon' => 'tourist_museum'),
+	        'amenity:arts_centre' => array('label' => 'Arts Centre','frequency' => 136,'icon' => 'tourist_art_gallery2'),
+	        'tourism:zoo' => array('label' => 'Zoo','frequency' => 47,'icon' => 'tourist_zoo'),
+	        'tourism:theme_park' => array('label' => 'Theme Park','frequency' => 24,'icon' => 'poi_point_of_interest'),
+	        'tourism:attraction' => array('label' => 'Attraction','frequency' => 1463,'icon' => 'poi_point_of_interest'),
+	        'leisure:golf_course' => array('label' => 'Golf Course','frequency' => 712,'icon' => 'sport_golf'),
+	        'historic:castle' => array('label' => 'Castle','frequency' => 316,'icon' => 'tourist_castle'),
+	        'amenity:hospital' => array('label' => 'Hospital','frequency' => 879,'icon' => 'health_hospital'),
+	        'amenity:school' => array('label' => 'School','frequency' => 8192,'icon' => 'education_school'),
+	        'amenity:theatre' => array('label' => 'Theatre','frequency' => 371,'icon' => 'tourist_theatre'),
+	        'amenity:public_building' => array('label' => 'Public Building','frequency' => 985,'icon' => ''),
+	        'amenity:library' => array('label' => 'Library','frequency' => 794,'icon' => 'amenity_library'),
+	        'amenity:townhall' => array('label' => 'Townhall','frequency' => 242,'icon' => ''),
+	        'amenity:community_centre' => array('label' => 'Community Centre','frequency' => 157,'icon' => ''),
+	        'amenity:fire_station' => array('label' => 'Fire Station','frequency' => 221,'icon' => 'amenity_firestation3'),
+	        'amenity:police' => array('label' => 'Police','frequency' => 334,'icon' => 'amenity_police2'),
+	        'amenity:bank' => array('label' => 'Bank','frequency' => 1248,'icon' => 'money_bank2'),
+	        'amenity:post_office' => array('label' => 'Post Office','frequency' => 859,'icon' => 'amenity_post_office'),
+	        'leisure:park' => array('label' => 'Park','frequency' => 2378,'icon' => ''),
+	        'amenity:park' => array('label' => 'Park','frequency' => 53,'icon' => ''),
+	        'landuse:park' => array('label' => 'Park','frequency' => 50,'icon' => ''),
+	        'landuse:recreation_ground' => array('label' => 'Recreation Ground','frequency' => 517,'icon' => ''),
+	        'tourism:hotel' => array('label' => 'Hotel','frequency' => 2150,'icon' => 'accommodation_hotel2'),
+	        'tourism:motel' => array('label' => 'Motel','frequency' => 43,'icon' => ''),
+	        'amenity:cinema' => array('label' => 'Cinema','frequency' => 277,'icon' => 'tourist_cinema'),
+	        'tourism:artwork' => array('label' => 'Artwork','frequency' => 171,'icon' => 'tourist_art_gallery2'),
+	        'historic:archaeological_site' => array('label' => 'Archaeological Site','frequency' => 407,'icon' => 'tourist_archaeological2'),
+	        'amenity:doctors' => array('label' => 'Doctors','frequency' => 581,'icon' => 'health_doctors'),
+	        'leisure:sports_centre' => array('label' => 'Sports Centre','frequency' => 767,'icon' => 'sport_leisure_centre'),
+	        'leisure:swimming_pool' => array('label' => 'Swimming Pool','frequency' => 24,'icon' => 'sport_swimming_outdoor'),
+	        'shop:supermarket' => array('label' => 'Supermarket','frequency' => 2673,'icon' => 'shopping_supermarket'),
+	        'shop:convenience' => array('label' => 'Convenience','frequency' => 1469,'icon' => 'shopping_convenience'),
+	        'amenity:restaurant' => array('label' => 'Restaurant','frequency' => 3179,'icon' => 'food_restaurant'),
+	        'amenity:fast_food' => array('label' => 'Fast Food','frequency' => 2289,'icon' => 'food_fastfood'),
+	        'amenity:cafe' => array('label' => 'Cafe','frequency' => 1780,'icon' => 'food_cafe'),
+	        'tourism:guest_house' => array('label' => 'Guest House','frequency' => 223,'icon' => 'accommodation_bed_and_breakfast'),
+	        'amenity:pharmacy' => array('label' => 'Pharmacy','frequency' => 733,'icon' => 'health_pharmacy_dispensing'),
+	        'amenity:fuel' => array('label' => 'Fuel','frequency' => 1308,'icon' => 'transport_fuel'),
+	        'natural:peak' => array('label' => 'Peak','frequency' => 3212,'icon' => 'poi_peak'),
+	        'waterway:waterfall' => array('label' => 'Waterfall','frequency' => 24,'icon' => ''),
+	        'natural:wood' => array('label' => 'Wood','frequency' => 1845,'icon' => 'landuse_coniferous_and_deciduous'),
+	        'natural:water' => array('label' => 'Water','frequency' => 1790,'icon' => ''),
+	        'landuse:forest' => array('label' => 'Forest','frequency' => 467,'icon' => ''),
+	        'landuse:cemetery' => array('label' => 'Cemetery','frequency' => 463,'icon' => ''),
+	        'landuse:allotments' => array('label' => 'Allotments','frequency' => 408,'icon' => ''),
+	        'landuse:farmyard' => array('label' => 'Farmyard','frequency' => 397,'icon' => ''),
+	        'railway:rail' => array('label' => 'Rail','frequency' => 4894,'icon' => ''),
+	        'waterway:canal' => array('label' => 'Canal','frequency' => 1723,'icon' => ''),
+	        'waterway:river' => array('label' => 'River','frequency' => 4089,'icon' => ''),
+	        'waterway:stream' => array('label' => 'Stream','frequency' => 2684,'icon' => ''),
+	        'shop:bicycle' => array('label' => 'Bicycle','frequency' => 349,'icon' => 'shopping_bicycle'),
+	        'shop:clothes' => array('label' => 'Clothes','frequency' => 315,'icon' => 'shopping_clothes'),
+	        'shop:hairdresser' => array('label' => 'Hairdresser','frequency' => 312,'icon' => 'shopping_hairdresser'),
+	        'shop:doityourself' => array('label' => 'Doityourself','frequency' => 247,'icon' => 'shopping_diy'),
+	        'shop:estate_agent' => array('label' => 'Estate Agent','frequency' => 162,'icon' => 'shopping_estateagent2'),
+	        'shop:car' => array('label' => 'Car','frequency' => 159,'icon' => 'shopping_car'),
+	        'shop:garden_centre' => array('label' => 'Garden Centre','frequency' => 143,'icon' => 'shopping_garden_centre'),
+	        'shop:car_repair' => array('label' => 'Car Repair','frequency' => 141,'icon' => 'shopping_car_repair'),
+	        'shop:newsagent' => array('label' => 'Newsagent','frequency' => 132,'icon' => ''),
+	        'shop:bakery' => array('label' => 'Bakery','frequency' => 129,'icon' => 'shopping_bakery'),
+	        'shop:furniture' => array('label' => 'Furniture','frequency' => 124,'icon' => ''),
+	        'shop:butcher' => array('label' => 'Butcher','frequency' => 105,'icon' => 'shopping_butcher'),
+	        'shop:apparel' => array('label' => 'Apparel','frequency' => 98,'icon' => 'shopping_clothes'),
+	        'shop:electronics' => array('label' => 'Electronics','frequency' => 96,'icon' => ''),
+	        'shop:department_store' => array('label' => 'Department Store','frequency' => 86,'icon' => ''),
+	        'shop:books' => array('label' => 'Books','frequency' => 85,'icon' => ''),
+	        'shop:yes' => array('label' => 'Shop','frequency' => 68,'icon' => ''),
+	        'shop:outdoor' => array('label' => 'Outdoor','frequency' => 67,'icon' => ''),
+	        'shop:mall' => array('label' => 'Mall','frequency' => 63,'icon' => ''),
+	        'shop:florist' => array('label' => 'Florist','frequency' => 61,'icon' => ''),
+	        'shop:charity' => array('label' => 'Charity','frequency' => 60,'icon' => ''),
+	        'shop:hardware' => array('label' => 'Hardware','frequency' => 59,'icon' => ''),
+	        'shop:laundry' => array('label' => 'Laundry','frequency' => 51,'icon' => 'shopping_laundrette'),
+	        'shop:shoes' => array('label' => 'Shoes','frequency' => 49,'icon' => ''),
+	        'shop:beverages' => array('label' => 'Beverages','frequency' => 48,'icon' => 'shopping_alcohol'),
+	        'shop:dry_cleaning' => array('label' => 'Dry Cleaning','frequency' => 46,'icon' => ''),
+	        'shop:carpet' => array('label' => 'Carpet','frequency' => 45,'icon' => ''),
+	        'shop:computer' => array('label' => 'Computer','frequency' => 44,'icon' => ''),
+	        'shop:alcohol' => array('label' => 'Alcohol','frequency' => 44,'icon' => 'shopping_alcohol'),
+	        'shop:optician' => array('label' => 'Optician','frequency' => 55,'icon' => 'health_opticians'),
+	        'shop:chemist' => array('label' => 'Chemist','frequency' => 42,'icon' => 'health_pharmacy'),
+	        'shop:gallery' => array('label' => 'Gallery','frequency' => 38,'icon' => 'tourist_art_gallery2'),
+	        'shop:mobile_phone' => array('label' => 'Mobile Phone','frequency' => 37,'icon' => ''),
+	        'shop:sports' => array('label' => 'Sports','frequency' => 37,'icon' => ''),
+	        'shop:jewelry' => array('label' => 'Jewelry','frequency' => 32,'icon' => 'shopping_jewelry'),
+	        'shop:pet' => array('label' => 'Pet','frequency' => 29,'icon' => ''),
+	        'shop:beauty' => array('label' => 'Beauty','frequency' => 28,'icon' => ''),
+	        'shop:stationery' => array('label' => 'Stationery','frequency' => 25,'icon' => ''),
+	        'shop:shopping_centre' => array('label' => 'Shopping Centre','frequency' => 25,'icon' => ''),
+	        'shop:general' => array('label' => 'General','frequency' => 25,'icon' => ''),
+	        'shop:electrical' => array('label' => 'Electrical','frequency' => 25,'icon' => ''),
+	        'shop:toys' => array('label' => 'Toys','frequency' => 23,'icon' => ''),
+	        'shop:jeweller' => array('label' => 'Jeweller','frequency' => 23,'icon' => ''),
+	        'shop:betting' => array('label' => 'Betting','frequency' => 23,'icon' => ''),
+	        'shop:household' => array('label' => 'Household','frequency' => 21,'icon' => ''),
+	        'shop:travel_agency' => array('label' => 'Travel Agency','frequency' => 21,'icon' => ''),
+	        'shop:hifi' => array('label' => 'Hifi','frequency' => 21,'icon' => ''),
+	        'amenity:shop' => array('label' => 'Shop','frequency' => 61,'icon' => ''),
+	        'tourism:information' => array('label' => 'Information','frequency' => 224,'icon' => 'amenity_information'),
 
-		'place:house' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
-		'place:house_name' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
-		'place:house_number' => array('label'=>'House Number','frequency'=>2086,'icon'=>'','defzoom'=>18,),
-		'place:country_code' => array('label'=>'Country Code','frequency'=>2086,'icon'=>'','defzoom'=>18,),
+	        'place:house' => array('label' => 'House','frequency' => 2086,'icon' => '','defzoom' => 18),
+	        'place:house_name' => array('label' => 'House','frequency' => 2086,'icon' => '','defzoom' => 18),
+	        'place:house_number' => array('label' => 'House Number','frequency' => 2086,'icon' => '','defzoom' => 18),
+	        'place:country_code' => array('label' => 'Country Code','frequency' => 2086,'icon' => '','defzoom' => 18),
 
-		//
+	        // /
+	        'leisure:pitch' => array('label' => 'Pitch','frequency' => 762,'icon' => ''),
+	        'highway:unsurfaced' => array('label' => 'Unsurfaced','frequency' => 492,'icon' => ''),
+	        'historic:ruins' => array('label' => 'Ruins','frequency' => 483,'icon' => 'tourist_ruin'),
+	        'amenity:college' => array('label' => 'College','frequency' => 473,'icon' => 'education_school'),
+	        'historic:monument' => array('label' => 'Monument','frequency' => 470,'icon' => 'tourist_monument'),
+	        'railway:subway' => array('label' => 'Subway','frequency' => 385,'icon' => ''),
+	        'historic:memorial' => array('label' => 'Memorial','frequency' => 382,'icon' => 'tourist_monument'),
+	        'leisure:nature_reserve' => array('label' => 'Nature Reserve','frequency' => 342,'icon' => ''),
+	        'leisure:common' => array('label' => 'Common','frequency' => 322,'icon' => ''),
+	        'waterway:lock_gate' => array('label' => 'Lock Gate','frequency' => 321,'icon' => ''),
+	        'natural:fell' => array('label' => 'Fell','frequency' => 308,'icon' => ''),
+	        'amenity:nightclub' => array('label' => 'Nightclub','frequency' => 292,'icon' => ''),
+	        'highway:path' => array('label' => 'Path','frequency' => 287,'icon' => ''),
+	        'leisure:garden' => array('label' => 'Garden','frequency' => 285,'icon' => ''),
+	        'landuse:reservoir' => array('label' => 'Reservoir','frequency' => 276,'icon' => ''),
+	        'leisure:playground' => array('label' => 'Playground','frequency' => 264,'icon' => ''),
+	        'leisure:stadium' => array('label' => 'Stadium','frequency' => 212,'icon' => ''),
+	        'historic:mine' => array('label' => 'Mine','frequency' => 193,'icon' => 'poi_mine'),
+	        'natural:cliff' => array('label' => 'Cliff','frequency' => 193,'icon' => ''),
+	        'tourism:caravan_site' => array('label' => 'Caravan Site','frequency' => 183,'icon' => 'accommodation_caravan_park'),
+	        'amenity:bus_station' => array('label' => 'Bus Station','frequency' => 181,'icon' => 'transport_bus_station'),
+	        'amenity:kindergarten' => array('label' => 'Kindergarten','frequency' => 179,'icon' => ''),
+	        'highway:construction' => array('label' => 'Construction','frequency' => 176,'icon' => ''),
+	        'amenity:atm' => array('label' => 'Atm','frequency' => 172,'icon' => 'money_atm2'),
+	        'amenity:emergency_phone' => array('label' => 'Emergency Phone','frequency' => 164,'icon' => ''),
+	        'waterway:lock' => array('label' => 'Lock','frequency' => 146,'icon' => ''),
+	        'waterway:riverbank' => array('label' => 'Riverbank','frequency' => 143,'icon' => ''),
+	        'natural:coastline' => array('label' => 'Coastline','frequency' => 142,'icon' => ''),
+	        'tourism:viewpoint' => array('label' => 'Viewpoint','frequency' => 140,'icon' => 'tourist_view_point'),
+	        'tourism:hostel' => array('label' => 'Hostel','frequency' => 140,'icon' => ''),
+	        'tourism:bed_and_breakfast' => array('label' => 'Bed And Breakfast','frequency' => 140,'icon' => 'accommodation_bed_and_breakfast'),
+	        'railway:halt' => array('label' => 'Halt','frequency' => 135,'icon' => ''),
+	        'railway:platform' => array('label' => 'Platform','frequency' => 134,'icon' => ''),
+	        'railway:tram' => array('label' => 'Tram','frequency' => 130,'icon' => 'transport_tram_stop'),
+	        'amenity:courthouse' => array('label' => 'Courthouse','frequency' => 129,'icon' => 'amenity_court'),
+	        'amenity:recycling' => array('label' => 'Recycling','frequency' => 126,'icon' => 'amenity_recycling'),
+	        'amenity:dentist' => array('label' => 'Dentist','frequency' => 124,'icon' => 'health_dentist'),
+	        'natural:beach' => array('label' => 'Beach','frequency' => 121,'icon' => 'tourist_beach'),
+	        'place:moor' => array('label' => 'Moor','frequency' => 118,'icon' => ''),
+	        'amenity:grave_yard' => array('label' => 'Grave Yard','frequency' => 110,'icon' => ''),
+	        'waterway:drain' => array('label' => 'Drain','frequency' => 108,'icon' => ''),
+	        'landuse:grass' => array('label' => 'Grass','frequency' => 106,'icon' => ''),
+	        'landuse:village_green' => array('label' => 'Village Green','frequency' => 106,'icon' => ''),
+	        'natural:bay' => array('label' => 'Bay','frequency' => 102,'icon' => ''),
+	        'railway:tram_stop' => array('label' => 'Tram Stop','frequency' => 101,'icon' => 'transport_tram_stop'),
+	        'leisure:marina' => array('label' => 'Marina','frequency' => 98,'icon' => ''),
+	        'highway:stile' => array('label' => 'Stile','frequency' => 97,'icon' => ''),
+	        'natural:moor' => array('label' => 'Moor','frequency' => 95,'icon' => ''),
+	        'railway:light_rail' => array('label' => 'Light Rail','frequency' => 91,'icon' => ''),
+	        'railway:narrow_gauge' => array('label' => 'Narrow Gauge','frequency' => 90,'icon' => ''),
+	        'natural:land' => array('label' => 'Land','frequency' => 86,'icon' => ''),
+	        'amenity:village_hall' => array('label' => 'Village Hall','frequency' => 82,'icon' => ''),
+	        'waterway:dock' => array('label' => 'Dock','frequency' => 80,'icon' => ''),
+	        'amenity:veterinary' => array('label' => 'Veterinary','frequency' => 79,'icon' => ''),
+	        'landuse:brownfield' => array('label' => 'Brownfield','frequency' => 77,'icon' => ''),
+	        'leisure:track' => array('label' => 'Track','frequency' => 76,'icon' => ''),
+	        'railway:historic_station' => array('label' => 'Historic Station','frequency' => 74,'icon' => ''),
+	        'landuse:construction' => array('label' => 'Construction','frequency' => 72,'icon' => ''),
+	        'amenity:prison' => array('label' => 'Prison','frequency' => 71,'icon' => 'amenity_prison'),
+	        'landuse:quarry' => array('label' => 'Quarry','frequency' => 71,'icon' => ''),
+	        'amenity:telephone' => array('label' => 'Telephone','frequency' => 70,'icon' => ''),
+	        'highway:traffic_signals' => array('label' => 'Traffic Signals','frequency' => 66,'icon' => ''),
+	        'natural:heath' => array('label' => 'Heath','frequency' => 62,'icon' => ''),
+	        'historic:house' => array('label' => 'House','frequency' => 61,'icon' => ''),
+	        'amenity:social_club' => array('label' => 'Social Club','frequency' => 61,'icon' => ''),
+	        'landuse:military' => array('label' => 'Military','frequency' => 61,'icon' => ''),
+	        'amenity:health_centre' => array('label' => 'Health Centre','frequency' => 59,'icon' => ''),
+	        'historic:building' => array('label' => 'Building','frequency' => 58,'icon' => ''),
+	        'amenity:clinic' => array('label' => 'Clinic','frequency' => 57,'icon' => ''),
+	        'highway:services' => array('label' => 'Services','frequency' => 56,'icon' => ''),
+	        'amenity:ferry_terminal' => array('label' => 'Ferry Terminal','frequency' => 55,'icon' => ''),
+	        'natural:marsh' => array('label' => 'Marsh','frequency' => 55,'icon' => ''),
+	        'natural:hill' => array('label' => 'Hill','frequency' => 54,'icon' => ''),
+	        'highway:raceway' => array('label' => 'Raceway','frequency' => 53,'icon' => ''),
+	        'amenity:taxi' => array('label' => 'Taxi','frequency' => 47,'icon' => ''),
+	        'amenity:take_away' => array('label' => 'Take Away','frequency' => 45,'icon' => ''),
+	        'amenity:car_rental' => array('label' => 'Car Rental','frequency' => 44,'icon' => ''),
+	        'place:islet' => array('label' => 'Islet','frequency' => 44,'icon' => ''),
+	        'amenity:nursery' => array('label' => 'Nursery','frequency' => 44,'icon' => ''),
+	        'amenity:nursing_home' => array('label' => 'Nursing Home','frequency' => 43,'icon' => ''),
+	        'amenity:toilets' => array('label' => 'Toilets','frequency' => 38,'icon' => ''),
+	        'amenity:hall' => array('label' => 'Hall','frequency' => 38,'icon' => ''),
+	        'waterway:boatyard' => array('label' => 'Boatyard','frequency' => 36,'icon' => ''),
+	        'highway:mini_roundabout' => array('label' => 'Mini Roundabout','frequency' => 35,'icon' => ''),
+	        'historic:manor' => array('label' => 'Manor','frequency' => 35,'icon' => ''),
+	        'tourism:chalet' => array('label' => 'Chalet','frequency' => 34,'icon' => ''),
+	        'amenity:bicycle_parking' => array('label' => 'Bicycle Parking','frequency' => 34,'icon' => ''),
+	        'amenity:hotel' => array('label' => 'Hotel','frequency' => 34,'icon' => ''),
+	        'waterway:weir' => array('label' => 'Weir','frequency' => 33,'icon' => ''),
+	        'natural:wetland' => array('label' => 'Wetland','frequency' => 33,'icon' => ''),
+	        'natural:cave_entrance' => array('label' => 'Cave Entrance','frequency' => 32,'icon' => ''),
+	        'amenity:crematorium' => array('label' => 'Crematorium','frequency' => 31,'icon' => ''),
+	        'tourism:picnic_site' => array('label' => 'Picnic Site','frequency' => 31,'icon' => ''),
+	        'landuse:wood' => array('label' => 'Wood','frequency' => 30,'icon' => ''),
+	        'landuse:basin' => array('label' => 'Basin','frequency' => 30,'icon' => ''),
+	        'natural:tree' => array('label' => 'Tree','frequency' => 30,'icon' => ''),
+	        'leisure:slipway' => array('label' => 'Slipway','frequency' => 29,'icon' => ''),
+	        'landuse:meadow' => array('label' => 'Meadow','frequency' => 29,'icon' => ''),
+	        'landuse:piste' => array('label' => 'Piste','frequency' => 28,'icon' => ''),
+	        'amenity:care_home' => array('label' => 'Care Home','frequency' => 28,'icon' => ''),
+	        'amenity:club' => array('label' => 'Club','frequency' => 28,'icon' => ''),
+	        'amenity:medical_centre' => array('label' => 'Medical Centre','frequency' => 27,'icon' => ''),
+	        'historic:roman_road' => array('label' => 'Roman Road','frequency' => 27,'icon' => ''),
+	        'historic:fort' => array('label' => 'Fort','frequency' => 26,'icon' => ''),
+	        'railway:subway_entrance' => array('label' => 'Subway Entrance','frequency' => 26,'icon' => ''),
+	        'historic:yes' => array('label' => 'Historic','frequency' => 25,'icon' => ''),
+	        'highway:gate' => array('label' => 'Gate','frequency' => 25,'icon' => ''),
+	        'leisure:fishing' => array('label' => 'Fishing','frequency' => 24,'icon' => ''),
+	        'historic:museum' => array('label' => 'Museum','frequency' => 24,'icon' => ''),
+	        'amenity:car_wash' => array('label' => 'Car Wash','frequency' => 24,'icon' => ''),
+	        'railway:level_crossing' => array('label' => 'Level Crossing','frequency' => 23,'icon' => ''),
+	        'leisure:bird_hide' => array('label' => 'Bird Hide','frequency' => 23,'icon' => ''),
+	        'natural:headland' => array('label' => 'Headland','frequency' => 21,'icon' => ''),
+	        'tourism:apartments' => array('label' => 'Apartments','frequency' => 21,'icon' => ''),
+	        'amenity:shopping' => array('label' => 'Shopping','frequency' => 21,'icon' => ''),
+	        'natural:scrub' => array('label' => 'Scrub','frequency' => 20,'icon' => ''),
+	        'natural:fen' => array('label' => 'Fen','frequency' => 20,'icon' => ''),
+	        'building:yes' => array('label' => 'Building','frequency' => 200,'icon' => ''),
+	        'mountain_pass:yes' => array('label' => 'Mountain Pass','frequency' => 200,'icon' => ''),
 
-		'leisure:pitch' => array('label'=>'Pitch','frequency'=>762,'icon'=>'',),
-		'highway:unsurfaced' => array('label'=>'Unsurfaced','frequency'=>492,'icon'=>'',),
-		'historic:ruins' => array('label'=>'Ruins','frequency'=>483,'icon'=>'tourist_ruin',),
-		'amenity:college' => array('label'=>'College','frequency'=>473,'icon'=>'education_school',),
-		'historic:monument' => array('label'=>'Monument','frequency'=>470,'icon'=>'tourist_monument',),
-		'railway:subway' => array('label'=>'Subway','frequency'=>385,'icon'=>'',),
-		'historic:memorial' => array('label'=>'Memorial','frequency'=>382,'icon'=>'tourist_monument',),
-		'leisure:nature_reserve' => array('label'=>'Nature Reserve','frequency'=>342,'icon'=>'',),
-		'leisure:common' => array('label'=>'Common','frequency'=>322,'icon'=>'',),
-		'waterway:lock_gate' => array('label'=>'Lock Gate','frequency'=>321,'icon'=>'',),
-		'natural:fell' => array('label'=>'Fell','frequency'=>308,'icon'=>'',),
-		'amenity:nightclub' => array('label'=>'Nightclub','frequency'=>292,'icon'=>'',),
-		'highway:path' => array('label'=>'Path','frequency'=>287,'icon'=>'',),
-		'leisure:garden' => array('label'=>'Garden','frequency'=>285,'icon'=>'',),
-		'landuse:reservoir' => array('label'=>'Reservoir','frequency'=>276,'icon'=>'',),
-		'leisure:playground' => array('label'=>'Playground','frequency'=>264,'icon'=>'',),
-		'leisure:stadium' => array('label'=>'Stadium','frequency'=>212,'icon'=>'',),
-		'historic:mine' => array('label'=>'Mine','frequency'=>193,'icon'=>'poi_mine',),
-		'natural:cliff' => array('label'=>'Cliff','frequency'=>193,'icon'=>'',),
-		'tourism:caravan_site' => array('label'=>'Caravan Site','frequency'=>183,'icon'=>'accommodation_caravan_park',),
-		'amenity:bus_station' => array('label'=>'Bus Station','frequency'=>181,'icon'=>'transport_bus_station',),
-		'amenity:kindergarten' => array('label'=>'Kindergarten','frequency'=>179,'icon'=>'',),
-		'highway:construction' => array('label'=>'Construction','frequency'=>176,'icon'=>'',),
-		'amenity:atm' => array('label'=>'Atm','frequency'=>172,'icon'=>'money_atm2',),
-		'amenity:emergency_phone' => array('label'=>'Emergency Phone','frequency'=>164,'icon'=>'',),
-		'waterway:lock' => array('label'=>'Lock','frequency'=>146,'icon'=>'',),
-		'waterway:riverbank' => array('label'=>'Riverbank','frequency'=>143,'icon'=>'',),
-		'natural:coastline' => array('label'=>'Coastline','frequency'=>142,'icon'=>'',),
-		'tourism:viewpoint' => array('label'=>'Viewpoint','frequency'=>140,'icon'=>'tourist_view_point',),
-		'tourism:hostel' => array('label'=>'Hostel','frequency'=>140,'icon'=>'',),
-		'tourism:bed_and_breakfast' => array('label'=>'Bed And Breakfast','frequency'=>140,'icon'=>'accommodation_bed_and_breakfast',),
-		'railway:halt' => array('label'=>'Halt','frequency'=>135,'icon'=>'',),
-		'railway:platform' => array('label'=>'Platform','frequency'=>134,'icon'=>'',),
-		'railway:tram' => array('label'=>'Tram','frequency'=>130,'icon'=>'transport_tram_stop',),
-		'amenity:courthouse' => array('label'=>'Courthouse','frequency'=>129,'icon'=>'amenity_court',),
-		'amenity:recycling' => array('label'=>'Recycling','frequency'=>126,'icon'=>'amenity_recycling',),
-		'amenity:dentist' => array('label'=>'Dentist','frequency'=>124,'icon'=>'health_dentist',),
-		'natural:beach' => array('label'=>'Beach','frequency'=>121,'icon'=>'tourist_beach',),
-		'place:moor' => array('label'=>'Moor','frequency'=>118,'icon'=>'',),
-		'amenity:grave_yard' => array('label'=>'Grave Yard','frequency'=>110,'icon'=>'',),
-		'waterway:drain' => array('label'=>'Drain','frequency'=>108,'icon'=>'',),
-		'landuse:grass' => array('label'=>'Grass','frequency'=>106,'icon'=>'',),
-		'landuse:village_green' => array('label'=>'Village Green','frequency'=>106,'icon'=>'',),
-		'natural:bay' => array('label'=>'Bay','frequency'=>102,'icon'=>'',),
-		'railway:tram_stop' => array('label'=>'Tram Stop','frequency'=>101,'icon'=>'transport_tram_stop',),
-		'leisure:marina' => array('label'=>'Marina','frequency'=>98,'icon'=>'',),
-		'highway:stile' => array('label'=>'Stile','frequency'=>97,'icon'=>'',),
-		'natural:moor' => array('label'=>'Moor','frequency'=>95,'icon'=>'',),
-		'railway:light_rail' => array('label'=>'Light Rail','frequency'=>91,'icon'=>'',),
-		'railway:narrow_gauge' => array('label'=>'Narrow Gauge','frequency'=>90,'icon'=>'',),
-		'natural:land' => array('label'=>'Land','frequency'=>86,'icon'=>'',),
-		'amenity:village_hall' => array('label'=>'Village Hall','frequency'=>82,'icon'=>'',),
-		'waterway:dock' => array('label'=>'Dock','frequency'=>80,'icon'=>'',),
-		'amenity:veterinary' => array('label'=>'Veterinary','frequency'=>79,'icon'=>'',),
-		'landuse:brownfield' => array('label'=>'Brownfield','frequency'=>77,'icon'=>'',),
-		'leisure:track' => array('label'=>'Track','frequency'=>76,'icon'=>'',),
-		'railway:historic_station' => array('label'=>'Historic Station','frequency'=>74,'icon'=>'',),
-		'landuse:construction' => array('label'=>'Construction','frequency'=>72,'icon'=>'',),
-		'amenity:prison' => array('label'=>'Prison','frequency'=>71,'icon'=>'amenity_prison',),
-		'landuse:quarry' => array('label'=>'Quarry','frequency'=>71,'icon'=>'',),
-		'amenity:telephone' => array('label'=>'Telephone','frequency'=>70,'icon'=>'',),
-		'highway:traffic_signals' => array('label'=>'Traffic Signals','frequency'=>66,'icon'=>'',),
-		'natural:heath' => array('label'=>'Heath','frequency'=>62,'icon'=>'',),
-		'historic:house' => array('label'=>'House','frequency'=>61,'icon'=>'',),
-		'amenity:social_club' => array('label'=>'Social Club','frequency'=>61,'icon'=>'',),
-		'landuse:military' => array('label'=>'Military','frequency'=>61,'icon'=>'',),
-		'amenity:health_centre' => array('label'=>'Health Centre','frequency'=>59,'icon'=>'',),
-		'historic:building' => array('label'=>'Building','frequency'=>58,'icon'=>'',),
-		'amenity:clinic' => array('label'=>'Clinic','frequency'=>57,'icon'=>'',),
-		'highway:services' => array('label'=>'Services','frequency'=>56,'icon'=>'',),
-		'amenity:ferry_terminal' => array('label'=>'Ferry Terminal','frequency'=>55,'icon'=>'',),
-		'natural:marsh' => array('label'=>'Marsh','frequency'=>55,'icon'=>'',),
-		'natural:hill' => array('label'=>'Hill','frequency'=>54,'icon'=>'',),
-		'highway:raceway' => array('label'=>'Raceway','frequency'=>53,'icon'=>'',),
-		'amenity:taxi' => array('label'=>'Taxi','frequency'=>47,'icon'=>'',),
-		'amenity:take_away' => array('label'=>'Take Away','frequency'=>45,'icon'=>'',),
-		'amenity:car_rental' => array('label'=>'Car Rental','frequency'=>44,'icon'=>'',),
-		'place:islet' => array('label'=>'Islet','frequency'=>44,'icon'=>'',),
-		'amenity:nursery' => array('label'=>'Nursery','frequency'=>44,'icon'=>'',),
-		'amenity:nursing_home' => array('label'=>'Nursing Home','frequency'=>43,'icon'=>'',),
-		'amenity:toilets' => array('label'=>'Toilets','frequency'=>38,'icon'=>'',),
-		'amenity:hall' => array('label'=>'Hall','frequency'=>38,'icon'=>'',),
-		'waterway:boatyard' => array('label'=>'Boatyard','frequency'=>36,'icon'=>'',),
-		'highway:mini_roundabout' => array('label'=>'Mini Roundabout','frequency'=>35,'icon'=>'',),
-		'historic:manor' => array('label'=>'Manor','frequency'=>35,'icon'=>'',),
-		'tourism:chalet' => array('label'=>'Chalet','frequency'=>34,'icon'=>'',),
-		'amenity:bicycle_parking' => array('label'=>'Bicycle Parking','frequency'=>34,'icon'=>'',),
-		'amenity:hotel' => array('label'=>'Hotel','frequency'=>34,'icon'=>'',),
-		'waterway:weir' => array('label'=>'Weir','frequency'=>33,'icon'=>'',),
-		'natural:wetland' => array('label'=>'Wetland','frequency'=>33,'icon'=>'',),
-		'natural:cave_entrance' => array('label'=>'Cave Entrance','frequency'=>32,'icon'=>'',),
-		'amenity:crematorium' => array('label'=>'Crematorium','frequency'=>31,'icon'=>'',),
-		'tourism:picnic_site' => array('label'=>'Picnic Site','frequency'=>31,'icon'=>'',),
-		'landuse:wood' => array('label'=>'Wood','frequency'=>30,'icon'=>'',),
-		'landuse:basin' => array('label'=>'Basin','frequency'=>30,'icon'=>'',),
-		'natural:tree' => array('label'=>'Tree','frequency'=>30,'icon'=>'',),
-		'leisure:slipway' => array('label'=>'Slipway','frequency'=>29,'icon'=>'',),
-		'landuse:meadow' => array('label'=>'Meadow','frequency'=>29,'icon'=>'',),
-		'landuse:piste' => array('label'=>'Piste','frequency'=>28,'icon'=>'',),
-		'amenity:care_home' => array('label'=>'Care Home','frequency'=>28,'icon'=>'',),
-		'amenity:club' => array('label'=>'Club','frequency'=>28,'icon'=>'',),
-		'amenity:medical_centre' => array('label'=>'Medical Centre','frequency'=>27,'icon'=>'',),
-		'historic:roman_road' => array('label'=>'Roman Road','frequency'=>27,'icon'=>'',),
-		'historic:fort' => array('label'=>'Fort','frequency'=>26,'icon'=>'',),
-		'railway:subway_entrance' => array('label'=>'Subway Entrance','frequency'=>26,'icon'=>'',),
-		'historic:yes' => array('label'=>'Historic','frequency'=>25,'icon'=>'',),
-		'highway:gate' => array('label'=>'Gate','frequency'=>25,'icon'=>'',),
-		'leisure:fishing' => array('label'=>'Fishing','frequency'=>24,'icon'=>'',),
-		'historic:museum' => array('label'=>'Museum','frequency'=>24,'icon'=>'',),
-		'amenity:car_wash' => array('label'=>'Car Wash','frequency'=>24,'icon'=>'',),
-		'railway:level_crossing' => array('label'=>'Level Crossing','frequency'=>23,'icon'=>'',),
-		'leisure:bird_hide' => array('label'=>'Bird Hide','frequency'=>23,'icon'=>'',),
-		'natural:headland' => array('label'=>'Headland','frequency'=>21,'icon'=>'',),
-		'tourism:apartments' => array('label'=>'Apartments','frequency'=>21,'icon'=>'',),
-		'amenity:shopping' => array('label'=>'Shopping','frequency'=>21,'icon'=>'',),
-		'natural:scrub' => array('label'=>'Scrub','frequency'=>20,'icon'=>'',),
-		'natural:fen' => array('label'=>'Fen','frequency'=>20,'icon'=>'',),
-		'building:yes' => array('label'=>'Building','frequency'=>200,'icon'=>'',),
-		'mountain_pass:yes' => array('label'=>'Mountain Pass','frequency'=>200,'icon'=>'',),
+	        'amenity:parking'  => array('label' => 'Parking','frequency' => 3157,'icon' => ''),
+	        'highway:bus_stop' => array('label' => 'Bus Stop','frequency' => 35777,'icon' => 'transport_bus_stop2'),
+	        'place:postcode'   => array('label' => 'Postcode','frequency' => 27267,'icon' => ''),
+	        'amenity:post_box' => array('label' => 'Post Box','frequency' => 9613,'icon' => ''),
 
-		'amenity:parking' => array('label'=>'Parking','frequency'=>3157,'icon'=>'',),
-		'highway:bus_stop' => array('label'=>'Bus Stop','frequency'=>35777,'icon'=>'transport_bus_stop2',),
-		'place:postcode' => array('label'=>'Postcode','frequency'=>27267,'icon'=>'',),
-		'amenity:post_box' => array('label'=>'Post Box','frequency'=>9613,'icon'=>'',),
+	        'place:houses' => array('label' => 'Houses','frequency' => 85,'icon' => ''),
+	        'railway:preserved' => array('label' => 'Preserved','frequency' => 227,'icon' => ''),
+	        'waterway:derelict_canal' => array('label' => 'Derelict Canal','frequency' => 21,'icon' => ''),
+	        'amenity:dead_pub' => array('label' => 'Dead Pub','frequency' => 20,'icon' => ''),
+	        'railway:disused_station' => array('label' => 'Disused Station','frequency' => 114,'icon' => ''),
+	        'railway:abandoned' => array('label' => 'Abandoned','frequency' => 641,'icon' => ''),
+	        'railway:disused' => array('label' => 'Disused','frequency' => 72,'icon' => ''),
+	       );
 
-		'place:houses' => array('label'=>'Houses','frequency'=>85,'icon'=>'',),
-		'railway:preserved' => array('label'=>'Preserved','frequency'=>227,'icon'=>'',),
-		'waterway:derelict_canal' => array('label'=>'Derelict Canal','frequency'=>21,'icon'=>'',),
-		'amenity:dead_pub' => array('label'=>'Dead Pub','frequency'=>20,'icon'=>'',),
-		'railway:disused_station' => array('label'=>'Disused Station','frequency'=>114,'icon'=>'',),
-		'railway:abandoned' => array('label'=>'Abandoned','frequency'=>641,'icon'=>'',),
-		'railway:disused' => array('label'=>'Disused','frequency'=>72,'icon'=>'',),
-	);
-}
+}//end getClassTypes()
 
 
 function getClassTypesWithImportance()
@@ -485,8 +500,11 @@ function getClassTypesWithImportance()
 	foreach ($aOrders as $sID => $a) {
 		$aOrders[$sID]['importance'] = $i++;
 	}
+
 	return $aOrders;
-}
+
+}//end getClassTypesWithImportance()
+
 
 function getResultDiameter($aResult)
 {
@@ -495,20 +513,23 @@ function getResultDiameter($aResult)
 	$fDiameter = 0.0001;
 
 	if (isset($aResult['class'])
-		  && isset($aResult['type'])
-		  && isset($aResult['admin_level'])
-		  && isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
-			&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter']) {
+	    && isset($aResult['type'])
+	    && isset($aResult['admin_level'])
+	    && isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
+	    && $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter']
+	) {
 		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'];
-	} elseif (isset($aResult['class'])
-		  && isset($aResult['type'])
-		  && isset($aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
-			&& $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter']) {
+	} else if (isset($aResult['class'])
+	    && isset($aResult['type'])
+	    && isset($aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
+	    && $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter']
+	) {
 		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'];
 	}
 
 	return $fDiameter;
-}
+
+}//end getResultDiameter()
 
 
 function javascript_renderData($xVal, $iOptions = 0)
@@ -528,7 +549,8 @@ function javascript_renderData($xVal, $iOptions = 0)
 			header('HTTP/1.0 400 Bad Request');
 		}
 	}
-}
+
+}//end javascript_renderData()
 
 
 function _debugDumpGroupedSearches($aData, $aTokens)
@@ -543,8 +565,10 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 			}
 		}
 	}
+
 	echo "<table border=\"1\">";
 	echo "<tr><th>rank</th><th>Name Tokens</th><th>Name Not</th><th>Address Tokens</th><th>Address Not</th><th>country</th><th>operator</th><th>class</th><th>type</th><th>house#</th><th>Lat</th><th>Lon</th><th>Radius</th></tr>";
+
 	foreach ($aData as $iRank => $aRankedSet) {
 		foreach ($aRankedSet as $aRow) {
 			echo "<tr>";
@@ -556,6 +580,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
+
 			echo "</td>";
 
 			echo "<td>";
@@ -564,6 +589,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
+
 			echo "</td>";
 
 			echo "<td>";
@@ -572,6 +598,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
+
 			echo "</td>";
 
 			echo "<td>";
@@ -580,6 +607,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
+
 			echo "</td>";
 
 			echo "<td>".$aRow['sCountryCode']."</td>";
@@ -595,10 +623,12 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 			echo "<td>".$aRow['fRadius']."</td>";
 
 			echo "</tr>";
-		}
-	}
+		}//end foreach
+	}//end foreach
+
 	echo "</table>";
-}
+
+}//end _debugDumpGroupedSearches()
 
 
 function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCode = false, $housenumber = -1, $bRaw = false)
@@ -609,8 +639,8 @@ function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCo
 
 	$aAddressLines = chksql($oDB->getAll($sSQL));
 	if ($bRaw) return $aAddressLines;
-	//echo "<pre>";
-	//var_dump($aAddressLines);
+	// echo "<pre>";
+	// var_dump($aAddressLines);
 	$aAddress = array();
 	$aFallback = array();
 	$aClassType = getClassTypes();
@@ -619,110 +649,137 @@ function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCo
 		$aTypeLabel = false;
 		if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) {
 			$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-		} elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
+		} else if (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
 			$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-		} elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))])) {
-			$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
+		} else if (isset($aClassType['boundary:administrative:'.((int) ($aLine['rank_address'] / 2))])) {
+			$aTypeLabel = $aClassType['boundary:administrative:'.((int) ($aLine['rank_address'] / 2))];
 			$bFallback = true;
 		} else {
-			$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
+			$aTypeLabel = array('simplelabel' => 'address'.$aLine['rank_address']);
 			$bFallback = true;
 		}
 
 		if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber']))) {
-			$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
+			$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel']) ? $aTypeLabel['simplelabel'] : $aTypeLabel['label']);
 			$sTypeLabel = str_replace(' ', '_', $sTypeLabel);
 			if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place') {
-				$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
+				$aAddress[$sTypeLabel] = $aLine['localname'] ? $aLine['localname'] : $aLine['housenumber'];
 			}
+
 			$aFallback[$sTypeLabel] = $bFallback;
 		}
-	}
+	}//end foreach
 	return $aAddress;
-}
+
+}//end getAddressDetails()
 
 
 function addQuotes($s)
 {
 	return "'".$s."'";
-}
 
-// returns boolean
-function validLatLon($fLat,$ fLon)
+}//end addQuotes()
+
+
+function validLatLon($fLat,$ fLon) // returns boolean
 {
 	return ($fLat <= 90.1 && $fLat >= -90.1 && $fLon <= 180.1 && $fLon >= -180.1);
-}
 
-// Do we have anything that looks like a lat/lon pair?
-// returns array(lat,lon,query_with_lat_lon_removed)
-// or null
+}//end validLatLon()
+
+
 function looksLikeLatLonPair($sQuery)
 {
+	// Do we have anything that looks like a lat/lon pair?
+	// returns array(lat,lon,query_with_lat_lon_removed)
+	// or null
 	$sFound    = null;
 	$fQueryLat = null;
 	$fQueryLon = null;
 
 	if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData)) {
-		//                1         2                   3                  4         5            6
-		// degrees decimal minutes
-		// N 40 26.767, W 79 58.933
-		// N 40°26.767′, W 79°58.933′
+		/*
+		    ______________1         2                   3                  4         5            6
+		    degrees decimal minutes
+		    N 40 26.767, W 79 58.933
+		    N 40°26.767′, W 79°58.933′
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
-		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
-	} elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData)) {
-		//                      1             2                      3          4            5                    6
-		// degrees decimal minutes
-		// 40 26.767 N, 79 58.933 W
-		// 40° 26.767′ N 79° 58.933′ W
+		$fQueryLat = (($aData[1] == 'N' ? 1 : -1) * ($aData[2] + $aData[3] / 60));
+		$fQueryLon = (($aData[4] == 'E' ? 1 : -1) * ($aData[5] + $aData[6] / 60));
+	} else if (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData)) {
+		/*
+		    _____________________1             2                      3          4            5                    6
+		    degrees decimal minutes
+		    40 26.767 N, 79 58.933 W
+		    40° 26.767′ N 79° 58.933′ W
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
-		$fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
-	} elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData)) {
-		//                      1        2            3            4                5        6            7            8
-		// degrees decimal seconds
-		// N 40 26 46 W 79 58 56
-		// N 40° 26′ 46″, W 79° 58′ 56″
+		$fQueryLat = (($aData[3] == 'N' ? 1 : -1) * ($aData[1] + $aData[2] / 60));
+		$fQueryLon = (($aData[6] == 'E' ? 1 : -1) * ($aData[4] + $aData[5] / 60));
+	} else if (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData)) {
+		/*
+		    _____________________1        2            3            4                5        6            7            8
+		    degrees decimal seconds
+		    N 40 26 46 W 79 58 56
+		    N 40° 26′ 46″, W 79° 58′ 56″
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
-		$fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
-	} elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData)) {
-		//                      1            2            3            4          5            6            7            8
-		// degrees decimal seconds
-		// 40 26 46 N 79 58 56 W
-		// 40° 26′ 46″ N, 79° 58′ 56″ W
+		$fQueryLat = (($aData[1] == 'N' ? 1 : -1) * ($aData[2] + $aData[3] / 60 + $aData[4] / 3600));
+		$fQueryLon = (($aData[5] == 'E' ? 1 : -1) * ($aData[6] + $aData[7] / 60 + $aData[8] / 3600));
+	} else if (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData)) {
+		/*
+		    _____________________1            2            3            4          5            6            7            8
+		    degrees decimal seconds
+		    40 26 46 N 79 58 56 W
+		    40° 26′ 46″ N, 79° 58′ 56″ W
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
-		$fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
-	} elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData)) {
-		//                      1        2                               3        4
-		// degrees decimal
-		// N 40.446° W 79.982°
+		$fQueryLat = (($aData[4] == 'N' ? 1 : -1) * ($aData[1] + $aData[2] / 60 + $aData[3] / 3600));
+		$fQueryLon = (($aData[8] == 'E' ? 1 : -1) * ($aData[5] + $aData[6] / 60 + $aData[7] / 3600));
+	} else if (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData)) {
+		/*
+		    _____________________1        2                               3        4
+		    degrees decimal
+		    N 40.446° W 79.982°
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
-		$fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
-	} elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData)) {
-		//                      1                           2          3                           4
-		// degrees decimal
-		// 40.446° N 79.982° W
+		$fQueryLat = (($aData[1] == 'N' ? 1 : -1) * ($aData[2]));
+		$fQueryLon = (($aData[3] == 'E' ? 1 : -1) * ($aData[4]));
+	} else if (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData)) {
+		/*
+		    ______________________1                           2          3                           4
+		    degrees decimal
+		    40.446° N 79.982° W
+		*/
+
 		$sFound    = $aData[0];
-		$fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
-		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
-	} elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
-		//                   1          2                             3                        4
-		// degrees decimal
-		// 12.34, 56.78
-		// [12.456,-78.90]
+		$fQueryLat = (($aData[2] == 'N' ? 1 : -1) * ($aData[1]));
+		$fQueryLon = (($aData[4] == 'E' ? 1 : -1) * ($aData[3]));
+	} else if (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
+		/*
+		    ____________________1          2                             3                        4
+		    degrees decimal
+		    12.34, 56.78
+		    [12.456,-78.90]
+		*/
+
 		$sFound    = $aData[0];
 		$fQueryLat = $aData[2];
 		$fQueryLon = $aData[3];
-	}
+	}//end if
 
 	if (!validLatLon($fQueryLat, $fQueryLon)) return;
 	$sQuery = trim(str_replace($sFound, ' ', $sQuery));
 
 	return array('lat' => $fQueryLat, 'lon' => $fQueryLon, 'query' => $sQuery);
-}
+
+}//end looksLikeLatLonPair()
 
 
 function geometryText2Points($geometry_as_text, $fRadius)
@@ -730,11 +787,11 @@ function geometryText2Points($geometry_as_text, $fRadius)
 	$aPolyPoints = null;
 	if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	} elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
+	} else if (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	} elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
+	} else if (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	} elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch)) {
+	} else if (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch)) {
 		$aPolyPoints = createPointsAroundCenter($aMatch[1], $aMatch[2], $fRadius);
 	}
 
@@ -743,19 +800,24 @@ function geometryText2Points($geometry_as_text, $fRadius)
 		foreach ($aPolyPoints as $aPoint) {
 			$aResultPoints[] = array($aPoint[1], $aPoint[2]);
 		}
+
 		return $aResultPoints;
 	}
 
 	return;
-}
+
+}//end geometryText2Points()
+
 
 function createPointsAroundCenter($fLon, $fLat, $fRadius)
 {
-	$iSteps = max(8, min(100, ($fRadius * 40000)^2));
-	$fStepSize = (2*pi())/$iSteps;
+	$iSteps = max(8, min(100, (($fRadius * 40000) ^ 2)));
+	$fStepSize = ((2 * pi()) / $iSteps);
 	$aPolyPoints = array();
-	for ($f = 0; $f < 2*pi(); $f += $fStepSize) {
-		$aPolyPoints[] = array('', $fLon+($fRadius*sin($f)), $fLat+($fRadius*cos($f)) );
+	for ($f = 0; $f < (2 * pi()); $f += $fStepSize) {
+		$aPolyPoints[] = array('', $fLon + ($fRadius * sin($f)), ($fLat + $fRadius * cos($f)) );
 	}
+
 	return $aPolyPoints;
-}
+
+}//end createPointsAroundCenter()

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -50,29 +50,22 @@ function byImportance($a, $b)
 }
 
 
-function getPreferredLanguages($sLangString=false)
+function getPreferredLanguages($sLangString = false)
 {
-	if (!$sLangString)
-	{
+	if (!$sLangString) {
 		// If we have been provided the value in $_GET it overrides browser value
-		if (isset($_GET['accept-language']) && $_GET['accept-language'])
-		{
+		if (isset($_GET['accept-language']) && $_GET['accept-language']) {
 			$_SERVER["HTTP_ACCEPT_LANGUAGE"] = $_GET['accept-language'];
 			$sLangString = $_GET['accept-language'];
-		}
-		else if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"]))
-		{
+		} elseif (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) {
 			$sLangString = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
 		}
 	}
 
 	$aLanguages = array();
-	if ($sLangString)
-	{
-		if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER))
-		{
-			foreach($aLanguagesParse as $iLang => $aLanguage)
-			{
+	if ($sLangString) {
+		if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER)) {
+			foreach ($aLanguagesParse as $iLang => $aLanguage) {
 				$aLanguages[$aLanguage[1]] = isset($aLanguage[5])?(float)$aLanguage[5]:1 - ($iLang/100);
 				if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = $aLanguages[$aLanguage[1]]/10;
 			}
@@ -80,20 +73,20 @@ function getPreferredLanguages($sLangString=false)
 		}
 	}
 	if (!sizeof($aLanguages) && CONST_Default_Language) $aLanguages = array(CONST_Default_Language=>1);
-	foreach($aLanguages as $sLangauge => $fLangauagePref)
-	{
+
+	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['short_name:'.$sLangauge] = 'short_name:'.$sLangauge;
 	}
-	foreach($aLanguages as $sLangauge => $fLangauagePref)
-	{
+
+	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['name:'.$sLangauge] = 'name:'.$sLangauge;
 	}
-	foreach($aLanguages as $sLangauge => $fLangauagePref)
-	{
+
+	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['place_name:'.$sLangauge] = 'place_name:'.$sLangauge;
 	}
-	foreach($aLanguages as $sLangauge => $fLangauagePref)
-	{
+
+	foreach ($aLanguages as $sLangauge => $fLangauagePref) {
 		$aLangPrefOrder['official_name:'.$sLangauge] = 'official_name:'.$sLangauge;
 	}
 	$aLangPrefOrder['short_name'] = 'short_name';
@@ -108,17 +101,15 @@ function getPreferredLanguages($sLangString=false)
 
 function getWordSets($aWords, $iDepth)
 {
-	$aResult = array(array(join(' ',$aWords)));
+	$aResult = array(array(join(' ', $aWords)));
 	$sFirstToken = '';
 	if ($iDepth < 8) {
-		while(sizeof($aWords) > 1)
-		{
+		while (sizeof($aWords) > 1) {
 			$sWord = array_shift($aWords);
 			$sFirstToken .= ($sFirstToken?' ':'').$sWord;
 			$aRest = getWordSets($aWords, $iDepth+1);
-			foreach($aRest as $aSet)
-			{
-				$aResult[] = array_merge(array($sFirstToken),$aSet);
+			foreach ($aRest as $aSet) {
+				$aResult[] = array_merge(array($sFirstToken), $aSet);
 			}
 		}
 	}
@@ -127,18 +118,15 @@ function getWordSets($aWords, $iDepth)
 
 function getInverseWordSets($aWords, $iDepth)
 {
-	$aResult = array(array(join(' ',$aWords)));
+	$aResult = array(array(join(' ', $aWords)));
 	$sFirstToken = '';
-	if ($iDepth < 8)
-	{
-		while(sizeof($aWords) > 1)
-		{
+	if ($iDepth < 8) {
+		while (sizeof($aWords) > 1) {
 			$sWord = array_pop($aWords);
 			$sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
 			$aRest = getInverseWordSets($aWords, $iDepth+1);
-			foreach($aRest as $aSet)
-			{
-				$aResult[] = array_merge(array($sFirstToken),$aSet);
+			foreach ($aRest as $aSet) {
+				$aResult[] = array_merge(array($sFirstToken), $aSet);
 			}
 		}
 	}
@@ -149,10 +137,8 @@ function getInverseWordSets($aWords, $iDepth)
 function getTokensFromSets($aSets)
 {
 	$aTokens = array();
-	foreach($aSets as $aSet)
-	{
-		foreach($aSet as $sWord)
-		{
+	foreach ($aSets as $aSet) {
+		foreach ($aSet as $sWord) {
 			$aTokens[' '.$sWord] = ' '.$sWord;
 			$aTokens[$sWord] = $sWord;
 		}
@@ -171,11 +157,9 @@ function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
 	$sSQL = 'select \'AA\', ST_X(ST_Centroid(geometry)) as lon,ST_Y(ST_Centroid(geometry)) as lat from gb_postcode where postcode = \''.$sPostcode.'\'';
 	$aNearPostcodes = chksql($oDB->getAll($sSQL));
 
-	if (sizeof($aNearPostcodes))
-	{
+	if (sizeof($aNearPostcodes)) {
 		$aPostcodes = array();
-		foreach($aNearPostcodes as $aPostcode)
-		{
+		foreach ($aNearPostcodes as $aPostcode) {
 			$aPostcodes[] = array('lat' => $aPostcode['lat'], 'lon' => $aPostcode['lon'], 'radius' => 0.005);
 		}
 
@@ -498,8 +482,7 @@ function getClassTypesWithImportance()
 {
 	$aOrders = getClassTypes();
 	$i = 1;
-	foreach($aOrders as $sID => $a)
-	{
+	foreach ($aOrders as $sID => $a) {
 		$aOrders[$sID]['importance'] = $i++;
 	}
 	return $aOrders;
@@ -515,15 +498,12 @@ function getResultDiameter($aResult)
 		  && isset($aResult['type'])
 		  && isset($aResult['admin_level'])
 		  && isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
-			&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
-	{
+			&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter']) {
 		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'];
-	}
-	elseif (isset($aResult['class'])
+	} elseif (isset($aResult['class'])
 		  && isset($aResult['type'])
 		  && isset($aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
-			&& $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
-	{
+			&& $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter']) {
 		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'];
 	}
 
@@ -537,19 +517,14 @@ function javascript_renderData($xVal, $iOptions = 0)
 		$iOptions |= JSON_UNESCAPED_UNICODE;
 	$jsonout = json_encode($xVal, $iOptions);
 
-	if( ! isset($_GET['json_callback']))
-	{
+	if (! isset($_GET['json_callback'])) {
 		header("Content-Type: application/json; charset=UTF-8");
 		echo $jsonout;
-	} else
-	{
-		if (preg_match('/^[$_\p{L}][$_\p{L}\p{Nd}.[\]]*$/u',$_GET['json_callback']))
-		{
+	} else {
+		if (preg_match('/^[$_\p{L}][$_\p{L}\p{Nd}.[\]]*$/u', $_GET['json_callback'])) {
 			header("Content-Type: application/javascript; charset=UTF-8");
 			echo $_GET['json_callback'].'('.$jsonout.')';
-		}
-		else
-		{
+		} else {
 			header('HTTP/1.0 400 Bad Request');
 		}
 	}
@@ -559,14 +534,10 @@ function javascript_renderData($xVal, $iOptions = 0)
 function _debugDumpGroupedSearches($aData, $aTokens)
 {
 	$aWordsIDs = array();
-	if ($aTokens)
-	{
-		foreach($aTokens as $sToken => $aWords)
-		{
-			if ($aWords)
-			{
-				foreach($aWords as $aToken)
-				{
+	if ($aTokens) {
+		foreach ($aTokens as $sToken => $aWords) {
+			if ($aWords) {
+				foreach ($aWords as $aToken) {
 					$aWordsIDs[$aToken['word_id']] = $sToken.'('.$aToken['word_id'].')';
 				}
 			}
@@ -574,17 +545,14 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 	}
 	echo "<table border=\"1\">";
 	echo "<tr><th>rank</th><th>Name Tokens</th><th>Name Not</th><th>Address Tokens</th><th>Address Not</th><th>country</th><th>operator</th><th>class</th><th>type</th><th>house#</th><th>Lat</th><th>Lon</th><th>Radius</th></tr>";
-	foreach($aData as $iRank => $aRankedSet)
-	{
-		foreach($aRankedSet as $aRow)
-		{
+	foreach ($aData as $iRank => $aRankedSet) {
+		foreach ($aRankedSet as $aRow) {
 			echo "<tr>";
 			echo "<td>$iRank</td>";
 
 			echo "<td>";
 			$sSep = '';
-			foreach($aRow['aName'] as $iWordID)
-			{
+			foreach ($aRow['aName'] as $iWordID) {
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
@@ -592,8 +560,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 
 			echo "<td>";
 			$sSep = '';
-			foreach($aRow['aNameNonSearch'] as $iWordID)
-			{
+			foreach ($aRow['aNameNonSearch'] as $iWordID) {
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
@@ -601,8 +568,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 
 			echo "<td>";
 			$sSep = '';
-			foreach($aRow['aAddress'] as $iWordID)
-			{
+			foreach ($aRow['aAddress'] as $iWordID) {
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
@@ -610,8 +576,7 @@ function _debugDumpGroupedSearches($aData, $aTokens)
 
 			echo "<td>";
 			$sSep = '';
-			foreach($aRow['aAddressNonSearch'] as $iWordID)
-			{
+			foreach ($aRow['aAddressNonSearch'] as $iWordID) {
 				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
 				$sSep = ', ';
 			}
@@ -649,28 +614,25 @@ function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCo
 	$aAddress = array();
 	$aFallback = array();
 	$aClassType = getClassTypes();
-	foreach($aAddressLines as $aLine)
-	{
+	foreach ($aAddressLines as $aLine) {
 		$bFallback = false;
 		$aTypeLabel = false;
-		if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-		elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-		elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
-		{
+		if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) {
+			$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
+		} elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) {
+			$aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
+		} elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))])) {
 			$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
 			$bFallback = true;
-		}
-		else
-		{
+		} else {
 			$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
 			$bFallback = true;
 		}
-		if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
-		{
+
+		if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber']))) {
 			$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
-			$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-			if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
-			{
+			$sTypeLabel = str_replace(' ', '_', $sTypeLabel);
+			if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place') {
 				$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
 			}
 			$aFallback[$sTypeLabel] = $bFallback;
@@ -686,7 +648,7 @@ function addQuotes($s)
 }
 
 // returns boolean
-function validLatLon($fLat,$fLon)
+function validLatLon($fLat,$ fLon)
 {
 	return ($fLat <= 90.1 && $fLat >= -90.1 && $fLon <= 180.1 && $fLon >= -180.1);
 }
@@ -700,70 +662,57 @@ function looksLikeLatLonPair($sQuery)
 	$fQueryLat = null;
 	$fQueryLon = null;
 
-	// degrees decimal minutes
-	// N 40 26.767, W 79 58.933
-	// N 40°26.767′, W 79°58.933′
-	//                  1         2                   3                  4         5            6
-	if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData))
-	{
+	if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData)) {
+		//                1         2                   3                  4         5            6
+		// degrees decimal minutes
+		// N 40 26.767, W 79 58.933
+		// N 40°26.767′, W 79°58.933′
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
 		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
-	}
-	// degrees decimal minutes
-	// 40 26.767 N, 79 58.933 W
-	// 40° 26.767′ N 79° 58.933′ W
-	//                      1             2                      3          4            5                    6
-	elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData)) {
+		//                      1             2                      3          4            5                    6
+		// degrees decimal minutes
+		// 40 26.767 N, 79 58.933 W
+		// 40° 26.767′ N 79° 58.933′ W
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
 		$fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
-	}
-	// degrees decimal seconds
-	// N 40 26 46 W 79 58 56
-	// N 40° 26′ 46″, W 79° 58′ 56″
-	//                      1        2            3            4                5        6            7            8
-	elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData)) {
+		//                      1        2            3            4                5        6            7            8
+		// degrees decimal seconds
+		// N 40 26 46 W 79 58 56
+		// N 40° 26′ 46″, W 79° 58′ 56″
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
 		$fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
-	}
-	// degrees decimal seconds
-	// 40 26 46 N 79 58 56 W
-	// 40° 26′ 46″ N, 79° 58′ 56″ W
-	//                      1            2            3            4          5            6            7            8
-	elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData)) {
+		//                      1            2            3            4          5            6            7            8
+		// degrees decimal seconds
+		// 40 26 46 N 79 58 56 W
+		// 40° 26′ 46″ N, 79° 58′ 56″ W
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
 		$fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
-	}
-	// degrees decimal
-	// N 40.446° W 79.982°
-	//                      1        2                               3        4
-	elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData)) {
+		//                      1        2                               3        4
+		// degrees decimal
+		// N 40.446° W 79.982°
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
 		$fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
-	}
-	// degrees decimal
-	// 40.446° N 79.982° W
-	//                      1                           2          3                           4
-	elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData)) {
+		//                      1                           2          3                           4
+		// degrees decimal
+		// 40.446° N 79.982° W
 		$sFound    = $aData[0];
 		$fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
 		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
-	}
-	// degrees decimal
-	// 12.34, 56.78
-	// [12.456,-78.90]
-	//                   1          2                             3                        4
-	elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData))
-	{
+	} elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
+		//                   1          2                             3                        4
+		// degrees decimal
+		// 12.34, 56.78
+		// [12.456,-78.90]
 		$sFound    = $aData[0];
 		$fQueryLat = $aData[2];
 		$fQueryLon = $aData[3];
@@ -778,29 +727,20 @@ function looksLikeLatLonPair($sQuery)
 
 function geometryText2Points($geometry_as_text, $fRadius)
 {
-	$aPolyPoints = NULL;
-	if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-	{
+	$aPolyPoints = null;
+	if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	}
-	elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-	{
+	} elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	}
-	elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-	{
+	} elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
 		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-	}
-	elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch))
-	{
+	} elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch)) {
 		$aPolyPoints = createPointsAroundCenter($aMatch[1], $aMatch[2], $fRadius);
 	}
 
-	if (isset($aPolyPoints))
-	{
+	if (isset($aPolyPoints)) {
 		$aResultPoints = array();
-		foreach($aPolyPoints as $aPoint)
-		{
+		foreach ($aPolyPoints as $aPoint) {
 			$aResultPoints[] = array($aPoint[1], $aPoint[2]);
 		}
 		return $aResultPoints;
@@ -811,12 +751,11 @@ function geometryText2Points($geometry_as_text, $fRadius)
 
 function createPointsAroundCenter($fLon, $fLat, $fRadius)
 {
-		$iSteps = max(8, min(100, ($fRadius * 40000)^2));
-		$fStepSize = (2*pi())/$iSteps;
-		$aPolyPoints = array();
-		for($f = 0; $f < 2*pi(); $f += $fStepSize)
-		{
-			$aPolyPoints[] = array('', $fLon+($fRadius*sin($f)), $fLat+($fRadius*cos($f)) );
-		}
-		return $aPolyPoints;
+	$iSteps = max(8, min(100, ($fRadius * 40000)^2));
+	$fStepSize = (2*pi())/$iSteps;
+	$aPolyPoints = array();
+	for ($f = 0; $f < 2*pi(); $f += $fStepSize) {
+		$aPolyPoints[] = array('', $fLon+($fRadius*sin($f)), $fLat+($fRadius*cos($f)) );
+	}
+	return $aPolyPoints;
 }

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -1,822 +1,822 @@
 <?php
 
-	function fail($sError, $sUserError = false)
+function fail($sError, $sUserError = false)
+{
+	if (!$sUserError) $sUserError = $sError;
+	error_log('ERROR: '.$sError);
+	echo $sUserError."\n";
+	exit(-1);
+}
+
+
+function getProcessorCount()
+{
+	$sCPU = file_get_contents('/proc/cpuinfo');
+	preg_match_all('#processor\s+: [0-9]+#', $sCPU, $aMatches);
+	return sizeof($aMatches[0]);
+}
+
+
+function getTotalMemoryMB()
+{
+	$sCPU = file_get_contents('/proc/meminfo');
+	preg_match('#MemTotal: +([0-9]+) kB#', $sCPU, $aMatches);
+	return (int)($aMatches[1]/1024);
+}
+
+
+function getCacheMemoryMB()
+{
+	$sCPU = file_get_contents('/proc/meminfo');
+	preg_match('#Cached: +([0-9]+) kB#', $sCPU, $aMatches);
+	return (int)($aMatches[1]/1024);
+}
+
+
+function bySearchRank($a, $b)
+{
+	if ($a['iSearchRank'] == $b['iSearchRank'])
+		return strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']);
+	return ($a['iSearchRank'] < $b['iSearchRank']?-1:1);
+}
+
+
+function byImportance($a, $b)
+{
+	if ($a['importance'] != $b['importance'])
+		return ($a['importance'] > $b['importance']?-1:1);
+
+	return ($a['foundorder'] < $b['foundorder']?-1:1);
+}
+
+
+function getPreferredLanguages($sLangString=false)
+{
+	if (!$sLangString)
 	{
-		if (!$sUserError) $sUserError = $sError;
-		error_log('ERROR: '.$sError);
-		echo $sUserError."\n";
-		exit(-1);
-	}
-
-
-	function getProcessorCount()
-	{
-		$sCPU = file_get_contents('/proc/cpuinfo');
-		preg_match_all('#processor\s+: [0-9]+#', $sCPU, $aMatches);
-		return sizeof($aMatches[0]);
-	}
-
-
-	function getTotalMemoryMB()
-	{
-		$sCPU = file_get_contents('/proc/meminfo');
-		preg_match('#MemTotal: +([0-9]+) kB#', $sCPU, $aMatches);
-		return (int)($aMatches[1]/1024);
-	}
-
-
-	function getCacheMemoryMB()
-	{
-		$sCPU = file_get_contents('/proc/meminfo');
-		preg_match('#Cached: +([0-9]+) kB#', $sCPU, $aMatches);
-		return (int)($aMatches[1]/1024);
-	}
-
-
-	function bySearchRank($a, $b)
-	{
-		if ($a['iSearchRank'] == $b['iSearchRank'])
-			return strlen($a['sOperator']) + strlen($a['sHouseNumber']) - strlen($b['sOperator']) - strlen($b['sHouseNumber']);
-		return ($a['iSearchRank'] < $b['iSearchRank']?-1:1);
-	}
-
-
-	function byImportance($a, $b)
-	{
-		if ($a['importance'] != $b['importance'])
-			return ($a['importance'] > $b['importance']?-1:1);
-
-		return ($a['foundorder'] < $b['foundorder']?-1:1);
-	}
-
-
-	function getPreferredLanguages($sLangString=false)
-	{
-		if (!$sLangString)
+		// If we have been provided the value in $_GET it overrides browser value
+		if (isset($_GET['accept-language']) && $_GET['accept-language'])
 		{
-			// If we have been provided the value in $_GET it overrides browser value
-			if (isset($_GET['accept-language']) && $_GET['accept-language'])
+			$_SERVER["HTTP_ACCEPT_LANGUAGE"] = $_GET['accept-language'];
+			$sLangString = $_GET['accept-language'];
+		}
+		else if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"]))
+		{
+			$sLangString = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
+		}
+	}
+
+	$aLanguages = array();
+	if ($sLangString)
+	{
+		if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER))
+		{
+			foreach($aLanguagesParse as $iLang => $aLanguage)
 			{
-				$_SERVER["HTTP_ACCEPT_LANGUAGE"] = $_GET['accept-language'];
-				$sLangString = $_GET['accept-language'];
+				$aLanguages[$aLanguage[1]] = isset($aLanguage[5])?(float)$aLanguage[5]:1 - ($iLang/100);
+				if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = $aLanguages[$aLanguage[1]]/10;
 			}
-			else if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"]))
+			arsort($aLanguages);
+		}
+	}
+	if (!sizeof($aLanguages) && CONST_Default_Language) $aLanguages = array(CONST_Default_Language=>1);
+	foreach($aLanguages as $sLangauge => $fLangauagePref)
+	{
+		$aLangPrefOrder['short_name:'.$sLangauge] = 'short_name:'.$sLangauge;
+	}
+	foreach($aLanguages as $sLangauge => $fLangauagePref)
+	{
+		$aLangPrefOrder['name:'.$sLangauge] = 'name:'.$sLangauge;
+	}
+	foreach($aLanguages as $sLangauge => $fLangauagePref)
+	{
+		$aLangPrefOrder['place_name:'.$sLangauge] = 'place_name:'.$sLangauge;
+	}
+	foreach($aLanguages as $sLangauge => $fLangauagePref)
+	{
+		$aLangPrefOrder['official_name:'.$sLangauge] = 'official_name:'.$sLangauge;
+	}
+	$aLangPrefOrder['short_name'] = 'short_name';
+	$aLangPrefOrder['name'] = 'name';
+	$aLangPrefOrder['place_name'] = 'place_name';
+	$aLangPrefOrder['official_name'] = 'official_name';
+	$aLangPrefOrder['ref'] = 'ref';
+	$aLangPrefOrder['type'] = 'type';
+	return $aLangPrefOrder;
+}
+
+
+function getWordSets($aWords, $iDepth)
+{
+	$aResult = array(array(join(' ',$aWords)));
+	$sFirstToken = '';
+	if ($iDepth < 8) {
+		while(sizeof($aWords) > 1)
+		{
+			$sWord = array_shift($aWords);
+			$sFirstToken .= ($sFirstToken?' ':'').$sWord;
+			$aRest = getWordSets($aWords, $iDepth+1);
+			foreach($aRest as $aSet)
 			{
-				$sLangString = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
+				$aResult[] = array_merge(array($sFirstToken),$aSet);
 			}
 		}
+	}
+	return $aResult;
+}
 
-		$aLanguages = array();
-		if ($sLangString)
+function getInverseWordSets($aWords, $iDepth)
+{
+	$aResult = array(array(join(' ',$aWords)));
+	$sFirstToken = '';
+	if ($iDepth < 8)
+	{
+		while(sizeof($aWords) > 1)
 		{
-			if (preg_match_all('/(([a-z]{1,8})(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $sLangString, $aLanguagesParse, PREG_SET_ORDER))
+			$sWord = array_pop($aWords);
+			$sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
+			$aRest = getInverseWordSets($aWords, $iDepth+1);
+			foreach($aRest as $aSet)
 			{
-				foreach($aLanguagesParse as $iLang => $aLanguage)
+				$aResult[] = array_merge(array($sFirstToken),$aSet);
+			}
+		}
+	}
+	return $aResult;
+}
+
+
+function getTokensFromSets($aSets)
+{
+	$aTokens = array();
+	foreach($aSets as $aSet)
+	{
+		foreach($aSet as $sWord)
+		{
+			$aTokens[' '.$sWord] = ' '.$sWord;
+			$aTokens[$sWord] = $sWord;
+		}
+	}
+	return $aTokens;
+}
+
+
+/*
+   GB Postcode functions
+ */
+
+function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
+{
+	// Try an exact match on the gb_postcode table
+	$sSQL = 'select \'AA\', ST_X(ST_Centroid(geometry)) as lon,ST_Y(ST_Centroid(geometry)) as lat from gb_postcode where postcode = \''.$sPostcode.'\'';
+	$aNearPostcodes = chksql($oDB->getAll($sSQL));
+
+	if (sizeof($aNearPostcodes))
+	{
+		$aPostcodes = array();
+		foreach($aNearPostcodes as $aPostcode)
+		{
+			$aPostcodes[] = array('lat' => $aPostcode['lat'], 'lon' => $aPostcode['lon'], 'radius' => 0.005);
+		}
+
+		return $aPostcodes;
+	}
+
+	return false;
+}
+
+
+function getClassTypes()
+{
+	return array(
+		'boundary:administrative:1' => array('label'=>'Continent','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:2' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:country' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>6, 'defdiameter' => 15,),
+		'boundary:administrative:3' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:4' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:state' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 5.12,),
+		'boundary:administrative:5' => array('label'=>'State District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:6' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:7' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:county' => array('label'=>'County','frequency'=>108,'icon'=>'poi_boundary_administrative','defzoom'=>10, 'defdiameter' => 1.28,),
+		'boundary:administrative:8' => array('label'=>'City','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:city' => array('label'=>'City','frequency'=>66,'icon'=>'poi_place_city','defzoom'=>12, 'defdiameter' => 0.32,),
+		'boundary:administrative:9' => array('label'=>'City District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:10' => array('label'=>'Suburb','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:administrative:11' => array('label'=>'Neighbourhood','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:region' => array('label'=>'Region','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 0.04,),
+		'place:island' => array('label'=>'Island','frequency'=>288,'icon'=>'','defzoom'=>11, 'defdiameter' => 0.64,),
+		'boundary:administrative' => array('label'=>'Administrative','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'boundary:postal_code' => array('label'=>'Postcode','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
+		'place:town' => array('label'=>'Town','frequency'=>1497,'icon'=>'poi_place_town','defzoom'=>14, 'defdiameter' => 0.08,),
+		'place:village' => array('label'=>'Village','frequency'=>11230,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
+		'place:hamlet' => array('label'=>'Hamlet','frequency'=>7075,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
+		'place:suburb' => array('label'=>'Suburb','frequency'=>2528,'icon'=>'poi_place_village', 'defdiameter' => 0.04,),
+		'place:locality' => array('label'=>'Locality','frequency'=>4113,'icon'=>'poi_place_village', 'defdiameter' => 0.02,),
+		'landuse:farm' => array('label'=>'Farm','frequency'=>1201,'icon'=>'', 'defdiameter' => 0.02,),
+		'place:farm' => array('label'=>'Farm','frequency'=>1162,'icon'=>'', 'defdiameter' => 0.02,),
+
+		'highway:motorway_junction' => array('label'=>'Motorway Junction','frequency'=>1126,'icon'=>'','simplelabel'=>'Junction',),
+		'highway:motorway' => array('label'=>'Motorway','frequency'=>4627,'icon'=>'','simplelabel'=>'Road',),
+		'highway:trunk' => array('label'=>'Trunk','frequency'=>23084,'icon'=>'','simplelabel'=>'Road',),
+		'highway:primary' => array('label'=>'Primary','frequency'=>32138,'icon'=>'','simplelabel'=>'Road',),
+		'highway:secondary' => array('label'=>'Secondary','frequency'=>25807,'icon'=>'','simplelabel'=>'Road',),
+		'highway:tertiary' => array('label'=>'Tertiary','frequency'=>29829,'icon'=>'','simplelabel'=>'Road',),
+		'highway:residential' => array('label'=>'Residential','frequency'=>361498,'icon'=>'','simplelabel'=>'Road',),
+		'highway:unclassified' => array('label'=>'Unclassified','frequency'=>66441,'icon'=>'','simplelabel'=>'Road',),
+		'highway:living_street' => array('label'=>'Living Street','frequency'=>710,'icon'=>'','simplelabel'=>'Road',),
+		'highway:service' => array('label'=>'Service','frequency'=>9963,'icon'=>'','simplelabel'=>'Road',),
+		'highway:track' => array('label'=>'Track','frequency'=>2565,'icon'=>'','simplelabel'=>'Road',),
+		'highway:road' => array('label'=>'Road','frequency'=>591,'icon'=>'','simplelabel'=>'Road',),
+		'highway:byway' => array('label'=>'Byway','frequency'=>346,'icon'=>'','simplelabel'=>'Road',),
+		'highway:bridleway' => array('label'=>'Bridleway','frequency'=>1556,'icon'=>'',),
+		'highway:cycleway' => array('label'=>'Cycleway','frequency'=>2419,'icon'=>'',),
+		'highway:pedestrian' => array('label'=>'Pedestrian','frequency'=>2757,'icon'=>'',),
+		'highway:footway' => array('label'=>'Footway','frequency'=>15008,'icon'=>'',),
+		'highway:steps' => array('label'=>'Steps','frequency'=>444,'icon'=>'','simplelabel'=>'Footway',),
+		'highway:motorway_link' => array('label'=>'Motorway Link','frequency'=>795,'icon'=>'','simplelabel'=>'Road',),
+		'highway:trunk_link' => array('label'=>'Trunk Link','frequency'=>1258,'icon'=>'','simplelabel'=>'Road',),
+		'highway:primary_link' => array('label'=>'Primary Link','frequency'=>313,'icon'=>'','simplelabel'=>'Road',),
+
+		'landuse:industrial' => array('label'=>'Industrial','frequency'=>1062,'icon'=>'',),
+		'landuse:residential' => array('label'=>'Residential','frequency'=>886,'icon'=>'',),
+		'landuse:retail' => array('label'=>'Retail','frequency'=>754,'icon'=>'',),
+		'landuse:commercial' => array('label'=>'Commercial','frequency'=>657,'icon'=>'',),
+
+		'place:airport' => array('label'=>'Airport','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
+		'aeroway:aerodrome' => array('label'=>'Aerodrome','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
+		'aeroway' => array('label'=>'Aeroway','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
+		'railway:station' => array('label'=>'Station','frequency'=>3431,'icon'=>'transport_train_station2', 'defdiameter' => 0.01,),
+		'amenity:place_of_worship' => array('label'=>'Place Of Worship','frequency'=>9049,'icon'=>'place_of_worship_unknown3',),
+		'amenity:pub' => array('label'=>'Pub','frequency'=>18969,'icon'=>'food_pub',),
+		'amenity:bar' => array('label'=>'Bar','frequency'=>164,'icon'=>'food_bar',),
+		'amenity:university' => array('label'=>'University','frequency'=>607,'icon'=>'education_university',),
+		'tourism:museum' => array('label'=>'Museum','frequency'=>543,'icon'=>'tourist_museum',),
+		'amenity:arts_centre' => array('label'=>'Arts Centre','frequency'=>136,'icon'=>'tourist_art_gallery2',),
+		'tourism:zoo' => array('label'=>'Zoo','frequency'=>47,'icon'=>'tourist_zoo',),
+		'tourism:theme_park' => array('label'=>'Theme Park','frequency'=>24,'icon'=>'poi_point_of_interest',),
+		'tourism:attraction' => array('label'=>'Attraction','frequency'=>1463,'icon'=>'poi_point_of_interest',),
+		'leisure:golf_course' => array('label'=>'Golf Course','frequency'=>712,'icon'=>'sport_golf',),
+		'historic:castle' => array('label'=>'Castle','frequency'=>316,'icon'=>'tourist_castle',),
+		'amenity:hospital' => array('label'=>'Hospital','frequency'=>879,'icon'=>'health_hospital',),
+		'amenity:school' => array('label'=>'School','frequency'=>8192,'icon'=>'education_school',),
+		'amenity:theatre' => array('label'=>'Theatre','frequency'=>371,'icon'=>'tourist_theatre',),
+		'amenity:public_building' => array('label'=>'Public Building','frequency'=>985,'icon'=>'',),
+		'amenity:library' => array('label'=>'Library','frequency'=>794,'icon'=>'amenity_library',),
+		'amenity:townhall' => array('label'=>'Townhall','frequency'=>242,'icon'=>'',),
+		'amenity:community_centre' => array('label'=>'Community Centre','frequency'=>157,'icon'=>'',),
+		'amenity:fire_station' => array('label'=>'Fire Station','frequency'=>221,'icon'=>'amenity_firestation3',),
+		'amenity:police' => array('label'=>'Police','frequency'=>334,'icon'=>'amenity_police2',),
+		'amenity:bank' => array('label'=>'Bank','frequency'=>1248,'icon'=>'money_bank2',),
+		'amenity:post_office' => array('label'=>'Post Office','frequency'=>859,'icon'=>'amenity_post_office',),
+		'leisure:park' => array('label'=>'Park','frequency'=>2378,'icon'=>'',),
+		'amenity:park' => array('label'=>'Park','frequency'=>53,'icon'=>'',),
+		'landuse:park' => array('label'=>'Park','frequency'=>50,'icon'=>'',),
+		'landuse:recreation_ground' => array('label'=>'Recreation Ground','frequency'=>517,'icon'=>'',),
+		'tourism:hotel' => array('label'=>'Hotel','frequency'=>2150,'icon'=>'accommodation_hotel2',),
+		'tourism:motel' => array('label'=>'Motel','frequency'=>43,'icon'=>'',),
+		'amenity:cinema' => array('label'=>'Cinema','frequency'=>277,'icon'=>'tourist_cinema',),
+		'tourism:artwork' => array('label'=>'Artwork','frequency'=>171,'icon'=>'tourist_art_gallery2',),
+		'historic:archaeological_site' => array('label'=>'Archaeological Site','frequency'=>407,'icon'=>'tourist_archaeological2',),
+		'amenity:doctors' => array('label'=>'Doctors','frequency'=>581,'icon'=>'health_doctors',),
+		'leisure:sports_centre' => array('label'=>'Sports Centre','frequency'=>767,'icon'=>'sport_leisure_centre',),
+		'leisure:swimming_pool' => array('label'=>'Swimming Pool','frequency'=>24,'icon'=>'sport_swimming_outdoor',),
+		'shop:supermarket' => array('label'=>'Supermarket','frequency'=>2673,'icon'=>'shopping_supermarket',),
+		'shop:convenience' => array('label'=>'Convenience','frequency'=>1469,'icon'=>'shopping_convenience',),
+		'amenity:restaurant' => array('label'=>'Restaurant','frequency'=>3179,'icon'=>'food_restaurant',),
+		'amenity:fast_food' => array('label'=>'Fast Food','frequency'=>2289,'icon'=>'food_fastfood',),
+		'amenity:cafe' => array('label'=>'Cafe','frequency'=>1780,'icon'=>'food_cafe',),
+		'tourism:guest_house' => array('label'=>'Guest House','frequency'=>223,'icon'=>'accommodation_bed_and_breakfast',),
+		'amenity:pharmacy' => array('label'=>'Pharmacy','frequency'=>733,'icon'=>'health_pharmacy_dispensing',),
+		'amenity:fuel' => array('label'=>'Fuel','frequency'=>1308,'icon'=>'transport_fuel',),
+		'natural:peak' => array('label'=>'Peak','frequency'=>3212,'icon'=>'poi_peak',),
+		'waterway:waterfall' => array('label'=>'Waterfall','frequency'=>24,'icon'=>'',),
+		'natural:wood' => array('label'=>'Wood','frequency'=>1845,'icon'=>'landuse_coniferous_and_deciduous',),
+		'natural:water' => array('label'=>'Water','frequency'=>1790,'icon'=>'',),
+		'landuse:forest' => array('label'=>'Forest','frequency'=>467,'icon'=>'',),
+		'landuse:cemetery' => array('label'=>'Cemetery','frequency'=>463,'icon'=>'',),
+		'landuse:allotments' => array('label'=>'Allotments','frequency'=>408,'icon'=>'',),
+		'landuse:farmyard' => array('label'=>'Farmyard','frequency'=>397,'icon'=>'',),
+		'railway:rail' => array('label'=>'Rail','frequency'=>4894,'icon'=>'',),
+		'waterway:canal' => array('label'=>'Canal','frequency'=>1723,'icon'=>'',),
+		'waterway:river' => array('label'=>'River','frequency'=>4089,'icon'=>'',),
+		'waterway:stream' => array('label'=>'Stream','frequency'=>2684,'icon'=>'',),
+		'shop:bicycle' => array('label'=>'Bicycle','frequency'=>349,'icon'=>'shopping_bicycle',),
+		'shop:clothes' => array('label'=>'Clothes','frequency'=>315,'icon'=>'shopping_clothes',),
+		'shop:hairdresser' => array('label'=>'Hairdresser','frequency'=>312,'icon'=>'shopping_hairdresser',),
+		'shop:doityourself' => array('label'=>'Doityourself','frequency'=>247,'icon'=>'shopping_diy',),
+		'shop:estate_agent' => array('label'=>'Estate Agent','frequency'=>162,'icon'=>'shopping_estateagent2',),
+		'shop:car' => array('label'=>'Car','frequency'=>159,'icon'=>'shopping_car',),
+		'shop:garden_centre' => array('label'=>'Garden Centre','frequency'=>143,'icon'=>'shopping_garden_centre',),
+		'shop:car_repair' => array('label'=>'Car Repair','frequency'=>141,'icon'=>'shopping_car_repair',),
+		'shop:newsagent' => array('label'=>'Newsagent','frequency'=>132,'icon'=>'',),
+		'shop:bakery' => array('label'=>'Bakery','frequency'=>129,'icon'=>'shopping_bakery',),
+		'shop:furniture' => array('label'=>'Furniture','frequency'=>124,'icon'=>'',),
+		'shop:butcher' => array('label'=>'Butcher','frequency'=>105,'icon'=>'shopping_butcher',),
+		'shop:apparel' => array('label'=>'Apparel','frequency'=>98,'icon'=>'shopping_clothes',),
+		'shop:electronics' => array('label'=>'Electronics','frequency'=>96,'icon'=>'',),
+		'shop:department_store' => array('label'=>'Department Store','frequency'=>86,'icon'=>'',),
+		'shop:books' => array('label'=>'Books','frequency'=>85,'icon'=>'',),
+		'shop:yes' => array('label'=>'Shop','frequency'=>68,'icon'=>'',),
+		'shop:outdoor' => array('label'=>'Outdoor','frequency'=>67,'icon'=>'',),
+		'shop:mall' => array('label'=>'Mall','frequency'=>63,'icon'=>'',),
+		'shop:florist' => array('label'=>'Florist','frequency'=>61,'icon'=>'',),
+		'shop:charity' => array('label'=>'Charity','frequency'=>60,'icon'=>'',),
+		'shop:hardware' => array('label'=>'Hardware','frequency'=>59,'icon'=>'',),
+		'shop:laundry' => array('label'=>'Laundry','frequency'=>51,'icon'=>'shopping_laundrette',),
+		'shop:shoes' => array('label'=>'Shoes','frequency'=>49,'icon'=>'',),
+		'shop:beverages' => array('label'=>'Beverages','frequency'=>48,'icon'=>'shopping_alcohol',),
+		'shop:dry_cleaning' => array('label'=>'Dry Cleaning','frequency'=>46,'icon'=>'',),
+		'shop:carpet' => array('label'=>'Carpet','frequency'=>45,'icon'=>'',),
+		'shop:computer' => array('label'=>'Computer','frequency'=>44,'icon'=>'',),
+		'shop:alcohol' => array('label'=>'Alcohol','frequency'=>44,'icon'=>'shopping_alcohol',),
+		'shop:optician' => array('label'=>'Optician','frequency'=>55,'icon'=>'health_opticians',),
+		'shop:chemist' => array('label'=>'Chemist','frequency'=>42,'icon'=>'health_pharmacy',),
+		'shop:gallery' => array('label'=>'Gallery','frequency'=>38,'icon'=>'tourist_art_gallery2',),
+		'shop:mobile_phone' => array('label'=>'Mobile Phone','frequency'=>37,'icon'=>'',),
+		'shop:sports' => array('label'=>'Sports','frequency'=>37,'icon'=>'',),
+		'shop:jewelry' => array('label'=>'Jewelry','frequency'=>32,'icon'=>'shopping_jewelry',),
+		'shop:pet' => array('label'=>'Pet','frequency'=>29,'icon'=>'',),
+		'shop:beauty' => array('label'=>'Beauty','frequency'=>28,'icon'=>'',),
+		'shop:stationery' => array('label'=>'Stationery','frequency'=>25,'icon'=>'',),
+		'shop:shopping_centre' => array('label'=>'Shopping Centre','frequency'=>25,'icon'=>'',),
+		'shop:general' => array('label'=>'General','frequency'=>25,'icon'=>'',),
+		'shop:electrical' => array('label'=>'Electrical','frequency'=>25,'icon'=>'',),
+		'shop:toys' => array('label'=>'Toys','frequency'=>23,'icon'=>'',),
+		'shop:jeweller' => array('label'=>'Jeweller','frequency'=>23,'icon'=>'',),
+		'shop:betting' => array('label'=>'Betting','frequency'=>23,'icon'=>'',),
+		'shop:household' => array('label'=>'Household','frequency'=>21,'icon'=>'',),
+		'shop:travel_agency' => array('label'=>'Travel Agency','frequency'=>21,'icon'=>'',),
+		'shop:hifi' => array('label'=>'Hifi','frequency'=>21,'icon'=>'',),
+		'amenity:shop' => array('label'=>'Shop','frequency'=>61,'icon'=>'',),
+		'tourism:information' => array('label'=>'Information','frequency'=>224,'icon'=>'amenity_information',),
+
+		'place:house' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
+		'place:house_name' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
+		'place:house_number' => array('label'=>'House Number','frequency'=>2086,'icon'=>'','defzoom'=>18,),
+		'place:country_code' => array('label'=>'Country Code','frequency'=>2086,'icon'=>'','defzoom'=>18,),
+
+		//
+
+		'leisure:pitch' => array('label'=>'Pitch','frequency'=>762,'icon'=>'',),
+		'highway:unsurfaced' => array('label'=>'Unsurfaced','frequency'=>492,'icon'=>'',),
+		'historic:ruins' => array('label'=>'Ruins','frequency'=>483,'icon'=>'tourist_ruin',),
+		'amenity:college' => array('label'=>'College','frequency'=>473,'icon'=>'education_school',),
+		'historic:monument' => array('label'=>'Monument','frequency'=>470,'icon'=>'tourist_monument',),
+		'railway:subway' => array('label'=>'Subway','frequency'=>385,'icon'=>'',),
+		'historic:memorial' => array('label'=>'Memorial','frequency'=>382,'icon'=>'tourist_monument',),
+		'leisure:nature_reserve' => array('label'=>'Nature Reserve','frequency'=>342,'icon'=>'',),
+		'leisure:common' => array('label'=>'Common','frequency'=>322,'icon'=>'',),
+		'waterway:lock_gate' => array('label'=>'Lock Gate','frequency'=>321,'icon'=>'',),
+		'natural:fell' => array('label'=>'Fell','frequency'=>308,'icon'=>'',),
+		'amenity:nightclub' => array('label'=>'Nightclub','frequency'=>292,'icon'=>'',),
+		'highway:path' => array('label'=>'Path','frequency'=>287,'icon'=>'',),
+		'leisure:garden' => array('label'=>'Garden','frequency'=>285,'icon'=>'',),
+		'landuse:reservoir' => array('label'=>'Reservoir','frequency'=>276,'icon'=>'',),
+		'leisure:playground' => array('label'=>'Playground','frequency'=>264,'icon'=>'',),
+		'leisure:stadium' => array('label'=>'Stadium','frequency'=>212,'icon'=>'',),
+		'historic:mine' => array('label'=>'Mine','frequency'=>193,'icon'=>'poi_mine',),
+		'natural:cliff' => array('label'=>'Cliff','frequency'=>193,'icon'=>'',),
+		'tourism:caravan_site' => array('label'=>'Caravan Site','frequency'=>183,'icon'=>'accommodation_caravan_park',),
+		'amenity:bus_station' => array('label'=>'Bus Station','frequency'=>181,'icon'=>'transport_bus_station',),
+		'amenity:kindergarten' => array('label'=>'Kindergarten','frequency'=>179,'icon'=>'',),
+		'highway:construction' => array('label'=>'Construction','frequency'=>176,'icon'=>'',),
+		'amenity:atm' => array('label'=>'Atm','frequency'=>172,'icon'=>'money_atm2',),
+		'amenity:emergency_phone' => array('label'=>'Emergency Phone','frequency'=>164,'icon'=>'',),
+		'waterway:lock' => array('label'=>'Lock','frequency'=>146,'icon'=>'',),
+		'waterway:riverbank' => array('label'=>'Riverbank','frequency'=>143,'icon'=>'',),
+		'natural:coastline' => array('label'=>'Coastline','frequency'=>142,'icon'=>'',),
+		'tourism:viewpoint' => array('label'=>'Viewpoint','frequency'=>140,'icon'=>'tourist_view_point',),
+		'tourism:hostel' => array('label'=>'Hostel','frequency'=>140,'icon'=>'',),
+		'tourism:bed_and_breakfast' => array('label'=>'Bed And Breakfast','frequency'=>140,'icon'=>'accommodation_bed_and_breakfast',),
+		'railway:halt' => array('label'=>'Halt','frequency'=>135,'icon'=>'',),
+		'railway:platform' => array('label'=>'Platform','frequency'=>134,'icon'=>'',),
+		'railway:tram' => array('label'=>'Tram','frequency'=>130,'icon'=>'transport_tram_stop',),
+		'amenity:courthouse' => array('label'=>'Courthouse','frequency'=>129,'icon'=>'amenity_court',),
+		'amenity:recycling' => array('label'=>'Recycling','frequency'=>126,'icon'=>'amenity_recycling',),
+		'amenity:dentist' => array('label'=>'Dentist','frequency'=>124,'icon'=>'health_dentist',),
+		'natural:beach' => array('label'=>'Beach','frequency'=>121,'icon'=>'tourist_beach',),
+		'place:moor' => array('label'=>'Moor','frequency'=>118,'icon'=>'',),
+		'amenity:grave_yard' => array('label'=>'Grave Yard','frequency'=>110,'icon'=>'',),
+		'waterway:drain' => array('label'=>'Drain','frequency'=>108,'icon'=>'',),
+		'landuse:grass' => array('label'=>'Grass','frequency'=>106,'icon'=>'',),
+		'landuse:village_green' => array('label'=>'Village Green','frequency'=>106,'icon'=>'',),
+		'natural:bay' => array('label'=>'Bay','frequency'=>102,'icon'=>'',),
+		'railway:tram_stop' => array('label'=>'Tram Stop','frequency'=>101,'icon'=>'transport_tram_stop',),
+		'leisure:marina' => array('label'=>'Marina','frequency'=>98,'icon'=>'',),
+		'highway:stile' => array('label'=>'Stile','frequency'=>97,'icon'=>'',),
+		'natural:moor' => array('label'=>'Moor','frequency'=>95,'icon'=>'',),
+		'railway:light_rail' => array('label'=>'Light Rail','frequency'=>91,'icon'=>'',),
+		'railway:narrow_gauge' => array('label'=>'Narrow Gauge','frequency'=>90,'icon'=>'',),
+		'natural:land' => array('label'=>'Land','frequency'=>86,'icon'=>'',),
+		'amenity:village_hall' => array('label'=>'Village Hall','frequency'=>82,'icon'=>'',),
+		'waterway:dock' => array('label'=>'Dock','frequency'=>80,'icon'=>'',),
+		'amenity:veterinary' => array('label'=>'Veterinary','frequency'=>79,'icon'=>'',),
+		'landuse:brownfield' => array('label'=>'Brownfield','frequency'=>77,'icon'=>'',),
+		'leisure:track' => array('label'=>'Track','frequency'=>76,'icon'=>'',),
+		'railway:historic_station' => array('label'=>'Historic Station','frequency'=>74,'icon'=>'',),
+		'landuse:construction' => array('label'=>'Construction','frequency'=>72,'icon'=>'',),
+		'amenity:prison' => array('label'=>'Prison','frequency'=>71,'icon'=>'amenity_prison',),
+		'landuse:quarry' => array('label'=>'Quarry','frequency'=>71,'icon'=>'',),
+		'amenity:telephone' => array('label'=>'Telephone','frequency'=>70,'icon'=>'',),
+		'highway:traffic_signals' => array('label'=>'Traffic Signals','frequency'=>66,'icon'=>'',),
+		'natural:heath' => array('label'=>'Heath','frequency'=>62,'icon'=>'',),
+		'historic:house' => array('label'=>'House','frequency'=>61,'icon'=>'',),
+		'amenity:social_club' => array('label'=>'Social Club','frequency'=>61,'icon'=>'',),
+		'landuse:military' => array('label'=>'Military','frequency'=>61,'icon'=>'',),
+		'amenity:health_centre' => array('label'=>'Health Centre','frequency'=>59,'icon'=>'',),
+		'historic:building' => array('label'=>'Building','frequency'=>58,'icon'=>'',),
+		'amenity:clinic' => array('label'=>'Clinic','frequency'=>57,'icon'=>'',),
+		'highway:services' => array('label'=>'Services','frequency'=>56,'icon'=>'',),
+		'amenity:ferry_terminal' => array('label'=>'Ferry Terminal','frequency'=>55,'icon'=>'',),
+		'natural:marsh' => array('label'=>'Marsh','frequency'=>55,'icon'=>'',),
+		'natural:hill' => array('label'=>'Hill','frequency'=>54,'icon'=>'',),
+		'highway:raceway' => array('label'=>'Raceway','frequency'=>53,'icon'=>'',),
+		'amenity:taxi' => array('label'=>'Taxi','frequency'=>47,'icon'=>'',),
+		'amenity:take_away' => array('label'=>'Take Away','frequency'=>45,'icon'=>'',),
+		'amenity:car_rental' => array('label'=>'Car Rental','frequency'=>44,'icon'=>'',),
+		'place:islet' => array('label'=>'Islet','frequency'=>44,'icon'=>'',),
+		'amenity:nursery' => array('label'=>'Nursery','frequency'=>44,'icon'=>'',),
+		'amenity:nursing_home' => array('label'=>'Nursing Home','frequency'=>43,'icon'=>'',),
+		'amenity:toilets' => array('label'=>'Toilets','frequency'=>38,'icon'=>'',),
+		'amenity:hall' => array('label'=>'Hall','frequency'=>38,'icon'=>'',),
+		'waterway:boatyard' => array('label'=>'Boatyard','frequency'=>36,'icon'=>'',),
+		'highway:mini_roundabout' => array('label'=>'Mini Roundabout','frequency'=>35,'icon'=>'',),
+		'historic:manor' => array('label'=>'Manor','frequency'=>35,'icon'=>'',),
+		'tourism:chalet' => array('label'=>'Chalet','frequency'=>34,'icon'=>'',),
+		'amenity:bicycle_parking' => array('label'=>'Bicycle Parking','frequency'=>34,'icon'=>'',),
+		'amenity:hotel' => array('label'=>'Hotel','frequency'=>34,'icon'=>'',),
+		'waterway:weir' => array('label'=>'Weir','frequency'=>33,'icon'=>'',),
+		'natural:wetland' => array('label'=>'Wetland','frequency'=>33,'icon'=>'',),
+		'natural:cave_entrance' => array('label'=>'Cave Entrance','frequency'=>32,'icon'=>'',),
+		'amenity:crematorium' => array('label'=>'Crematorium','frequency'=>31,'icon'=>'',),
+		'tourism:picnic_site' => array('label'=>'Picnic Site','frequency'=>31,'icon'=>'',),
+		'landuse:wood' => array('label'=>'Wood','frequency'=>30,'icon'=>'',),
+		'landuse:basin' => array('label'=>'Basin','frequency'=>30,'icon'=>'',),
+		'natural:tree' => array('label'=>'Tree','frequency'=>30,'icon'=>'',),
+		'leisure:slipway' => array('label'=>'Slipway','frequency'=>29,'icon'=>'',),
+		'landuse:meadow' => array('label'=>'Meadow','frequency'=>29,'icon'=>'',),
+		'landuse:piste' => array('label'=>'Piste','frequency'=>28,'icon'=>'',),
+		'amenity:care_home' => array('label'=>'Care Home','frequency'=>28,'icon'=>'',),
+		'amenity:club' => array('label'=>'Club','frequency'=>28,'icon'=>'',),
+		'amenity:medical_centre' => array('label'=>'Medical Centre','frequency'=>27,'icon'=>'',),
+		'historic:roman_road' => array('label'=>'Roman Road','frequency'=>27,'icon'=>'',),
+		'historic:fort' => array('label'=>'Fort','frequency'=>26,'icon'=>'',),
+		'railway:subway_entrance' => array('label'=>'Subway Entrance','frequency'=>26,'icon'=>'',),
+		'historic:yes' => array('label'=>'Historic','frequency'=>25,'icon'=>'',),
+		'highway:gate' => array('label'=>'Gate','frequency'=>25,'icon'=>'',),
+		'leisure:fishing' => array('label'=>'Fishing','frequency'=>24,'icon'=>'',),
+		'historic:museum' => array('label'=>'Museum','frequency'=>24,'icon'=>'',),
+		'amenity:car_wash' => array('label'=>'Car Wash','frequency'=>24,'icon'=>'',),
+		'railway:level_crossing' => array('label'=>'Level Crossing','frequency'=>23,'icon'=>'',),
+		'leisure:bird_hide' => array('label'=>'Bird Hide','frequency'=>23,'icon'=>'',),
+		'natural:headland' => array('label'=>'Headland','frequency'=>21,'icon'=>'',),
+		'tourism:apartments' => array('label'=>'Apartments','frequency'=>21,'icon'=>'',),
+		'amenity:shopping' => array('label'=>'Shopping','frequency'=>21,'icon'=>'',),
+		'natural:scrub' => array('label'=>'Scrub','frequency'=>20,'icon'=>'',),
+		'natural:fen' => array('label'=>'Fen','frequency'=>20,'icon'=>'',),
+		'building:yes' => array('label'=>'Building','frequency'=>200,'icon'=>'',),
+		'mountain_pass:yes' => array('label'=>'Mountain Pass','frequency'=>200,'icon'=>'',),
+
+		'amenity:parking' => array('label'=>'Parking','frequency'=>3157,'icon'=>'',),
+		'highway:bus_stop' => array('label'=>'Bus Stop','frequency'=>35777,'icon'=>'transport_bus_stop2',),
+		'place:postcode' => array('label'=>'Postcode','frequency'=>27267,'icon'=>'',),
+		'amenity:post_box' => array('label'=>'Post Box','frequency'=>9613,'icon'=>'',),
+
+		'place:houses' => array('label'=>'Houses','frequency'=>85,'icon'=>'',),
+		'railway:preserved' => array('label'=>'Preserved','frequency'=>227,'icon'=>'',),
+		'waterway:derelict_canal' => array('label'=>'Derelict Canal','frequency'=>21,'icon'=>'',),
+		'amenity:dead_pub' => array('label'=>'Dead Pub','frequency'=>20,'icon'=>'',),
+		'railway:disused_station' => array('label'=>'Disused Station','frequency'=>114,'icon'=>'',),
+		'railway:abandoned' => array('label'=>'Abandoned','frequency'=>641,'icon'=>'',),
+		'railway:disused' => array('label'=>'Disused','frequency'=>72,'icon'=>'',),
+	);
+}
+
+
+function getClassTypesWithImportance()
+{
+	$aOrders = getClassTypes();
+	$i = 1;
+	foreach($aOrders as $sID => $a)
+	{
+		$aOrders[$sID]['importance'] = $i++;
+	}
+	return $aOrders;
+}
+
+function getResultDiameter($aResult)
+{
+	$aClassType = getClassTypes();
+
+	$fDiameter = 0.0001;
+
+	if (isset($aResult['class'])
+		  && isset($aResult['type'])
+		  && isset($aResult['admin_level'])
+		  && isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
+			&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
+	{
+		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'];
+	}
+	elseif (isset($aResult['class'])
+		  && isset($aResult['type'])
+		  && isset($aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
+			&& $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
+	{
+		$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'];
+	}
+
+	return $fDiameter;
+}
+
+
+function javascript_renderData($xVal, $iOptions = 0)
+{
+	if (defined('PHP_VERSION_ID') && PHP_VERSION_ID > 50400)
+		$iOptions |= JSON_UNESCAPED_UNICODE;
+	$jsonout = json_encode($xVal, $iOptions);
+
+	if( ! isset($_GET['json_callback']))
+	{
+		header("Content-Type: application/json; charset=UTF-8");
+		echo $jsonout;
+	} else
+	{
+		if (preg_match('/^[$_\p{L}][$_\p{L}\p{Nd}.[\]]*$/u',$_GET['json_callback']))
+		{
+			header("Content-Type: application/javascript; charset=UTF-8");
+			echo $_GET['json_callback'].'('.$jsonout.')';
+		}
+		else
+		{
+			header('HTTP/1.0 400 Bad Request');
+		}
+	}
+}
+
+
+function _debugDumpGroupedSearches($aData, $aTokens)
+{
+	$aWordsIDs = array();
+	if ($aTokens)
+	{
+		foreach($aTokens as $sToken => $aWords)
+		{
+			if ($aWords)
+			{
+				foreach($aWords as $aToken)
 				{
-					$aLanguages[$aLanguage[1]] = isset($aLanguage[5])?(float)$aLanguage[5]:1 - ($iLang/100);
-					if (!isset($aLanguages[$aLanguage[2]])) $aLanguages[$aLanguage[2]] = $aLanguages[$aLanguage[1]]/10;
-				}
-				arsort($aLanguages);
-			}
-		}
-		if (!sizeof($aLanguages) && CONST_Default_Language) $aLanguages = array(CONST_Default_Language=>1);
-		foreach($aLanguages as $sLangauge => $fLangauagePref)
-		{
-			$aLangPrefOrder['short_name:'.$sLangauge] = 'short_name:'.$sLangauge;
-		}
-		foreach($aLanguages as $sLangauge => $fLangauagePref)
-		{
-			$aLangPrefOrder['name:'.$sLangauge] = 'name:'.$sLangauge;
-		}
-		foreach($aLanguages as $sLangauge => $fLangauagePref)
-		{
-			$aLangPrefOrder['place_name:'.$sLangauge] = 'place_name:'.$sLangauge;
-		}
-		foreach($aLanguages as $sLangauge => $fLangauagePref)
-		{
-			$aLangPrefOrder['official_name:'.$sLangauge] = 'official_name:'.$sLangauge;
-		}
-		$aLangPrefOrder['short_name'] = 'short_name';
-		$aLangPrefOrder['name'] = 'name';
-		$aLangPrefOrder['place_name'] = 'place_name';
-		$aLangPrefOrder['official_name'] = 'official_name';
-		$aLangPrefOrder['ref'] = 'ref';
-		$aLangPrefOrder['type'] = 'type';
-		return $aLangPrefOrder;
-	}
-
-
-	function getWordSets($aWords, $iDepth)
-	{
-		$aResult = array(array(join(' ',$aWords)));
-		$sFirstToken = '';
-		if ($iDepth < 8) {
-			while(sizeof($aWords) > 1)
-			{
-				$sWord = array_shift($aWords);
-				$sFirstToken .= ($sFirstToken?' ':'').$sWord;
-				$aRest = getWordSets($aWords, $iDepth+1);
-				foreach($aRest as $aSet)
-				{
-					$aResult[] = array_merge(array($sFirstToken),$aSet);
+					$aWordsIDs[$aToken['word_id']] = $sToken.'('.$aToken['word_id'].')';
 				}
 			}
 		}
-		return $aResult;
 	}
-
-	function getInverseWordSets($aWords, $iDepth)
+	echo "<table border=\"1\">";
+	echo "<tr><th>rank</th><th>Name Tokens</th><th>Name Not</th><th>Address Tokens</th><th>Address Not</th><th>country</th><th>operator</th><th>class</th><th>type</th><th>house#</th><th>Lat</th><th>Lon</th><th>Radius</th></tr>";
+	foreach($aData as $iRank => $aRankedSet)
 	{
-		$aResult = array(array(join(' ',$aWords)));
-		$sFirstToken = '';
-		if ($iDepth < 8)
+		foreach($aRankedSet as $aRow)
 		{
-			while(sizeof($aWords) > 1)
+			echo "<tr>";
+			echo "<td>$iRank</td>";
+
+			echo "<td>";
+			$sSep = '';
+			foreach($aRow['aName'] as $iWordID)
 			{
-				$sWord = array_pop($aWords);
-				$sFirstToken = $sWord.($sFirstToken?' ':'').$sFirstToken;
-				$aRest = getInverseWordSets($aWords, $iDepth+1);
-				foreach($aRest as $aSet)
-				{
-					$aResult[] = array_merge(array($sFirstToken),$aSet);
-				}
+				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
+				$sSep = ', ';
 			}
-		}
-		return $aResult;
-	}
+			echo "</td>";
 
-
-	function getTokensFromSets($aSets)
-	{
-		$aTokens = array();
-		foreach($aSets as $aSet)
-		{
-			foreach($aSet as $sWord)
+			echo "<td>";
+			$sSep = '';
+			foreach($aRow['aNameNonSearch'] as $iWordID)
 			{
-				$aTokens[' '.$sWord] = ' '.$sWord;
-				$aTokens[$sWord] = $sWord;
+				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
+				$sSep = ', ';
 			}
-		}
-		return $aTokens;
-	}
+			echo "</td>";
 
-
-	/*
-	   GB Postcode functions
-	 */
-
-	function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
-	{
-		// Try an exact match on the gb_postcode table
-		$sSQL = 'select \'AA\', ST_X(ST_Centroid(geometry)) as lon,ST_Y(ST_Centroid(geometry)) as lat from gb_postcode where postcode = \''.$sPostcode.'\'';
-		$aNearPostcodes = chksql($oDB->getAll($sSQL));
-
-		if (sizeof($aNearPostcodes))
-		{
-			$aPostcodes = array();
-			foreach($aNearPostcodes as $aPostcode)
+			echo "<td>";
+			$sSep = '';
+			foreach($aRow['aAddress'] as $iWordID)
 			{
-				$aPostcodes[] = array('lat' => $aPostcode['lat'], 'lon' => $aPostcode['lon'], 'radius' => 0.005);
+				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
+				$sSep = ', ';
 			}
+			echo "</td>";
 
-			return $aPostcodes;
-		}
-
-		return false;
-	}
-
-
-	function getClassTypes()
-	{
-		return array(
- 'boundary:administrative:1' => array('label'=>'Continent','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:2' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:country' => array('label'=>'Country','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>6, 'defdiameter' => 15,),
- 'boundary:administrative:3' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:4' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:state' => array('label'=>'State','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 5.12,),
- 'boundary:administrative:5' => array('label'=>'State District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:6' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:7' => array('label'=>'County','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:county' => array('label'=>'County','frequency'=>108,'icon'=>'poi_boundary_administrative','defzoom'=>10, 'defdiameter' => 1.28,),
- 'boundary:administrative:8' => array('label'=>'City','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:city' => array('label'=>'City','frequency'=>66,'icon'=>'poi_place_city','defzoom'=>12, 'defdiameter' => 0.32,),
- 'boundary:administrative:9' => array('label'=>'City District','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:10' => array('label'=>'Suburb','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:administrative:11' => array('label'=>'Neighbourhood','frequency'=>0,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:region' => array('label'=>'Region','frequency'=>0,'icon'=>'poi_boundary_administrative','defzoom'=>8, 'defdiameter' => 0.04,),
- 'place:island' => array('label'=>'Island','frequency'=>288,'icon'=>'','defzoom'=>11, 'defdiameter' => 0.64,),
- 'boundary:administrative' => array('label'=>'Administrative','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'boundary:postal_code' => array('label'=>'Postcode','frequency'=>413,'icon'=>'poi_boundary_administrative', 'defdiameter' => 0.32,),
- 'place:town' => array('label'=>'Town','frequency'=>1497,'icon'=>'poi_place_town','defzoom'=>14, 'defdiameter' => 0.08,),
- 'place:village' => array('label'=>'Village','frequency'=>11230,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
- 'place:hamlet' => array('label'=>'Hamlet','frequency'=>7075,'icon'=>'poi_place_village','defzoom'=>15, 'defdiameter' => 0.04,),
- 'place:suburb' => array('label'=>'Suburb','frequency'=>2528,'icon'=>'poi_place_village', 'defdiameter' => 0.04,),
- 'place:locality' => array('label'=>'Locality','frequency'=>4113,'icon'=>'poi_place_village', 'defdiameter' => 0.02,),
- 'landuse:farm' => array('label'=>'Farm','frequency'=>1201,'icon'=>'', 'defdiameter' => 0.02,),
- 'place:farm' => array('label'=>'Farm','frequency'=>1162,'icon'=>'', 'defdiameter' => 0.02,),
-
- 'highway:motorway_junction' => array('label'=>'Motorway Junction','frequency'=>1126,'icon'=>'','simplelabel'=>'Junction',),
- 'highway:motorway' => array('label'=>'Motorway','frequency'=>4627,'icon'=>'','simplelabel'=>'Road',),
- 'highway:trunk' => array('label'=>'Trunk','frequency'=>23084,'icon'=>'','simplelabel'=>'Road',),
- 'highway:primary' => array('label'=>'Primary','frequency'=>32138,'icon'=>'','simplelabel'=>'Road',),
- 'highway:secondary' => array('label'=>'Secondary','frequency'=>25807,'icon'=>'','simplelabel'=>'Road',),
- 'highway:tertiary' => array('label'=>'Tertiary','frequency'=>29829,'icon'=>'','simplelabel'=>'Road',),
- 'highway:residential' => array('label'=>'Residential','frequency'=>361498,'icon'=>'','simplelabel'=>'Road',),
- 'highway:unclassified' => array('label'=>'Unclassified','frequency'=>66441,'icon'=>'','simplelabel'=>'Road',),
- 'highway:living_street' => array('label'=>'Living Street','frequency'=>710,'icon'=>'','simplelabel'=>'Road',),
- 'highway:service' => array('label'=>'Service','frequency'=>9963,'icon'=>'','simplelabel'=>'Road',),
- 'highway:track' => array('label'=>'Track','frequency'=>2565,'icon'=>'','simplelabel'=>'Road',),
- 'highway:road' => array('label'=>'Road','frequency'=>591,'icon'=>'','simplelabel'=>'Road',),
- 'highway:byway' => array('label'=>'Byway','frequency'=>346,'icon'=>'','simplelabel'=>'Road',),
- 'highway:bridleway' => array('label'=>'Bridleway','frequency'=>1556,'icon'=>'',),
- 'highway:cycleway' => array('label'=>'Cycleway','frequency'=>2419,'icon'=>'',),
- 'highway:pedestrian' => array('label'=>'Pedestrian','frequency'=>2757,'icon'=>'',),
- 'highway:footway' => array('label'=>'Footway','frequency'=>15008,'icon'=>'',),
- 'highway:steps' => array('label'=>'Steps','frequency'=>444,'icon'=>'','simplelabel'=>'Footway',),
- 'highway:motorway_link' => array('label'=>'Motorway Link','frequency'=>795,'icon'=>'','simplelabel'=>'Road',),
- 'highway:trunk_link' => array('label'=>'Trunk Link','frequency'=>1258,'icon'=>'','simplelabel'=>'Road',),
- 'highway:primary_link' => array('label'=>'Primary Link','frequency'=>313,'icon'=>'','simplelabel'=>'Road',),
-
- 'landuse:industrial' => array('label'=>'Industrial','frequency'=>1062,'icon'=>'',),
- 'landuse:residential' => array('label'=>'Residential','frequency'=>886,'icon'=>'',),
- 'landuse:retail' => array('label'=>'Retail','frequency'=>754,'icon'=>'',),
- 'landuse:commercial' => array('label'=>'Commercial','frequency'=>657,'icon'=>'',),
-
- 'place:airport' => array('label'=>'Airport','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
- 'aeroway:aerodrome' => array('label'=>'Aerodrome','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
- 'aeroway' => array('label'=>'Aeroway','frequency'=>36,'icon'=>'transport_airport2', 'defdiameter' => 0.03,),
- 'railway:station' => array('label'=>'Station','frequency'=>3431,'icon'=>'transport_train_station2', 'defdiameter' => 0.01,),
- 'amenity:place_of_worship' => array('label'=>'Place Of Worship','frequency'=>9049,'icon'=>'place_of_worship_unknown3',),
- 'amenity:pub' => array('label'=>'Pub','frequency'=>18969,'icon'=>'food_pub',),
- 'amenity:bar' => array('label'=>'Bar','frequency'=>164,'icon'=>'food_bar',),
- 'amenity:university' => array('label'=>'University','frequency'=>607,'icon'=>'education_university',),
- 'tourism:museum' => array('label'=>'Museum','frequency'=>543,'icon'=>'tourist_museum',),
- 'amenity:arts_centre' => array('label'=>'Arts Centre','frequency'=>136,'icon'=>'tourist_art_gallery2',),
- 'tourism:zoo' => array('label'=>'Zoo','frequency'=>47,'icon'=>'tourist_zoo',),
- 'tourism:theme_park' => array('label'=>'Theme Park','frequency'=>24,'icon'=>'poi_point_of_interest',),
- 'tourism:attraction' => array('label'=>'Attraction','frequency'=>1463,'icon'=>'poi_point_of_interest',),
- 'leisure:golf_course' => array('label'=>'Golf Course','frequency'=>712,'icon'=>'sport_golf',),
- 'historic:castle' => array('label'=>'Castle','frequency'=>316,'icon'=>'tourist_castle',),
- 'amenity:hospital' => array('label'=>'Hospital','frequency'=>879,'icon'=>'health_hospital',),
- 'amenity:school' => array('label'=>'School','frequency'=>8192,'icon'=>'education_school',),
- 'amenity:theatre' => array('label'=>'Theatre','frequency'=>371,'icon'=>'tourist_theatre',),
- 'amenity:public_building' => array('label'=>'Public Building','frequency'=>985,'icon'=>'',),
- 'amenity:library' => array('label'=>'Library','frequency'=>794,'icon'=>'amenity_library',),
- 'amenity:townhall' => array('label'=>'Townhall','frequency'=>242,'icon'=>'',),
- 'amenity:community_centre' => array('label'=>'Community Centre','frequency'=>157,'icon'=>'',),
- 'amenity:fire_station' => array('label'=>'Fire Station','frequency'=>221,'icon'=>'amenity_firestation3',),
- 'amenity:police' => array('label'=>'Police','frequency'=>334,'icon'=>'amenity_police2',),
- 'amenity:bank' => array('label'=>'Bank','frequency'=>1248,'icon'=>'money_bank2',),
- 'amenity:post_office' => array('label'=>'Post Office','frequency'=>859,'icon'=>'amenity_post_office',),
- 'leisure:park' => array('label'=>'Park','frequency'=>2378,'icon'=>'',),
- 'amenity:park' => array('label'=>'Park','frequency'=>53,'icon'=>'',),
- 'landuse:park' => array('label'=>'Park','frequency'=>50,'icon'=>'',),
- 'landuse:recreation_ground' => array('label'=>'Recreation Ground','frequency'=>517,'icon'=>'',),
- 'tourism:hotel' => array('label'=>'Hotel','frequency'=>2150,'icon'=>'accommodation_hotel2',),
- 'tourism:motel' => array('label'=>'Motel','frequency'=>43,'icon'=>'',),
- 'amenity:cinema' => array('label'=>'Cinema','frequency'=>277,'icon'=>'tourist_cinema',),
- 'tourism:artwork' => array('label'=>'Artwork','frequency'=>171,'icon'=>'tourist_art_gallery2',),
- 'historic:archaeological_site' => array('label'=>'Archaeological Site','frequency'=>407,'icon'=>'tourist_archaeological2',),
- 'amenity:doctors' => array('label'=>'Doctors','frequency'=>581,'icon'=>'health_doctors',),
- 'leisure:sports_centre' => array('label'=>'Sports Centre','frequency'=>767,'icon'=>'sport_leisure_centre',),
- 'leisure:swimming_pool' => array('label'=>'Swimming Pool','frequency'=>24,'icon'=>'sport_swimming_outdoor',),
- 'shop:supermarket' => array('label'=>'Supermarket','frequency'=>2673,'icon'=>'shopping_supermarket',),
- 'shop:convenience' => array('label'=>'Convenience','frequency'=>1469,'icon'=>'shopping_convenience',),
- 'amenity:restaurant' => array('label'=>'Restaurant','frequency'=>3179,'icon'=>'food_restaurant',),
- 'amenity:fast_food' => array('label'=>'Fast Food','frequency'=>2289,'icon'=>'food_fastfood',),
- 'amenity:cafe' => array('label'=>'Cafe','frequency'=>1780,'icon'=>'food_cafe',),
- 'tourism:guest_house' => array('label'=>'Guest House','frequency'=>223,'icon'=>'accommodation_bed_and_breakfast',),
- 'amenity:pharmacy' => array('label'=>'Pharmacy','frequency'=>733,'icon'=>'health_pharmacy_dispensing',),
- 'amenity:fuel' => array('label'=>'Fuel','frequency'=>1308,'icon'=>'transport_fuel',),
- 'natural:peak' => array('label'=>'Peak','frequency'=>3212,'icon'=>'poi_peak',),
- 'waterway:waterfall' => array('label'=>'Waterfall','frequency'=>24,'icon'=>'',),
- 'natural:wood' => array('label'=>'Wood','frequency'=>1845,'icon'=>'landuse_coniferous_and_deciduous',),
- 'natural:water' => array('label'=>'Water','frequency'=>1790,'icon'=>'',),
- 'landuse:forest' => array('label'=>'Forest','frequency'=>467,'icon'=>'',),
- 'landuse:cemetery' => array('label'=>'Cemetery','frequency'=>463,'icon'=>'',),
- 'landuse:allotments' => array('label'=>'Allotments','frequency'=>408,'icon'=>'',),
- 'landuse:farmyard' => array('label'=>'Farmyard','frequency'=>397,'icon'=>'',),
- 'railway:rail' => array('label'=>'Rail','frequency'=>4894,'icon'=>'',),
- 'waterway:canal' => array('label'=>'Canal','frequency'=>1723,'icon'=>'',),
- 'waterway:river' => array('label'=>'River','frequency'=>4089,'icon'=>'',),
- 'waterway:stream' => array('label'=>'Stream','frequency'=>2684,'icon'=>'',),
- 'shop:bicycle' => array('label'=>'Bicycle','frequency'=>349,'icon'=>'shopping_bicycle',),
- 'shop:clothes' => array('label'=>'Clothes','frequency'=>315,'icon'=>'shopping_clothes',),
- 'shop:hairdresser' => array('label'=>'Hairdresser','frequency'=>312,'icon'=>'shopping_hairdresser',),
- 'shop:doityourself' => array('label'=>'Doityourself','frequency'=>247,'icon'=>'shopping_diy',),
- 'shop:estate_agent' => array('label'=>'Estate Agent','frequency'=>162,'icon'=>'shopping_estateagent2',),
- 'shop:car' => array('label'=>'Car','frequency'=>159,'icon'=>'shopping_car',),
- 'shop:garden_centre' => array('label'=>'Garden Centre','frequency'=>143,'icon'=>'shopping_garden_centre',),
- 'shop:car_repair' => array('label'=>'Car Repair','frequency'=>141,'icon'=>'shopping_car_repair',),
- 'shop:newsagent' => array('label'=>'Newsagent','frequency'=>132,'icon'=>'',),
- 'shop:bakery' => array('label'=>'Bakery','frequency'=>129,'icon'=>'shopping_bakery',),
- 'shop:furniture' => array('label'=>'Furniture','frequency'=>124,'icon'=>'',),
- 'shop:butcher' => array('label'=>'Butcher','frequency'=>105,'icon'=>'shopping_butcher',),
- 'shop:apparel' => array('label'=>'Apparel','frequency'=>98,'icon'=>'shopping_clothes',),
- 'shop:electronics' => array('label'=>'Electronics','frequency'=>96,'icon'=>'',),
- 'shop:department_store' => array('label'=>'Department Store','frequency'=>86,'icon'=>'',),
- 'shop:books' => array('label'=>'Books','frequency'=>85,'icon'=>'',),
- 'shop:yes' => array('label'=>'Shop','frequency'=>68,'icon'=>'',),
- 'shop:outdoor' => array('label'=>'Outdoor','frequency'=>67,'icon'=>'',),
- 'shop:mall' => array('label'=>'Mall','frequency'=>63,'icon'=>'',),
- 'shop:florist' => array('label'=>'Florist','frequency'=>61,'icon'=>'',),
- 'shop:charity' => array('label'=>'Charity','frequency'=>60,'icon'=>'',),
- 'shop:hardware' => array('label'=>'Hardware','frequency'=>59,'icon'=>'',),
- 'shop:laundry' => array('label'=>'Laundry','frequency'=>51,'icon'=>'shopping_laundrette',),
- 'shop:shoes' => array('label'=>'Shoes','frequency'=>49,'icon'=>'',),
- 'shop:beverages' => array('label'=>'Beverages','frequency'=>48,'icon'=>'shopping_alcohol',),
- 'shop:dry_cleaning' => array('label'=>'Dry Cleaning','frequency'=>46,'icon'=>'',),
- 'shop:carpet' => array('label'=>'Carpet','frequency'=>45,'icon'=>'',),
- 'shop:computer' => array('label'=>'Computer','frequency'=>44,'icon'=>'',),
- 'shop:alcohol' => array('label'=>'Alcohol','frequency'=>44,'icon'=>'shopping_alcohol',),
- 'shop:optician' => array('label'=>'Optician','frequency'=>55,'icon'=>'health_opticians',),
- 'shop:chemist' => array('label'=>'Chemist','frequency'=>42,'icon'=>'health_pharmacy',),
- 'shop:gallery' => array('label'=>'Gallery','frequency'=>38,'icon'=>'tourist_art_gallery2',),
- 'shop:mobile_phone' => array('label'=>'Mobile Phone','frequency'=>37,'icon'=>'',),
- 'shop:sports' => array('label'=>'Sports','frequency'=>37,'icon'=>'',),
- 'shop:jewelry' => array('label'=>'Jewelry','frequency'=>32,'icon'=>'shopping_jewelry',),
- 'shop:pet' => array('label'=>'Pet','frequency'=>29,'icon'=>'',),
- 'shop:beauty' => array('label'=>'Beauty','frequency'=>28,'icon'=>'',),
- 'shop:stationery' => array('label'=>'Stationery','frequency'=>25,'icon'=>'',),
- 'shop:shopping_centre' => array('label'=>'Shopping Centre','frequency'=>25,'icon'=>'',),
- 'shop:general' => array('label'=>'General','frequency'=>25,'icon'=>'',),
- 'shop:electrical' => array('label'=>'Electrical','frequency'=>25,'icon'=>'',),
- 'shop:toys' => array('label'=>'Toys','frequency'=>23,'icon'=>'',),
- 'shop:jeweller' => array('label'=>'Jeweller','frequency'=>23,'icon'=>'',),
- 'shop:betting' => array('label'=>'Betting','frequency'=>23,'icon'=>'',),
- 'shop:household' => array('label'=>'Household','frequency'=>21,'icon'=>'',),
- 'shop:travel_agency' => array('label'=>'Travel Agency','frequency'=>21,'icon'=>'',),
- 'shop:hifi' => array('label'=>'Hifi','frequency'=>21,'icon'=>'',),
- 'amenity:shop' => array('label'=>'Shop','frequency'=>61,'icon'=>'',),
- 'tourism:information' => array('label'=>'Information','frequency'=>224,'icon'=>'amenity_information',),
-
- 'place:house' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
- 'place:house_name' => array('label'=>'House','frequency'=>2086,'icon'=>'','defzoom'=>18,),
- 'place:house_number' => array('label'=>'House Number','frequency'=>2086,'icon'=>'','defzoom'=>18,),
- 'place:country_code' => array('label'=>'Country Code','frequency'=>2086,'icon'=>'','defzoom'=>18,),
-
- //
-
- 'leisure:pitch' => array('label'=>'Pitch','frequency'=>762,'icon'=>'',),
- 'highway:unsurfaced' => array('label'=>'Unsurfaced','frequency'=>492,'icon'=>'',),
- 'historic:ruins' => array('label'=>'Ruins','frequency'=>483,'icon'=>'tourist_ruin',),
- 'amenity:college' => array('label'=>'College','frequency'=>473,'icon'=>'education_school',),
- 'historic:monument' => array('label'=>'Monument','frequency'=>470,'icon'=>'tourist_monument',),
- 'railway:subway' => array('label'=>'Subway','frequency'=>385,'icon'=>'',),
- 'historic:memorial' => array('label'=>'Memorial','frequency'=>382,'icon'=>'tourist_monument',),
- 'leisure:nature_reserve' => array('label'=>'Nature Reserve','frequency'=>342,'icon'=>'',),
- 'leisure:common' => array('label'=>'Common','frequency'=>322,'icon'=>'',),
- 'waterway:lock_gate' => array('label'=>'Lock Gate','frequency'=>321,'icon'=>'',),
- 'natural:fell' => array('label'=>'Fell','frequency'=>308,'icon'=>'',),
- 'amenity:nightclub' => array('label'=>'Nightclub','frequency'=>292,'icon'=>'',),
- 'highway:path' => array('label'=>'Path','frequency'=>287,'icon'=>'',),
- 'leisure:garden' => array('label'=>'Garden','frequency'=>285,'icon'=>'',),
- 'landuse:reservoir' => array('label'=>'Reservoir','frequency'=>276,'icon'=>'',),
- 'leisure:playground' => array('label'=>'Playground','frequency'=>264,'icon'=>'',),
- 'leisure:stadium' => array('label'=>'Stadium','frequency'=>212,'icon'=>'',),
- 'historic:mine' => array('label'=>'Mine','frequency'=>193,'icon'=>'poi_mine',),
- 'natural:cliff' => array('label'=>'Cliff','frequency'=>193,'icon'=>'',),
- 'tourism:caravan_site' => array('label'=>'Caravan Site','frequency'=>183,'icon'=>'accommodation_caravan_park',),
- 'amenity:bus_station' => array('label'=>'Bus Station','frequency'=>181,'icon'=>'transport_bus_station',),
- 'amenity:kindergarten' => array('label'=>'Kindergarten','frequency'=>179,'icon'=>'',),
- 'highway:construction' => array('label'=>'Construction','frequency'=>176,'icon'=>'',),
- 'amenity:atm' => array('label'=>'Atm','frequency'=>172,'icon'=>'money_atm2',),
- 'amenity:emergency_phone' => array('label'=>'Emergency Phone','frequency'=>164,'icon'=>'',),
- 'waterway:lock' => array('label'=>'Lock','frequency'=>146,'icon'=>'',),
- 'waterway:riverbank' => array('label'=>'Riverbank','frequency'=>143,'icon'=>'',),
- 'natural:coastline' => array('label'=>'Coastline','frequency'=>142,'icon'=>'',),
- 'tourism:viewpoint' => array('label'=>'Viewpoint','frequency'=>140,'icon'=>'tourist_view_point',),
- 'tourism:hostel' => array('label'=>'Hostel','frequency'=>140,'icon'=>'',),
- 'tourism:bed_and_breakfast' => array('label'=>'Bed And Breakfast','frequency'=>140,'icon'=>'accommodation_bed_and_breakfast',),
- 'railway:halt' => array('label'=>'Halt','frequency'=>135,'icon'=>'',),
- 'railway:platform' => array('label'=>'Platform','frequency'=>134,'icon'=>'',),
- 'railway:tram' => array('label'=>'Tram','frequency'=>130,'icon'=>'transport_tram_stop',),
- 'amenity:courthouse' => array('label'=>'Courthouse','frequency'=>129,'icon'=>'amenity_court',),
- 'amenity:recycling' => array('label'=>'Recycling','frequency'=>126,'icon'=>'amenity_recycling',),
- 'amenity:dentist' => array('label'=>'Dentist','frequency'=>124,'icon'=>'health_dentist',),
- 'natural:beach' => array('label'=>'Beach','frequency'=>121,'icon'=>'tourist_beach',),
- 'place:moor' => array('label'=>'Moor','frequency'=>118,'icon'=>'',),
- 'amenity:grave_yard' => array('label'=>'Grave Yard','frequency'=>110,'icon'=>'',),
- 'waterway:drain' => array('label'=>'Drain','frequency'=>108,'icon'=>'',),
- 'landuse:grass' => array('label'=>'Grass','frequency'=>106,'icon'=>'',),
- 'landuse:village_green' => array('label'=>'Village Green','frequency'=>106,'icon'=>'',),
- 'natural:bay' => array('label'=>'Bay','frequency'=>102,'icon'=>'',),
- 'railway:tram_stop' => array('label'=>'Tram Stop','frequency'=>101,'icon'=>'transport_tram_stop',),
- 'leisure:marina' => array('label'=>'Marina','frequency'=>98,'icon'=>'',),
- 'highway:stile' => array('label'=>'Stile','frequency'=>97,'icon'=>'',),
- 'natural:moor' => array('label'=>'Moor','frequency'=>95,'icon'=>'',),
- 'railway:light_rail' => array('label'=>'Light Rail','frequency'=>91,'icon'=>'',),
- 'railway:narrow_gauge' => array('label'=>'Narrow Gauge','frequency'=>90,'icon'=>'',),
- 'natural:land' => array('label'=>'Land','frequency'=>86,'icon'=>'',),
- 'amenity:village_hall' => array('label'=>'Village Hall','frequency'=>82,'icon'=>'',),
- 'waterway:dock' => array('label'=>'Dock','frequency'=>80,'icon'=>'',),
- 'amenity:veterinary' => array('label'=>'Veterinary','frequency'=>79,'icon'=>'',),
- 'landuse:brownfield' => array('label'=>'Brownfield','frequency'=>77,'icon'=>'',),
- 'leisure:track' => array('label'=>'Track','frequency'=>76,'icon'=>'',),
- 'railway:historic_station' => array('label'=>'Historic Station','frequency'=>74,'icon'=>'',),
- 'landuse:construction' => array('label'=>'Construction','frequency'=>72,'icon'=>'',),
- 'amenity:prison' => array('label'=>'Prison','frequency'=>71,'icon'=>'amenity_prison',),
- 'landuse:quarry' => array('label'=>'Quarry','frequency'=>71,'icon'=>'',),
- 'amenity:telephone' => array('label'=>'Telephone','frequency'=>70,'icon'=>'',),
- 'highway:traffic_signals' => array('label'=>'Traffic Signals','frequency'=>66,'icon'=>'',),
- 'natural:heath' => array('label'=>'Heath','frequency'=>62,'icon'=>'',),
- 'historic:house' => array('label'=>'House','frequency'=>61,'icon'=>'',),
- 'amenity:social_club' => array('label'=>'Social Club','frequency'=>61,'icon'=>'',),
- 'landuse:military' => array('label'=>'Military','frequency'=>61,'icon'=>'',),
- 'amenity:health_centre' => array('label'=>'Health Centre','frequency'=>59,'icon'=>'',),
- 'historic:building' => array('label'=>'Building','frequency'=>58,'icon'=>'',),
- 'amenity:clinic' => array('label'=>'Clinic','frequency'=>57,'icon'=>'',),
- 'highway:services' => array('label'=>'Services','frequency'=>56,'icon'=>'',),
- 'amenity:ferry_terminal' => array('label'=>'Ferry Terminal','frequency'=>55,'icon'=>'',),
- 'natural:marsh' => array('label'=>'Marsh','frequency'=>55,'icon'=>'',),
- 'natural:hill' => array('label'=>'Hill','frequency'=>54,'icon'=>'',),
- 'highway:raceway' => array('label'=>'Raceway','frequency'=>53,'icon'=>'',),
- 'amenity:taxi' => array('label'=>'Taxi','frequency'=>47,'icon'=>'',),
- 'amenity:take_away' => array('label'=>'Take Away','frequency'=>45,'icon'=>'',),
- 'amenity:car_rental' => array('label'=>'Car Rental','frequency'=>44,'icon'=>'',),
- 'place:islet' => array('label'=>'Islet','frequency'=>44,'icon'=>'',),
- 'amenity:nursery' => array('label'=>'Nursery','frequency'=>44,'icon'=>'',),
- 'amenity:nursing_home' => array('label'=>'Nursing Home','frequency'=>43,'icon'=>'',),
- 'amenity:toilets' => array('label'=>'Toilets','frequency'=>38,'icon'=>'',),
- 'amenity:hall' => array('label'=>'Hall','frequency'=>38,'icon'=>'',),
- 'waterway:boatyard' => array('label'=>'Boatyard','frequency'=>36,'icon'=>'',),
- 'highway:mini_roundabout' => array('label'=>'Mini Roundabout','frequency'=>35,'icon'=>'',),
- 'historic:manor' => array('label'=>'Manor','frequency'=>35,'icon'=>'',),
- 'tourism:chalet' => array('label'=>'Chalet','frequency'=>34,'icon'=>'',),
- 'amenity:bicycle_parking' => array('label'=>'Bicycle Parking','frequency'=>34,'icon'=>'',),
- 'amenity:hotel' => array('label'=>'Hotel','frequency'=>34,'icon'=>'',),
- 'waterway:weir' => array('label'=>'Weir','frequency'=>33,'icon'=>'',),
- 'natural:wetland' => array('label'=>'Wetland','frequency'=>33,'icon'=>'',),
- 'natural:cave_entrance' => array('label'=>'Cave Entrance','frequency'=>32,'icon'=>'',),
- 'amenity:crematorium' => array('label'=>'Crematorium','frequency'=>31,'icon'=>'',),
- 'tourism:picnic_site' => array('label'=>'Picnic Site','frequency'=>31,'icon'=>'',),
- 'landuse:wood' => array('label'=>'Wood','frequency'=>30,'icon'=>'',),
- 'landuse:basin' => array('label'=>'Basin','frequency'=>30,'icon'=>'',),
- 'natural:tree' => array('label'=>'Tree','frequency'=>30,'icon'=>'',),
- 'leisure:slipway' => array('label'=>'Slipway','frequency'=>29,'icon'=>'',),
- 'landuse:meadow' => array('label'=>'Meadow','frequency'=>29,'icon'=>'',),
- 'landuse:piste' => array('label'=>'Piste','frequency'=>28,'icon'=>'',),
- 'amenity:care_home' => array('label'=>'Care Home','frequency'=>28,'icon'=>'',),
- 'amenity:club' => array('label'=>'Club','frequency'=>28,'icon'=>'',),
- 'amenity:medical_centre' => array('label'=>'Medical Centre','frequency'=>27,'icon'=>'',),
- 'historic:roman_road' => array('label'=>'Roman Road','frequency'=>27,'icon'=>'',),
- 'historic:fort' => array('label'=>'Fort','frequency'=>26,'icon'=>'',),
- 'railway:subway_entrance' => array('label'=>'Subway Entrance','frequency'=>26,'icon'=>'',),
- 'historic:yes' => array('label'=>'Historic','frequency'=>25,'icon'=>'',),
- 'highway:gate' => array('label'=>'Gate','frequency'=>25,'icon'=>'',),
- 'leisure:fishing' => array('label'=>'Fishing','frequency'=>24,'icon'=>'',),
- 'historic:museum' => array('label'=>'Museum','frequency'=>24,'icon'=>'',),
- 'amenity:car_wash' => array('label'=>'Car Wash','frequency'=>24,'icon'=>'',),
- 'railway:level_crossing' => array('label'=>'Level Crossing','frequency'=>23,'icon'=>'',),
- 'leisure:bird_hide' => array('label'=>'Bird Hide','frequency'=>23,'icon'=>'',),
- 'natural:headland' => array('label'=>'Headland','frequency'=>21,'icon'=>'',),
- 'tourism:apartments' => array('label'=>'Apartments','frequency'=>21,'icon'=>'',),
- 'amenity:shopping' => array('label'=>'Shopping','frequency'=>21,'icon'=>'',),
- 'natural:scrub' => array('label'=>'Scrub','frequency'=>20,'icon'=>'',),
- 'natural:fen' => array('label'=>'Fen','frequency'=>20,'icon'=>'',),
- 'building:yes' => array('label'=>'Building','frequency'=>200,'icon'=>'',),
- 'mountain_pass:yes' => array('label'=>'Mountain Pass','frequency'=>200,'icon'=>'',),
-
- 'amenity:parking' => array('label'=>'Parking','frequency'=>3157,'icon'=>'',),
- 'highway:bus_stop' => array('label'=>'Bus Stop','frequency'=>35777,'icon'=>'transport_bus_stop2',),
- 'place:postcode' => array('label'=>'Postcode','frequency'=>27267,'icon'=>'',),
- 'amenity:post_box' => array('label'=>'Post Box','frequency'=>9613,'icon'=>'',),
-
- 'place:houses' => array('label'=>'Houses','frequency'=>85,'icon'=>'',),
- 'railway:preserved' => array('label'=>'Preserved','frequency'=>227,'icon'=>'',),
- 'waterway:derelict_canal' => array('label'=>'Derelict Canal','frequency'=>21,'icon'=>'',),
- 'amenity:dead_pub' => array('label'=>'Dead Pub','frequency'=>20,'icon'=>'',),
- 'railway:disused_station' => array('label'=>'Disused Station','frequency'=>114,'icon'=>'',),
- 'railway:abandoned' => array('label'=>'Abandoned','frequency'=>641,'icon'=>'',),
- 'railway:disused' => array('label'=>'Disused','frequency'=>72,'icon'=>'',),
-				);
-	}
-
-
-	function getClassTypesWithImportance()
-	{
-		$aOrders = getClassTypes();
-		$i = 1;
-		foreach($aOrders as $sID => $a)
-		{
-			$aOrders[$sID]['importance'] = $i++;
-		}
-		return $aOrders;
-	}
-
-	function getResultDiameter($aResult)
-	{
-		$aClassType = getClassTypes();
-
-		$fDiameter = 0.0001;
-
-		if (isset($aResult['class'])
-			  && isset($aResult['type'])
-			  && isset($aResult['admin_level'])
-			  && isset($aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
-				&& $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'])
-		{
-			$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type'].':'.$aResult['admin_level']]['defdiameter'];
-		}
-		elseif (isset($aResult['class'])
-			  && isset($aResult['type'])
-			  && isset($aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
-				&& $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'])
-		{
-			$fDiameter = $aClassType[$aResult['class'].':'.$aResult['type']]['defdiameter'];
-		}
-
-		return $fDiameter;
-	}
-
-
-	function javascript_renderData($xVal, $iOptions = 0)
-	{
-		if (defined('PHP_VERSION_ID') && PHP_VERSION_ID > 50400)
-			$iOptions |= JSON_UNESCAPED_UNICODE;
-		$jsonout = json_encode($xVal, $iOptions);
-
-		if( ! isset($_GET['json_callback']))
-		{
-			header("Content-Type: application/json; charset=UTF-8");
-			echo $jsonout;
-		} else
-		{
-			if (preg_match('/^[$_\p{L}][$_\p{L}\p{Nd}.[\]]*$/u',$_GET['json_callback']))
+			echo "<td>";
+			$sSep = '';
+			foreach($aRow['aAddressNonSearch'] as $iWordID)
 			{
-				header("Content-Type: application/javascript; charset=UTF-8");
-				echo $_GET['json_callback'].'('.$jsonout.')';
+				echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
+				$sSep = ', ';
 			}
-			else
-			{
-				header('HTTP/1.0 400 Bad Request');
-			}
+			echo "</td>";
+
+			echo "<td>".$aRow['sCountryCode']."</td>";
+
+			echo "<td>".$aRow['sOperator']."</td>";
+			echo "<td>".$aRow['sClass']."</td>";
+			echo "<td>".$aRow['sType']."</td>";
+
+			echo "<td>".$aRow['sHouseNumber']."</td>";
+
+			echo "<td>".$aRow['fLat']."</td>";
+			echo "<td>".$aRow['fLon']."</td>";
+			echo "<td>".$aRow['fRadius']."</td>";
+
+			echo "</tr>";
 		}
 	}
+	echo "</table>";
+}
 
 
-	function _debugDumpGroupedSearches($aData, $aTokens)
+function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCode = false, $housenumber = -1, $bRaw = false)
+{
+	$sSQL = "select *,get_name_by_language(name,$sLanguagePrefArraySQL) as localname from get_addressdata($iPlaceID, $housenumber)";
+	if (!$bRaw) $sSQL .= " WHERE isaddress OR type = 'country_code'";
+	$sSQL .= " order by rank_address desc,isaddress desc";
+
+	$aAddressLines = chksql($oDB->getAll($sSQL));
+	if ($bRaw) return $aAddressLines;
+	//echo "<pre>";
+	//var_dump($aAddressLines);
+	$aAddress = array();
+	$aFallback = array();
+	$aClassType = getClassTypes();
+	foreach($aAddressLines as $aLine)
 	{
-		$aWordsIDs = array();
-		if ($aTokens)
+		$bFallback = false;
+		$aTypeLabel = false;
+		if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
+		elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
+		elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
 		{
-			foreach($aTokens as $sToken => $aWords)
-			{
-				if ($aWords)
-				{
-					foreach($aWords as $aToken)
-					{
-						$aWordsIDs[$aToken['word_id']] = $sToken.'('.$aToken['word_id'].')';
-					}
-				}
-			}
+			$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
+			$bFallback = true;
 		}
-		echo "<table border=\"1\">";
-		echo "<tr><th>rank</th><th>Name Tokens</th><th>Name Not</th><th>Address Tokens</th><th>Address Not</th><th>country</th><th>operator</th><th>class</th><th>type</th><th>house#</th><th>Lat</th><th>Lon</th><th>Radius</th></tr>";
-		foreach($aData as $iRank => $aRankedSet)
+		else
 		{
-			foreach($aRankedSet as $aRow)
-			{
-				echo "<tr>";
-				echo "<td>$iRank</td>";
-
-				echo "<td>";
-				$sSep = '';
-				foreach($aRow['aName'] as $iWordID)
-				{
-					echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
-					$sSep = ', ';
-				}
-				echo "</td>";
-
-				echo "<td>";
-				$sSep = '';
-				foreach($aRow['aNameNonSearch'] as $iWordID)
-				{
-					echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
-					$sSep = ', ';
-				}
-				echo "</td>";
-
-				echo "<td>";
-				$sSep = '';
-				foreach($aRow['aAddress'] as $iWordID)
-				{
-					echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
-					$sSep = ', ';
-				}
-				echo "</td>";
-
-				echo "<td>";
-				$sSep = '';
-				foreach($aRow['aAddressNonSearch'] as $iWordID)
-				{
-					echo $sSep.'#'.$aWordsIDs[$iWordID].'#';
-					$sSep = ', ';
-				}
-				echo "</td>";
-
-				echo "<td>".$aRow['sCountryCode']."</td>";
-
-				echo "<td>".$aRow['sOperator']."</td>";
-				echo "<td>".$aRow['sClass']."</td>";
-				echo "<td>".$aRow['sType']."</td>";
-
-				echo "<td>".$aRow['sHouseNumber']."</td>";
-
-				echo "<td>".$aRow['fLat']."</td>";
-				echo "<td>".$aRow['fLon']."</td>";
-				echo "<td>".$aRow['fRadius']."</td>";
-
-				echo "</tr>";
-			}
+			$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
+			$bFallback = true;
 		}
-		echo "</table>";
+		if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
+		{
+			$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
+			$sTypeLabel = str_replace(' ','_',$sTypeLabel);
+			if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
+			{
+				$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
+			}
+			$aFallback[$sTypeLabel] = $bFallback;
+		}
 	}
+	return $aAddress;
+}
 
 
-	function getAddressDetails(&$oDB, $sLanguagePrefArraySQL, $iPlaceID, $sCountryCode = false, $housenumber = -1, $bRaw = false)
+function addQuotes($s)
+{
+	return "'".$s."'";
+}
+
+// returns boolean
+function validLatLon($fLat,$fLon)
+{
+	return ($fLat <= 90.1 && $fLat >= -90.1 && $fLon <= 180.1 && $fLon >= -180.1);
+}
+
+// Do we have anything that looks like a lat/lon pair?
+// returns array(lat,lon,query_with_lat_lon_removed)
+// or null
+function looksLikeLatLonPair($sQuery)
+{
+	$sFound    = null;
+	$fQueryLat = null;
+	$fQueryLon = null;
+
+	// degrees decimal minutes
+	// N 40 26.767, W 79 58.933
+	// N 40°26.767′, W 79°58.933′
+	//                  1         2                   3                  4         5            6
+	if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData))
 	{
-		$sSQL = "select *,get_name_by_language(name,$sLanguagePrefArraySQL) as localname from get_addressdata($iPlaceID, $housenumber)";
-		if (!$bRaw) $sSQL .= " WHERE isaddress OR type = 'country_code'";
-		$sSQL .= " order by rank_address desc,isaddress desc";
-
-		$aAddressLines = chksql($oDB->getAll($sSQL));
-		if ($bRaw) return $aAddressLines;
-		//echo "<pre>";
-		//var_dump($aAddressLines);
-		$aAddress = array();
-		$aFallback = array();
-		$aClassType = getClassTypes();
-		foreach($aAddressLines as $aLine)
-		{
-			$bFallback = false;
-			$aTypeLabel = false;
-			if (isset($aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type'].':'.$aLine['admin_level']];
-			elseif (isset($aClassType[$aLine['class'].':'.$aLine['type']])) $aTypeLabel = $aClassType[$aLine['class'].':'.$aLine['type']];
-			elseif (isset($aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))]))
-			{
-				$aTypeLabel = $aClassType['boundary:administrative:'.((int)($aLine['rank_address']/2))];
-				$bFallback = true;
-			}
-			else
-			{
-				$aTypeLabel = array('simplelabel'=>'address'.$aLine['rank_address']);
-				$bFallback = true;
-			}
-			if ($aTypeLabel && ((isset($aLine['localname']) && $aLine['localname']) || (isset($aLine['housenumber']) && $aLine['housenumber'])))
-			{
-				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
-				$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
-				{
-					$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
-				}
-				$aFallback[$sTypeLabel] = $bFallback;
-			}
-		}
-		return $aAddress;
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
+		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
 	}
-
-
-	function addQuotes($s)
+	// degrees decimal minutes
+	// 40 26.767 N, 79 58.933 W
+	// 40° 26.767′ N 79° 58.933′ W
+	//                      1             2                      3          4            5                    6
+	elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData))
 	{
-		return "'".$s."'";
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
+		$fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
 	}
-
-	// returns boolean
-	function validLatLon($fLat,$fLon)
+	// degrees decimal seconds
+	// N 40 26 46 W 79 58 56
+	// N 40° 26′ 46″, W 79° 58′ 56″
+	//                      1        2            3            4                5        6            7            8
+	elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData))
 	{
-		return ($fLat <= 90.1 && $fLat >= -90.1 && $fLon <= 180.1 && $fLon >= -180.1);
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
+		$fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
 	}
-
-	// Do we have anything that looks like a lat/lon pair?
-	// returns array(lat,lon,query_with_lat_lon_removed)
-	// or null
-	function looksLikeLatLonPair($sQuery)
+	// degrees decimal seconds
+	// 40 26 46 N 79 58 56 W
+	// 40° 26′ 46″ N, 79° 58′ 56″ W
+	//                      1            2            3            4          5            6            7            8
+	elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData))
 	{
-		$sFound    = null;
-		$fQueryLat = null;
-		$fQueryLon = null;
-
-		// degrees decimal minutes
-		// N 40 26.767, W 79 58.933
-		// N 40°26.767′, W 79°58.933′
-		//                  1         2                   3                  4         5            6
-		if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
-			$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
-		}
-		// degrees decimal minutes
-		// 40 26.767 N, 79 58.933 W
-		// 40° 26.767′ N 79° 58.933′ W
-		//                      1             2                      3          4            5                    6
-		elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
-			$fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
-		}
-		// degrees decimal seconds
-		// N 40 26 46 W 79 58 56
-		// N 40° 26′ 46″, W 79° 58′ 56″
-		//                      1        2            3            4                5        6            7            8
-		elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
-			$fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
-		}
-		// degrees decimal seconds
-		// 40 26 46 N 79 58 56 W
-		// 40° 26′ 46″ N, 79° 58′ 56″ W
-		//                      1            2            3            4          5            6            7            8
-		elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
-			$fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
-		}
-		// degrees decimal
-		// N 40.446° W 79.982°
-		//                      1        2                               3        4
-		elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
-			$fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
-		}
-		// degrees decimal
-		// 40.446° N 79.982° W
-		//                      1                           2          3                           4
-		elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
-			$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
-		}
-		// degrees decimal
-		// 12.34, 56.78
-		// [12.456,-78.90]
-		//                   1          2                             3                        4
-		elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData))
-		{
-			$sFound    = $aData[0];
-			$fQueryLat = $aData[2];
-			$fQueryLon = $aData[3];
-		}
-
-		if (!validLatLon($fQueryLat, $fQueryLon)) return;
-		$sQuery = trim(str_replace($sFound, ' ', $sQuery));
-
-		return array('lat' => $fQueryLat, 'lon' => $fQueryLon, 'query' => $sQuery);
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
+		$fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
 	}
-
-
-	function geometryText2Points($geometry_as_text, $fRadius)
+	// degrees decimal
+	// N 40.446° W 79.982°
+	//                      1        2                               3        4
+	elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData))
 	{
-		$aPolyPoints = NULL;
-		if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-		{
-			preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-		}
-		elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-		{
-			preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-		}
-		elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
-		{
-			preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-		}
-		elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch))
-		{
-			$aPolyPoints = createPointsAroundCenter($aMatch[1], $aMatch[2], $fRadius);
-		}
-
-		if (isset($aPolyPoints))
-		{
-			$aResultPoints = array();
-			foreach($aPolyPoints as $aPoint)
-			{
-				$aResultPoints[] = array($aPoint[1], $aPoint[2]);
-			}
-			return $aResultPoints;
-		}
-
-		return;
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
+		$fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
 	}
-
-	function createPointsAroundCenter($fLon, $fLat, $fRadius)
+	// degrees decimal
+	// 40.446° N 79.982° W
+	//                      1                           2          3                           4
+	elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData))
 	{
-			$iSteps = max(8, min(100, ($fRadius * 40000)^2));
-			$fStepSize = (2*pi())/$iSteps;
-			$aPolyPoints = array();
-			for($f = 0; $f < 2*pi(); $f += $fStepSize)
-			{
-				$aPolyPoints[] = array('', $fLon+($fRadius*sin($f)), $fLat+($fRadius*cos($f)) );
-			}
-			return $aPolyPoints;
+		$sFound    = $aData[0];
+		$fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
+		$fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
 	}
+	// degrees decimal
+	// 12.34, 56.78
+	// [12.456,-78.90]
+	//                   1          2                             3                        4
+	elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData))
+	{
+		$sFound    = $aData[0];
+		$fQueryLat = $aData[2];
+		$fQueryLon = $aData[3];
+	}
+
+	if (!validLatLon($fQueryLat, $fQueryLon)) return;
+	$sQuery = trim(str_replace($sFound, ' ', $sQuery));
+
+	return array('lat' => $fQueryLat, 'lon' => $fQueryLon, 'query' => $sQuery);
+}
+
+
+function geometryText2Points($geometry_as_text, $fRadius)
+{
+	$aPolyPoints = NULL;
+	if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
+	{
+		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
+	}
+	elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
+	{
+		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
+	}
+	elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch))
+	{
+		preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
+	}
+	elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch))
+	{
+		$aPolyPoints = createPointsAroundCenter($aMatch[1], $aMatch[2], $fRadius);
+	}
+
+	if (isset($aPolyPoints))
+	{
+		$aResultPoints = array();
+		foreach($aPolyPoints as $aPoint)
+		{
+			$aResultPoints[] = array($aPoint[1], $aPoint[2]);
+		}
+		return $aResultPoints;
+	}
+
+	return;
+}
+
+function createPointsAroundCenter($fLon, $fLat, $fRadius)
+{
+		$iSteps = max(8, min(100, ($fRadius * 40000)^2));
+		$fStepSize = (2*pi())/$iSteps;
+		$aPolyPoints = array();
+		for($f = 0; $f < 2*pi(); $f += $fStepSize)
+		{
+			$aPolyPoints[] = array('', $fLon+($fRadius*sin($f)), $fLat+($fRadius*cos($f)) );
+		}
+		return $aPolyPoints;
+}

--- a/lib/log.php
+++ b/lib/log.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 {
 	$fStartTime = microtime(true);
@@ -10,7 +11,7 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 	if (isset($_GET['format'])) $sOutputFormat = $_GET['format'];
 
 	if ($sType == 'reverse') {
-		$sOutQuery = (isset($_GET['lat'])?$_GET['lat']:'').'/';
+		$sOutQuery = (isset($_GET['lat']) ? $_GET['lat'] : '').'/';
 		if (isset($_GET['lon'])) $sOutQuery .= $_GET['lon'];
 		if (isset($_GET['zoom'])) $sOutQuery .= '/'.$_GET['zoom'];
 	} else {
@@ -18,20 +19,20 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 	}
 
 	$hLog = array(
-			date('Y-m-d H:i:s', $aStartTime[0]).'.'.$aStartTime[1],
-			$_SERVER["REMOTE_ADDR"],
-			$_SERVER['QUERY_STRING'],
-			$sOutQuery,
-			$sType,
-			$fStartTime
-			);
+	         date('Y-m-d H:i:s', $aStartTime[0]).'.'.$aStartTime[1],
+	         $_SERVER["REMOTE_ADDR"],
+	         $_SERVER['QUERY_STRING'],
+	         $sOutQuery,
+	         $sType,
+	         $fStartTime
+	        );
 
 	if (CONST_Log_DB) {
 		if (isset($_GET['email']))
 			$sUserAgent = $_GET['email'];
-		elseif (isset($_SERVER['HTTP_REFERER']))
+		else if (isset($_SERVER['HTTP_REFERER']))
 			$sUserAgent = $_SERVER['HTTP_REFERER'];
-		elseif (isset($_SERVER['HTTP_USER_AGENT']))
+		else if (isset($_SERVER['HTTP_USER_AGENT']))
 			$sUserAgent = $_SERVER['HTTP_USER_AGENT'];
 		else $sUserAgent = '';
 		$sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
@@ -41,7 +42,9 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 	}
 
 	return $hLog;
-}
+
+}//end logStart()
+
 
 function logEnd(&$oDB, $hLog, $iNumResults)
 {
@@ -63,11 +66,12 @@ function logEnd(&$oDB, $hLog, $iNumResults)
 		$aOutdata = sprintf(
 			"[%s] %.4f %d %s \"%s\"\n",
 			$hLog[0],
-			$fEndTime-$hLog[5],
+			($fEndTime - $hLog[5]),
 			$iNumResults,
 			$hLog[4],
 			$hLog[2]
 		);
-		file_put_contents(CONST_Log_File, $aOutdata, FILE_APPEND | LOCK_EX);
+		file_put_contents(CONST_Log_File, $aOutdata, (FILE_APPEND | LOCK_EX));
 	}
-}
+
+}//end logEnd()

--- a/lib/log.php
+++ b/lib/log.php
@@ -9,17 +9,16 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 	$sOutputFormat = '';
 	if (isset($_GET['format'])) $sOutputFormat = $_GET['format'];
 
-	if ($sType == 'reverse')
-	{
+	if ($sType == 'reverse') {
 		$sOutQuery = (isset($_GET['lat'])?$_GET['lat']:'').'/';
 		if (isset($_GET['lon'])) $sOutQuery .= $_GET['lon'];
 		if (isset($_GET['zoom'])) $sOutQuery .= '/'.$_GET['zoom'];
-	}
-	else
+	} else {
 		$sOutQuery = $sQuery;
+	}
 
 	$hLog = array(
-			date('Y-m-d H:i:s',$aStartTime[0]).'.'.$aStartTime[1],
+			date('Y-m-d H:i:s', $aStartTime[0]).'.'.$aStartTime[1],
 			$_SERVER["REMOTE_ADDR"],
 			$_SERVER['QUERY_STRING'],
 			$sOutQuery,
@@ -27,19 +26,17 @@ function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 			$fStartTime
 			);
 
-	if (CONST_Log_DB)
-	{
+	if (CONST_Log_DB) {
 		if (isset($_GET['email']))
 			$sUserAgent = $_GET['email'];
 		elseif (isset($_SERVER['HTTP_REFERER']))
 			$sUserAgent = $_SERVER['HTTP_REFERER'];
 		elseif (isset($_SERVER['HTTP_USER_AGENT']))
 			$sUserAgent = $_SERVER['HTTP_USER_AGENT'];
-		else
-			$sUserAgent = '';
+		else $sUserAgent = '';
 		$sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
 		$sSQL .= ' values ('.getDBQuoted($sType).','.getDBQuoted($hLog[0]).','.getDBQuoted($hLog[2]);
-		$sSQL .= ','.getDBQuoted($hLog[1]).','.getDBQuoted($sUserAgent).','.getDBQuoted(join(',',$aLanguageList)).','.getDBQuoted($sOutputFormat).','.getDBQuoted($hLog[3]).')';
+		$sSQL .= ','.getDBQuoted($hLog[1]).','.getDBQuoted($sUserAgent).','.getDBQuoted(join(',', $aLanguageList)).','.getDBQuoted($sOutputFormat).','.getDBQuoted($hLog[3]).')';
 		$oDB->query($sSQL);
 	}
 
@@ -50,11 +47,10 @@ function logEnd(&$oDB, $hLog, $iNumResults)
 {
 	$fEndTime = microtime(true);
 
-	if (CONST_Log_DB)
-	{
+	if (CONST_Log_DB) {
 		$aEndTime = explode('.', $fEndTime);
 		if (!$aEndTime[1]) $aEndTime[1] = '0';
-		$sEndTime = date('Y-m-d H:i:s',$aEndTime[0]).'.'.$aEndTime[1];
+		$sEndTime = date('Y-m-d H:i:s', $aEndTime[0]).'.'.$aEndTime[1];
 
 		$sSQL = 'update new_query_log set endtime = '.getDBQuoted($sEndTime).', results = '.$iNumResults;
 		$sSQL .= ' where starttime = '.getDBQuoted($hLog[0]);
@@ -63,12 +59,15 @@ function logEnd(&$oDB, $hLog, $iNumResults)
 		$oDB->query($sSQL);
 	}
 
-	if (CONST_Log_File)
-	{
-		$aOutdata = sprintf("[%s] %.4f %d %s \"%s\"\n",
-		                    $hLog[0], $fEndTime-$hLog[5], $iNumResults,
-		                    $hLog[4], $hLog[2]);
+	if (CONST_Log_File) {
+		$aOutdata = sprintf(
+			"[%s] %.4f %d %s \"%s\"\n",
+			$hLog[0],
+			$fEndTime-$hLog[5],
+			$iNumResults,
+			$hLog[4],
+			$hLog[2]
+		);
 		file_put_contents(CONST_Log_File, $aOutdata, FILE_APPEND | LOCK_EX);
 	}
-
 }

--- a/lib/log.php
+++ b/lib/log.php
@@ -1,74 +1,74 @@
 <?php
 
-	function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
+function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
+{
+	$fStartTime = microtime(true);
+	$aStartTime = explode('.', $fStartTime);
+	if (!isset($aStartTime[1])) $aStartTime[1] = '0';
+
+	$sOutputFormat = '';
+	if (isset($_GET['format'])) $sOutputFormat = $_GET['format'];
+
+	if ($sType == 'reverse')
 	{
-		$fStartTime = microtime(true);
-		$aStartTime = explode('.', $fStartTime);
-		if (!isset($aStartTime[1])) $aStartTime[1] = '0';
+		$sOutQuery = (isset($_GET['lat'])?$_GET['lat']:'').'/';
+		if (isset($_GET['lon'])) $sOutQuery .= $_GET['lon'];
+		if (isset($_GET['zoom'])) $sOutQuery .= '/'.$_GET['zoom'];
+	}
+	else
+		$sOutQuery = $sQuery;
 
-		$sOutputFormat = '';
-		if (isset($_GET['format'])) $sOutputFormat = $_GET['format'];
+	$hLog = array(
+			date('Y-m-d H:i:s',$aStartTime[0]).'.'.$aStartTime[1],
+			$_SERVER["REMOTE_ADDR"],
+			$_SERVER['QUERY_STRING'],
+			$sOutQuery,
+			$sType,
+			$fStartTime
+			);
 
-		if ($sType == 'reverse')
-		{
-			$sOutQuery = (isset($_GET['lat'])?$_GET['lat']:'').'/';
-			if (isset($_GET['lon'])) $sOutQuery .= $_GET['lon'];
-			if (isset($_GET['zoom'])) $sOutQuery .= '/'.$_GET['zoom'];
-		}
+	if (CONST_Log_DB)
+	{
+		if (isset($_GET['email']))
+			$sUserAgent = $_GET['email'];
+		elseif (isset($_SERVER['HTTP_REFERER']))
+			$sUserAgent = $_SERVER['HTTP_REFERER'];
+		elseif (isset($_SERVER['HTTP_USER_AGENT']))
+			$sUserAgent = $_SERVER['HTTP_USER_AGENT'];
 		else
-			$sOutQuery = $sQuery;
-
-		$hLog = array(
-				date('Y-m-d H:i:s',$aStartTime[0]).'.'.$aStartTime[1],
-				$_SERVER["REMOTE_ADDR"],
-				$_SERVER['QUERY_STRING'],
-				$sOutQuery,
-				$sType,
-				$fStartTime
-				);
-
-		if (CONST_Log_DB)
-		{
-			if (isset($_GET['email']))
-				$sUserAgent = $_GET['email'];
-			elseif (isset($_SERVER['HTTP_REFERER']))
-				$sUserAgent = $_SERVER['HTTP_REFERER'];
-			elseif (isset($_SERVER['HTTP_USER_AGENT']))
-				$sUserAgent = $_SERVER['HTTP_USER_AGENT'];
-			else
-				$sUserAgent = '';
-			$sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
-			$sSQL .= ' values ('.getDBQuoted($sType).','.getDBQuoted($hLog[0]).','.getDBQuoted($hLog[2]);
-			$sSQL .= ','.getDBQuoted($hLog[1]).','.getDBQuoted($sUserAgent).','.getDBQuoted(join(',',$aLanguageList)).','.getDBQuoted($sOutputFormat).','.getDBQuoted($hLog[3]).')';
-			$oDB->query($sSQL);
-		}
-
-		return $hLog;
+			$sUserAgent = '';
+		$sSQL = 'insert into new_query_log (type,starttime,query,ipaddress,useragent,language,format,searchterm)';
+		$sSQL .= ' values ('.getDBQuoted($sType).','.getDBQuoted($hLog[0]).','.getDBQuoted($hLog[2]);
+		$sSQL .= ','.getDBQuoted($hLog[1]).','.getDBQuoted($sUserAgent).','.getDBQuoted(join(',',$aLanguageList)).','.getDBQuoted($sOutputFormat).','.getDBQuoted($hLog[3]).')';
+		$oDB->query($sSQL);
 	}
 
-	function logEnd(&$oDB, $hLog, $iNumResults)
+	return $hLog;
+}
+
+function logEnd(&$oDB, $hLog, $iNumResults)
+{
+	$fEndTime = microtime(true);
+
+	if (CONST_Log_DB)
 	{
-		$fEndTime = microtime(true);
+		$aEndTime = explode('.', $fEndTime);
+		if (!$aEndTime[1]) $aEndTime[1] = '0';
+		$sEndTime = date('Y-m-d H:i:s',$aEndTime[0]).'.'.$aEndTime[1];
 
-		if (CONST_Log_DB)
-		{
-			$aEndTime = explode('.', $fEndTime);
-			if (!$aEndTime[1]) $aEndTime[1] = '0';
-			$sEndTime = date('Y-m-d H:i:s',$aEndTime[0]).'.'.$aEndTime[1];
-
-			$sSQL = 'update new_query_log set endtime = '.getDBQuoted($sEndTime).', results = '.$iNumResults;
-			$sSQL .= ' where starttime = '.getDBQuoted($hLog[0]);
-			$sSQL .= ' and ipaddress = '.getDBQuoted($hLog[1]);
-			$sSQL .= ' and query = '.getDBQuoted($hLog[2]);
-			$oDB->query($sSQL);
-		}
-
-		if (CONST_Log_File)
-		{
-			$aOutdata = sprintf("[%s] %.4f %d %s \"%s\"\n",
-			                    $hLog[0], $fEndTime-$hLog[5], $iNumResults,
-			                    $hLog[4], $hLog[2]);
-			file_put_contents(CONST_Log_File, $aOutdata, FILE_APPEND | LOCK_EX);
-		}
-
+		$sSQL = 'update new_query_log set endtime = '.getDBQuoted($sEndTime).', results = '.$iNumResults;
+		$sSQL .= ' where starttime = '.getDBQuoted($hLog[0]);
+		$sSQL .= ' and ipaddress = '.getDBQuoted($hLog[1]);
+		$sSQL .= ' and query = '.getDBQuoted($hLog[2]);
+		$oDB->query($sSQL);
 	}
+
+	if (CONST_Log_File)
+	{
+		$aOutdata = sprintf("[%s] %.4f %d %s \"%s\"\n",
+		                    $hLog[0], $fEndTime-$hLog[5], $iNumResults,
+		                    $hLog[4], $hLog[2]);
+		file_put_contents(CONST_Log_File, $aOutdata, FILE_APPEND | LOCK_EX);
+	}
+
+}

--- a/lib/output.php
+++ b/lib/output.php
@@ -1,43 +1,43 @@
 <?php
 
-	function formatOSMType($sType, $bIncludeExternal=true)
+function formatOSMType($sType, $bIncludeExternal=true)
+{
+	if ($sType == 'N') return 'node';
+	if ($sType == 'W') return 'way';
+	if ($sType == 'R') return 'relation';
+
+	if (!$bIncludeExternal) return '';
+
+	if ($sType == 'T') return 'tiger';
+	if ($sType == 'I') return 'way';
+
+	return '';
+}
+
+function osmLink($aFeature, $sRefText=false)
+{
+	$sOSMType = formatOSMType($aFeature['osm_type'], false);
+	if ($sOSMType)
 	{
-		if ($sType == 'N') return 'node';
-		if ($sType == 'W') return 'way';
-		if ($sType == 'R') return 'relation';
-
-		if (!$bIncludeExternal) return '';
-
-		if ($sType == 'T') return 'tiger';
-		if ($sType == 'I') return 'way';
-
-		return '';
+		return '<a href="//www.openstreetmap.org/'.$sOSMType.'/'.$aFeature['osm_id'].'">'.$sOSMType.' '.($sRefText?$sRefText:$aFeature['osm_id']).'</a>';
 	}
+	return '';
+}
 
-	function osmLink($aFeature, $sRefText=false)
+function wikipediaLink($aFeature)
+{
+	if ($aFeature['wikipedia'])
 	{
-		$sOSMType = formatOSMType($aFeature['osm_type'], false);
-		if ($sOSMType)
-		{
-			return '<a href="//www.openstreetmap.org/'.$sOSMType.'/'.$aFeature['osm_id'].'">'.$sOSMType.' '.($sRefText?$sRefText:$aFeature['osm_id']).'</a>';
-		}
-		return '';
+		list($sLanguage, $sArticle) = explode(':',$aFeature['wikipedia']);
+		return '<a href="https://'.$sLanguage.'.wikipedia.org/wiki/'.urlencode($sArticle).'" target="_blank">'.$aFeature['wikipedia'].'</a>';
 	}
+	return '';
+}
 
-	function wikipediaLink($aFeature)
-	{
-		if ($aFeature['wikipedia'])
-		{
-			list($sLanguage, $sArticle) = explode(':',$aFeature['wikipedia']);
-			return '<a href="https://'.$sLanguage.'.wikipedia.org/wiki/'.urlencode($sArticle).'" target="_blank">'.$aFeature['wikipedia'].'</a>';
-		}
-		return '';
-	}
+function detailsLink($aFeature, $sTitle=false)
+{
+	if (!$aFeature['place_id']) return '';
 
-	function detailsLink($aFeature, $sTitle=false)
-	{
-		if (!$aFeature['place_id']) return '';
-
-		return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
-	}
+	return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
+}
 

--- a/lib/output.php
+++ b/lib/output.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function formatOSMType($sType, $bIncludeExternal = true)
 {
 	if ($sType == 'N') return 'node';
@@ -12,16 +13,21 @@ function formatOSMType($sType, $bIncludeExternal = true)
 	if ($sType == 'I') return 'way';
 
 	return '';
-}
+
+}//end formatOSMType()
+
 
 function osmLink($aFeature, $sRefText = false)
 {
 	$sOSMType = formatOSMType($aFeature['osm_type'], false);
 	if ($sOSMType) {
-		return '<a href="//www.openstreetmap.org/'.$sOSMType.'/'.$aFeature['osm_id'].'">'.$sOSMType.' '.($sRefText?$sRefText:$aFeature['osm_id']).'</a>';
+		return '<a href="//www.openstreetmap.org/'.$sOSMType.'/'.$aFeature['osm_id'].'">'.$sOSMType.' '.($sRefText ? $sRefText : $aFeature['osm_id']).'</a>';
 	}
+
 	return '';
-}
+
+}//end osmLink()
+
 
 function wikipediaLink($aFeature)
 {
@@ -29,12 +35,16 @@ function wikipediaLink($aFeature)
 		list($sLanguage, $sArticle) = explode(':', $aFeature['wikipedia']);
 		return '<a href="https://'.$sLanguage.'.wikipedia.org/wiki/'.urlencode($sArticle).'" target="_blank">'.$aFeature['wikipedia'].'</a>';
 	}
+
 	return '';
-}
+
+}//end wikipediaLink()
+
 
 function detailsLink($aFeature, $sTitle = false)
 {
 	if (!$aFeature['place_id']) return '';
 
-	return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
-}
+	return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle ? $sTitle : $aFeature['place_id']).'</a>';
+
+}//end detailsLink()

--- a/lib/output.php
+++ b/lib/output.php
@@ -1,6 +1,6 @@
 <?php
 
-function formatOSMType($sType, $bIncludeExternal=true)
+function formatOSMType($sType, $bIncludeExternal = true)
 {
 	if ($sType == 'N') return 'node';
 	if ($sType == 'W') return 'way';
@@ -14,11 +14,10 @@ function formatOSMType($sType, $bIncludeExternal=true)
 	return '';
 }
 
-function osmLink($aFeature, $sRefText=false)
+function osmLink($aFeature, $sRefText = false)
 {
 	$sOSMType = formatOSMType($aFeature['osm_type'], false);
-	if ($sOSMType)
-	{
+	if ($sOSMType) {
 		return '<a href="//www.openstreetmap.org/'.$sOSMType.'/'.$aFeature['osm_id'].'">'.$sOSMType.' '.($sRefText?$sRefText:$aFeature['osm_id']).'</a>';
 	}
 	return '';
@@ -26,18 +25,16 @@ function osmLink($aFeature, $sRefText=false)
 
 function wikipediaLink($aFeature)
 {
-	if ($aFeature['wikipedia'])
-	{
-		list($sLanguage, $sArticle) = explode(':',$aFeature['wikipedia']);
+	if ($aFeature['wikipedia']) {
+		list($sLanguage, $sArticle) = explode(':', $aFeature['wikipedia']);
 		return '<a href="https://'.$sLanguage.'.wikipedia.org/wiki/'.urlencode($sArticle).'" target="_blank">'.$aFeature['wikipedia'].'</a>';
 	}
 	return '';
 }
 
-function detailsLink($aFeature, $sTitle=false)
+function detailsLink($aFeature, $sTitle = false)
 {
 	if (!$aFeature['place_id']) return '';
 
 	return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
 }
-

--- a/lib/website.php
+++ b/lib/website.php
@@ -30,12 +30,9 @@ function chksql($oSql, $sMsg = "Database request failed")
 	<p><b>Details:</b> <pre>
 INTERNALFAIL;
 
-	if (CONST_Debug)
-	{
+	if (CONST_Debug) {
 		var_dump($oSql);
-	}
-	else
-	{
+	} else {
 		echo "<pre>\n".$oSql->getUserInfo()."</pre>";
 	}
 
@@ -51,15 +48,12 @@ function failInternalError($sError, $sSQL = false, $vDumpVar = false)
 	echo '<p>Nominatim has encountered an internal error while processing your request. This is most likely because of a bug in the software.</p>';
 	echo "<p><b>Details:</b> ".$sError,"</p>";
 	echo '<p>Feel free to file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
-	if (CONST_Debug)
-	{
+	if (CONST_Debug) {
 		echo "<hr><h2>Debugging Information</h2><br>";
-		if ($sSQL)
-		{
+		if ($sSQL) {
 			echo "<h3>SQL query</h3><code>".$sSQL."</code>";
 		}
-		if ($vDumpVar)
-		{
+		if ($vDumpVar) {
 			echo "<h3>Result</h3> <code>";
 			var_dump($vDumpVar);
 			echo "</code>";
@@ -89,50 +83,47 @@ function userError($sError)
  *
  */
 
-function getParamBool($sName, $bDefault=false)
+function getParamBool($sName, $bDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
 	return (bool) $_GET[$sName];
 }
 
-function getParamInt($sName, $bDefault=false)
+function getParamInt($sName, $bDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
-	if (!preg_match('/^[+-]?[0-9]+$/', $_GET[$sName]))
-	{
+	if (!preg_match('/^[+-]?[0-9]+$/', $_GET[$sName])) {
 		userError("Integer number expected for parameter '$sName'");
 	}
 
 	return (int) $_GET[$sName];
 }
 
-function getParamFloat($sName, $bDefault=false)
+function getParamFloat($sName, $bDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
-	if (!preg_match('/^[+-]?[0-9]*\.?[0-9]+$/', $_GET[$sName]))
-	{
+	if (!preg_match('/^[+-]?[0-9]*\.?[0-9]+$/', $_GET[$sName])) {
 		userError("Floating-point number expected for parameter '$sName'");
 	}
 
 	return (float) $_GET[$sName];
 }
 
-function getParamString($sName, $bDefault=false)
+function getParamString($sName, $bDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
 	return $_GET[$sName];
 }
 
-function getParamSet($sName, $aValues, $sDefault=false)
+function getParamSet($sName, $aValues, $sDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $sDefault;
 
-	if (!in_array($_GET[$sName], $aValues))
-	{
+	if (!in_array($_GET[$sName], $aValues)) {
 		userError("Parameter '$sName' must be one of: ".join(', ', $aValues));
 	}
 

--- a/lib/website.php
+++ b/lib/website.php
@@ -5,82 +5,82 @@
  * Error handling functions
  *
  */
-	function chksql($oSql, $sMsg = "Database request failed")
-	{
-		if (!PEAR::isError($oSql)) return $oSql;
+function chksql($oSql, $sMsg = "Database request failed")
+{
+	if (!PEAR::isError($oSql)) return $oSql;
 
-		header('HTTP/1.0 500 Internal Server Error');
-		header('Content-type: text/html; charset=utf-8');
+	header('HTTP/1.0 500 Internal Server Error');
+	header('Content-type: text/html; charset=utf-8');
 
-		$sSqlError = $oSql->getMessage();
+	$sSqlError = $oSql->getMessage();
 
-		echo <<<INTERNALFAIL
-	<html>
-	  <head><title>Internal Server Error</title></head>
-	  <body>
-		<h1>Internal Server Error</h1>
-		<p>Nominatim has encountered an internal error while accessing the database.
-		   This may happen because the database is broken or because of a bug in
-		   the software. If you think it is a bug, feel free to report
-		   it over on <a href="https://github.com/twain47/Nominatim/issues">
-		   Github</a>. Please include the URL that caused the problem and the
-		   complete error details below.</p>
-		<p><b>Message:</b> $sMsg</p>
-		<p><b>SQL Error:</b> $sSqlError</p>
-		<p><b>Details:</b> <pre>
+	echo <<<INTERNALFAIL
+<html>
+  <head><title>Internal Server Error</title></head>
+  <body>
+	<h1>Internal Server Error</h1>
+	<p>Nominatim has encountered an internal error while accessing the database.
+	   This may happen because the database is broken or because of a bug in
+	   the software. If you think it is a bug, feel free to report
+	   it over on <a href="https://github.com/twain47/Nominatim/issues">
+	   Github</a>. Please include the URL that caused the problem and the
+	   complete error details below.</p>
+	<p><b>Message:</b> $sMsg</p>
+	<p><b>SQL Error:</b> $sSqlError</p>
+	<p><b>Details:</b> <pre>
 INTERNALFAIL;
 
-		if (CONST_Debug)
-		{
-			var_dump($oSql);
-		}
-		else
-		{
-			echo "<pre>\n".$oSql->getUserInfo()."</pre>";
-		}
-
-		echo "</pre></p></body></html>";
-		exit;
-	}
-
-	function failInternalError($sError, $sSQL = false, $vDumpVar = false)
+	if (CONST_Debug)
 	{
-		header('HTTP/1.0 500 Internal Server Error');
-		header('Content-type: text/html; charset=utf-8');
-		echo "<html><body><h1>Internal Server Error</h1>";
-		echo '<p>Nominatim has encountered an internal error while processing your request. This is most likely because of a bug in the software.</p>';
-		echo "<p><b>Details:</b> ".$sError,"</p>";
-		echo '<p>Feel free to file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
-		if (CONST_Debug)
-		{
-			echo "<hr><h2>Debugging Information</h2><br>";
-			if ($sSQL)
-			{
-				echo "<h3>SQL query</h3><code>".$sSQL."</code>";
-			}
-			if ($vDumpVar)
-			{
-				echo "<h3>Result</h3> <code>";
-				var_dump($vDumpVar);
-				echo "</code>";
-			}
-		}
-		echo "\n</body></html>\n";
-		exit;
+		var_dump($oSql);
 	}
-
-
-	function userError($sError)
+	else
 	{
-		header('HTTP/1.0 400 Bad Request');
-		header('Content-type: text/html; charset=utf-8');
-		echo "<html><body><h1>Bad Request</h1>";
-		echo '<p>Nominatim has encountered an error with your request.</p>';
-		echo "<p><b>Details:</b> ".$sError."</p>";
-		echo '<p>If you feel this error is incorrect feel file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
-		echo "\n</body></html>\n";
-		exit;
+		echo "<pre>\n".$oSql->getUserInfo()."</pre>";
 	}
+
+	echo "</pre></p></body></html>";
+	exit;
+}
+
+function failInternalError($sError, $sSQL = false, $vDumpVar = false)
+{
+	header('HTTP/1.0 500 Internal Server Error');
+	header('Content-type: text/html; charset=utf-8');
+	echo "<html><body><h1>Internal Server Error</h1>";
+	echo '<p>Nominatim has encountered an internal error while processing your request. This is most likely because of a bug in the software.</p>';
+	echo "<p><b>Details:</b> ".$sError,"</p>";
+	echo '<p>Feel free to file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
+	if (CONST_Debug)
+	{
+		echo "<hr><h2>Debugging Information</h2><br>";
+		if ($sSQL)
+		{
+			echo "<h3>SQL query</h3><code>".$sSQL."</code>";
+		}
+		if ($vDumpVar)
+		{
+			echo "<h3>Result</h3> <code>";
+			var_dump($vDumpVar);
+			echo "</code>";
+		}
+	}
+	echo "\n</body></html>\n";
+	exit;
+}
+
+
+function userError($sError)
+{
+	header('HTTP/1.0 400 Bad Request');
+	header('Content-type: text/html; charset=utf-8');
+	echo "<html><body><h1>Bad Request</h1>";
+	echo '<p>Nominatim has encountered an error with your request.</p>';
+	echo "<p><b>Details:</b> ".$sError."</p>";
+	echo '<p>If you feel this error is incorrect feel file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
+	echo "\n</body></html>\n";
+	exit;
+}
 
 
 /***************************************************************************
@@ -89,52 +89,52 @@ INTERNALFAIL;
  *
  */
 
-	function getParamBool($sName, $bDefault=false)
-	{
-		if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
+function getParamBool($sName, $bDefault=false)
+{
+	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
-		return (bool) $_GET[$sName];
+	return (bool) $_GET[$sName];
+}
+
+function getParamInt($sName, $bDefault=false)
+{
+	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
+
+	if (!preg_match('/^[+-]?[0-9]+$/', $_GET[$sName]))
+	{
+		userError("Integer number expected for parameter '$sName'");
 	}
 
-	function getParamInt($sName, $bDefault=false)
+	return (int) $_GET[$sName];
+}
+
+function getParamFloat($sName, $bDefault=false)
+{
+	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
+
+	if (!preg_match('/^[+-]?[0-9]*\.?[0-9]+$/', $_GET[$sName]))
 	{
-		if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
-
-		if (!preg_match('/^[+-]?[0-9]+$/', $_GET[$sName]))
-		{
-			userError("Integer number expected for parameter '$sName'");
-		}
-
-		return (int) $_GET[$sName];
+		userError("Floating-point number expected for parameter '$sName'");
 	}
 
-	function getParamFloat($sName, $bDefault=false)
+	return (float) $_GET[$sName];
+}
+
+function getParamString($sName, $bDefault=false)
+{
+	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
+
+	return $_GET[$sName];
+}
+
+function getParamSet($sName, $aValues, $sDefault=false)
+{
+	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $sDefault;
+
+	if (!in_array($_GET[$sName], $aValues))
 	{
-		if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
-
-		if (!preg_match('/^[+-]?[0-9]*\.?[0-9]+$/', $_GET[$sName]))
-		{
-			userError("Floating-point number expected for parameter '$sName'");
-		}
-
-		return (float) $_GET[$sName];
+		userError("Parameter '$sName' must be one of: ".join(', ', $aValues));
 	}
 
-	function getParamString($sName, $bDefault=false)
-	{
-		if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
-
-		return $_GET[$sName];
-	}
-
-	function getParamSet($sName, $aValues, $sDefault=false)
-	{
-		if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $sDefault;
-
-		if (!in_array($_GET[$sName], $aValues))
-		{
-			userError("Parameter '$sName' must be one of: ".join(', ', $aValues));
-		}
-
-		return $_GET[$sName];
-	}
+	return $_GET[$sName];
+}

--- a/lib/website.php
+++ b/lib/website.php
@@ -1,10 +1,9 @@
 <?php
-
-/***************************************************************************
- *
+/**
  * Error handling functions
- *
  */
+
+
 function chksql($oSql, $sMsg = "Database request failed")
 {
 	if (!PEAR::isError($oSql)) return $oSql;
@@ -38,10 +37,13 @@ INTERNALFAIL;
 
 	echo "</pre></p></body></html>";
 	exit;
-}
+
+}//end chksql()
+
 
 function failInternalError($sError, $sSQL = false, $vDumpVar = false)
 {
+
 	header('HTTP/1.0 500 Internal Server Error');
 	header('Content-type: text/html; charset=utf-8');
 	echo "<html><body><h1>Internal Server Error</h1>";
@@ -53,19 +55,23 @@ function failInternalError($sError, $sSQL = false, $vDumpVar = false)
 		if ($sSQL) {
 			echo "<h3>SQL query</h3><code>".$sSQL."</code>";
 		}
+
 		if ($vDumpVar) {
 			echo "<h3>Result</h3> <code>";
 			var_dump($vDumpVar);
 			echo "</code>";
 		}
+
 	}
 	echo "\n</body></html>\n";
 	exit;
-}
+
+}//end failInternalError()
 
 
 function userError($sError)
 {
+
 	header('HTTP/1.0 400 Bad Request');
 	header('Content-type: text/html; charset=utf-8');
 	echo "<html><body><h1>Bad Request</h1>";
@@ -74,21 +80,24 @@ function userError($sError)
 	echo '<p>If you feel this error is incorrect feel file an issue on <a href="https://github.com/twain47/Nominatim/issues">Github</a>. Please include the error message above and the URL you used.</p>';
 	echo "\n</body></html>\n";
 	exit;
-}
+
+}//end userError()
 
 
-/***************************************************************************
- *
+/**
  * Functions for parsing URL parameters
- *
  */
+
 
 function getParamBool($sName, $bDefault = false)
 {
+
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
 	return (bool) $_GET[$sName];
-}
+
+}//end getParamBool()
+
 
 function getParamInt($sName, $bDefault = false)
 {
@@ -99,7 +108,9 @@ function getParamInt($sName, $bDefault = false)
 	}
 
 	return (int) $_GET[$sName];
-}
+
+}//end getParamInt()
+
 
 function getParamFloat($sName, $bDefault = false)
 {
@@ -110,14 +121,18 @@ function getParamFloat($sName, $bDefault = false)
 	}
 
 	return (float) $_GET[$sName];
-}
+
+}//end getParamFloat()
+
 
 function getParamString($sName, $bDefault = false)
 {
 	if (!isset($_GET[$sName]) || strlen($_GET[$sName]) == 0) return $bDefault;
 
 	return $_GET[$sName];
-}
+
+}//end getParamString()
+
 
 function getParamSet($sName, $aValues, $sDefault = false)
 {
@@ -128,4 +143,5 @@ function getParamSet($sName, $aValues, $sDefault = false)
 	}
 
 	return $_GET[$sName];
-}
+
+}//end getParamSet()

--- a/php-lint-rules.xml
+++ b/php-lint-rules.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<ruleset name="Nominatim Standard">
+
+  <description>Nominatim coding standard</description>
+
+  <!-- based on another standard, you can find it here -->
+  <!-- /usr/share/php/PHP/CodeSniffer/Standards/PSR2/ruleset.xml -->
+  <rule ref="PHPCS"/>
+
+  <rule ref="PEAR.Commenting.FileComment.Missing">
+    <severity>0</severity>
+  </rule>
+
+  <!-- Nominatim: we use tabs -->
+  <rule ref="Generic.WhiteSpace.DisallowTabIndent.TabsUsed">
+    <severity>0</severity>
+  </rule>
+
+  <!-- CONST_this_var is fine, we don't need ConstThisVar -->
+  <rule ref="Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase">
+    <severity>0</severity>
+  </rule>
+
+  <!-- we allow "if (a) echo 'b'" without brackets -->
+  <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Generic.ControlStructures.InlineControlStructure.Discouraged">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.PHP.DisallowInlineIf.Found">
+    <severity>0</severity>
+  </rule>
+
+  <!-- simply disagree with "Each line in an array declaration must end in a comma" -->
+  <rule ref="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Arrays.ArrayDeclaration.NoComma">
+    <severity>0</severity>
+  </rule>
+
+
+  <!-- Aligning looks often better, but causes too many warnings for now -->
+  <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSame">
+    <severity>0</severity>
+  </rule>
+
+  <!-- currently 300 warnings, we set a limit later -->
+  <rule ref="Generic.Files.LineLength">
+    <!-- <severity>0</severity> -->
+    <properties>
+     <property name="lineLimit" value="9999"/>
+     <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
+
+  <!-- We allow "if (a)". No need for "if (a === TRUE)" -->
+  <rule ref="Squiz.Operators.ComparisonOperatorUsage.ImplicitTrue">
+    <severity>0</severity>
+  </rule>
+
+  <!-- We allow "if (!a)". No need for "if (a === FALSE)" -->
+  <rule ref="Squiz.Operators.ComparisonOperatorUsage.NotAllowed">
+    <severity>0</severity>
+  </rule>
+
+  <!-- We allow "$abc = array($aPoint[1], $aPoint[2])" -->
+  <rule ref="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed">
+    <severity>0</severity>
+  </rule>
+
+  <!-- Aligned looks nicer, but causes too many warnings currently -->
+  <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
+    <severity>0</severity>
+  </rule>
+
+
+  <!-- We allow comments after statements -->
+  <rule ref="Squiz.Commenting.PostStatementComment.Found">
+    <severity>0</severity>
+  </rule>
+
+  <!-- Comments don't have to end with one of .!? -->
+  <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+    <severity>0</severity>
+  </rule>
+
+  <!-- Comments don't have to start uppercase -->
+  <rule ref="Squiz.Commenting.InlineComment.NotCapital">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="PEAR.Commenting.ClassComment.Missing">
+    <severity>0</severity>
+  </rule>    
+  <rule ref="PEAR.Commenting.FunctionComment.Missing">
+    <severity>0</severity>
+  </rule>
+
+
+
+</ruleset>

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -1,105 +1,106 @@
 <?php
-	@define('CONST_BasePath', '@CMAKE_SOURCE_DIR@');
-	@define('CONST_InstallPath', '@CMAKE_BINARY_DIR@');
-	if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
-	if (file_exists(CONST_InstallPath.'/settings/local.php')) require_once(CONST_InstallPath.'/settings/local.php');
-	if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 
-	// General settings
-	@define('CONST_Debug', false);
-	@define('CONST_Database_DSN', 'pgsql://@/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
-	@define('CONST_Database_Web_User', 'www-data');
-	@define('CONST_Max_Word_Frequency', '50000');
-	@define('CONST_Limit_Reindexing', true);
-	// Set to false to avoid importing extra postcodes for the US.
-	@define('CONST_Use_Extra_US_Postcodes', true);
-	// Set to true after importing Tiger house number data for the US.
-	// Note: The tables must already exist or queries will throw errors.
-	//       After changing this setting run ./utils/setup --create-functions
-	//       again.
-	@define('CONST_Use_US_Tiger_Data', false);
-	// Set to true after importing other external house number data.
-	// Note: the aux tables must already exist or queries will throw errors.
-	//       After changing this setting run ./utils/setup --create-functions
-	//       again.
-	@define('CONST_Use_Aux_Location_data', false);
+@define('CONST_BasePath', '@CMAKE_SOURCE_DIR@');
+@define('CONST_InstallPath', '@CMAKE_BINARY_DIR@');
+if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
+if (file_exists(CONST_InstallPath.'/settings/local.php')) require_once(CONST_InstallPath.'/settings/local.php');
+if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 
-	// Proxy settings
-	@define('CONST_HTTP_Proxy', false);
-	@define('CONST_HTTP_Proxy_Host', 'proxy.mydomain.com');
-	@define('CONST_HTTP_Proxy_Port', '3128');
-	@define('CONST_HTTP_Proxy_Login', '');
-	@define('CONST_HTTP_Proxy_Password', '');
+// General settings
+@define('CONST_Debug', false);
+@define('CONST_Database_DSN', 'pgsql://@/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
+@define('CONST_Database_Web_User', 'www-data');
+@define('CONST_Max_Word_Frequency', '50000');
+@define('CONST_Limit_Reindexing', true);
+// Set to false to avoid importing extra postcodes for the US.
+@define('CONST_Use_Extra_US_Postcodes', true);
+// Set to true after importing Tiger house number data for the US.
+// Note: The tables must already exist or queries will throw errors.
+//       After changing this setting run ./utils/setup --create-functions
+//       again.
+@define('CONST_Use_US_Tiger_Data', false);
+// Set to true after importing other external house number data.
+// Note: the aux tables must already exist or queries will throw errors.
+//       After changing this setting run ./utils/setup --create-functions
+//       again.
+@define('CONST_Use_Aux_Location_data', false);
 
-	// Paths
-	@define('CONST_Osm2pgsql_Binary', CONST_InstallPath.'/osm2pgsql/osm2pgsql');
-	@define('CONST_Osmosis_Binary', '/usr/bin/osmosis');
-	@define('CONST_Tiger_Data_Path', CONST_BasePath.'/data/tiger');
+// Proxy settings
+@define('CONST_HTTP_Proxy', false);
+@define('CONST_HTTP_Proxy_Host', 'proxy.mydomain.com');
+@define('CONST_HTTP_Proxy_Port', '3128');
+@define('CONST_HTTP_Proxy_Login', '');
+@define('CONST_HTTP_Proxy_Password', '');
 
-	// osm2pgsql settings
-	@define('CONST_Osm2pgsql_Flatnode_File', null);
+// Paths
+@define('CONST_Osm2pgsql_Binary', CONST_InstallPath.'/osm2pgsql/osm2pgsql');
+@define('CONST_Osmosis_Binary', '/usr/bin/osmosis');
+@define('CONST_Tiger_Data_Path', CONST_BasePath.'/data/tiger');
 
-	// tablespace settings
-	// osm2pgsql caching tables (aka slim mode tables) - update only
-	@define('CONST_Tablespace_Osm2pgsql_Data', false);
-	@define('CONST_Tablespace_Osm2pgsql_Index', false);
-	// osm2pgsql output tables (aka main table) - update only
-	@define('CONST_Tablespace_Place_Data', false);
-	@define('CONST_Tablespace_Place_Index', false);
-	// address computation tables - update only
-	@define('CONST_Tablespace_Address_Data', false);
-	@define('CONST_Tablespace_Address_Index', false);
-	// search tables - needed for lookups
-	@define('CONST_Tablespace_Search_Data', false);
-	@define('CONST_Tablespace_Search_Index', false);
-	// additional data, e.g. TIGER data, type searches - needed for lookups
-	@define('CONST_Tablespace_Aux_Data', false);
-	@define('CONST_Tablespace_Aux_Index', false);
+// osm2pgsql settings
+@define('CONST_Osm2pgsql_Flatnode_File', null);
 
-	// Replication settings
-	@define('CONST_Replication_Url', 'http://planet.openstreetmap.org/replication/minute');
-	@define('CONST_Replication_MaxInterval', '3600');
-	@define('CONST_Replication_Update_Interval', '60');  // How often upstream publishes diffs
-	@define('CONST_Replication_Recheck_Interval', '60'); // How long to sleep if no update found yet
+// tablespace settings
+// osm2pgsql caching tables (aka slim mode tables) - update only
+@define('CONST_Tablespace_Osm2pgsql_Data', false);
+@define('CONST_Tablespace_Osm2pgsql_Index', false);
+// osm2pgsql output tables (aka main table) - update only
+@define('CONST_Tablespace_Place_Data', false);
+@define('CONST_Tablespace_Place_Index', false);
+// address computation tables - update only
+@define('CONST_Tablespace_Address_Data', false);
+@define('CONST_Tablespace_Address_Index', false);
+// search tables - needed for lookups
+@define('CONST_Tablespace_Search_Data', false);
+@define('CONST_Tablespace_Search_Index', false);
+// additional data, e.g. TIGER data, type searches - needed for lookups
+@define('CONST_Tablespace_Aux_Data', false);
+@define('CONST_Tablespace_Aux_Index', false);
 
-	// Website settings
-	@define('CONST_NoAccessControl', true);
+// Replication settings
+@define('CONST_Replication_Url', 'http://planet.openstreetmap.org/replication/minute');
+@define('CONST_Replication_MaxInterval', '3600');
+@define('CONST_Replication_Update_Interval', '60');  // How often upstream publishes diffs
+@define('CONST_Replication_Recheck_Interval', '60'); // How long to sleep if no update found yet
 
-	@define('CONST_Website_BaseURL', 'http://'.php_uname('n').'/');
-	// Language to assume when none is supplied with the query.
-	// When set to false, the local language (i.e. the name tag without suffix)
-	// will be used.
-	@define('CONST_Default_Language', false);
-	// Appearance of the map in the debug interface.
-	@define('CONST_Default_Lat', 20.0);
-	@define('CONST_Default_Lon', 0.0);
-	@define('CONST_Default_Zoom', 2);
-	@define('CONST_Map_Tile_URL', 'http://{s}.tile.osm.org/{z}/{x}/{y}.png');
-	@define('CONST_Map_Tile_Attribution', ''); // Set if tile source isn't osm.org
+// Website settings
+@define('CONST_NoAccessControl', true);
 
-	@define('CONST_Search_AreaPolygons', true);
+@define('CONST_Website_BaseURL', 'http://'.php_uname('n').'/');
+// Language to assume when none is supplied with the query.
+// When set to false, the local language (i.e. the name tag without suffix)
+// will be used.
+@define('CONST_Default_Language', false);
+// Appearance of the map in the debug interface.
+@define('CONST_Default_Lat', 20.0);
+@define('CONST_Default_Lon', 0.0);
+@define('CONST_Default_Zoom', 2);
+@define('CONST_Map_Tile_URL', 'http://{s}.tile.osm.org/{z}/{x}/{y}.png');
+@define('CONST_Map_Tile_Attribution', ''); // Set if tile source isn't osm.org
 
-	@define('CONST_Search_BatchMode', false);
+@define('CONST_Search_AreaPolygons', true);
 
-	@define('CONST_Search_TryDroppedAddressTerms', false);
-	@define('CONST_Search_NameOnlySearchFrequencyThreshold', 500);
-	// If set to true, then reverse order of queries will be tried by default.
-	// When set to false only selected languages alloow reverse search.
-	@define('CONST_Search_ReversePlanForAll', true);
+@define('CONST_Search_BatchMode', false);
 
-	// Maximum number of OSM ids that may be queried at once
-	// for the places endpoint.
-	@define('CONST_Places_Max_ID_count', 50); 
+@define('CONST_Search_TryDroppedAddressTerms', false);
+@define('CONST_Search_NameOnlySearchFrequencyThreshold', 500);
+// If set to true, then reverse order of queries will be tried by default.
+// When set to false only selected languages alloow reverse search.
+@define('CONST_Search_ReversePlanForAll', true);
 
-	// Number of different geometry formats that may be queried in parallel.
-	// Set to zero to disable polygon output.
-	@define('CONST_PolygonOutput_MaximumTypes', 1);
+// Maximum number of OSM ids that may be queried at once
+// for the places endpoint.
+@define('CONST_Places_Max_ID_count', 50); 
 
-	// Log settings
-	// Set to true to log into new_query_log table.
-	// You should set up a cron job that regularly clears out this table.
-	@define('CONST_Log_DB', false);
-	// Set to a file name to enable logging to a file.
-	@define('CONST_Log_File', false);
+// Number of different geometry formats that may be queried in parallel.
+// Set to zero to disable polygon output.
+@define('CONST_PolygonOutput_MaximumTypes', 1);
+
+// Log settings
+// Set to true to log into new_query_log table.
+// You should set up a cron job that regularly clears out this table.
+@define('CONST_Log_DB', false);
+// Set to a file name to enable logging to a file.
+@define('CONST_Log_File', false);
 
 

--- a/vagrant/install-on-ubuntu-16.sh
+++ b/vagrant/install-on-ubuntu-16.sh
@@ -35,6 +35,7 @@ sudo update-locale LANG=en_US.UTF-8 #DOCS:
                             phpunit
 
     pip install --user lettuce==0.2.18 six==1.7 haversine
+    sudo pear install PHP_CodeSniffer
 
 #
 # System Configuration

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -1,23 +1,25 @@
 <?php
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/output.php');
 
-	$sOutputFormat = 'html';
-	ini_set('memory_limit', '200M');
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/output.php');
 
-	$oDB =& getDB();
+$sOutputFormat = 'html';
+ini_set('memory_limit', '200M');
 
-	$sSQL = "select placex.place_id, calculated_country_code as country_code, name->'name' as name, i.* from placex, import_polygon_delete i where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type and placex.class = i.class and placex.type = i.type";
-	$aPolygons = chksql($oDB->getAll($sSQL),
-	                    "Could not get list of deleted OSM elements.");
+$oDB =& getDB();
 
-	if (CONST_DEBUG)
-	{
-		var_dump($aPolygons);
-		exit;
-	}
+$sSQL = "select placex.place_id, calculated_country_code as country_code, name->'name' as name, i.* from placex, import_polygon_delete i where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type and placex.class = i.class and placex.type = i.type";
+$aPolygons = chksql($oDB->getAll($sSQL),
+                    "Could not get list of deleted OSM elements.");
+
+if (CONST_DEBUG)
+{
+	var_dump($aPolygons);
+	exit;
+}
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -68,34 +70,36 @@ table td {
 
 <table>
 <?php
-	if (!$aPolygons) exit;
-	echo "<tr>";
+
+if (!$aPolygons) exit;
+echo "<tr>";
 //var_dump($aPolygons[0]);
-	foreach($aPolygons[0] as $sCol => $sVal)
+foreach($aPolygons[0] as $sCol => $sVal)
+{
+	echo "<th>".$sCol."</th>";
+}
+echo "</tr>";
+foreach($aPolygons as $aRow)
+{
+	echo "<tr>";
+	foreach($aRow as $sCol => $sVal)
 	{
-		echo "<th>".$sCol."</th>";
+		switch($sCol)
+		{
+			case 'osm_id':
+				echo '<td>'.osmLink($aRow).'</td>';
+				break;
+			case 'place_id':
+				echo '<td>'.detailsLink($aRow).'</td>';
+				break;
+			default:
+				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+				break;
+		}
 	}
 	echo "</tr>";
-	foreach($aPolygons as $aRow)
-	{
-		echo "<tr>";
-		foreach($aRow as $sCol => $sVal)
-		{
-			switch($sCol)
-			{
-				case 'osm_id':
-					echo '<td>'.osmLink($aRow).'</td>';
-					break;
-				case 'place_id':
-					echo '<td>'.detailsLink($aRow).'</td>';
-					break;
-				default:
-					echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-					break;
-			}
-		}
-		echo "</tr>";
-	}
+}
+
 ?>
 </table>
 

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -1,9 +1,9 @@
 <?php
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/output.php';
 
 $sOutputFormat = 'html';
 ini_set('memory_limit', '200M');
@@ -71,26 +71,28 @@ table td {
 
 if (!$aPolygons) exit;
 echo "<tr>";
-//var_dump($aPolygons[0]);
+// var_dump($aPolygons[0]);
 foreach ($aPolygons[0] as $sCol => $sVal) {
 	echo "<th>".$sCol."</th>";
 }
+
 echo "</tr>";
 foreach ($aPolygons as $aRow) {
 	echo "<tr>";
 	foreach ($aRow as $sCol => $sVal) {
 		switch ($sCol) {
-			case 'osm_id':
-				echo '<td>'.osmLink($aRow).'</td>';
-				break;
-			case 'place_id':
-				echo '<td>'.detailsLink($aRow).'</td>';
-				break;
-			default:
-				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-				break;
+		case 'osm_id':
+			echo '<td>'.osmLink($aRow).'</td>';
+			break;
+		case 'place_id':
+			echo '<td>'.detailsLink($aRow).'</td>';
+			break;
+		default:
+			echo "<td>".($sVal ? $sVal : '&nbsp;')."</td>";
+			break;
 		}
 	}
+
 	echo "</tr>";
 }
 

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -11,11 +11,9 @@ ini_set('memory_limit', '200M');
 $oDB =& getDB();
 
 $sSQL = "select placex.place_id, calculated_country_code as country_code, name->'name' as name, i.* from placex, import_polygon_delete i where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type and placex.class = i.class and placex.type = i.type";
-$aPolygons = chksql($oDB->getAll($sSQL),
-                    "Could not get list of deleted OSM elements.");
+$aPolygons = chksql($oDB->getAll($sSQL), "Could not get list of deleted OSM elements.");
 
-if (CONST_DEBUG)
-{
+if (CONST_DEBUG) {
 	var_dump($aPolygons);
 	exit;
 }
@@ -74,18 +72,14 @@ table td {
 if (!$aPolygons) exit;
 echo "<tr>";
 //var_dump($aPolygons[0]);
-foreach($aPolygons[0] as $sCol => $sVal)
-{
+foreach ($aPolygons[0] as $sCol => $sVal) {
 	echo "<th>".$sCol."</th>";
 }
 echo "</tr>";
-foreach($aPolygons as $aRow)
-{
+foreach ($aPolygons as $aRow) {
 	echo "<tr>";
-	foreach($aRow as $sCol => $sVal)
-	{
-		switch($sCol)
-		{
+	foreach ($aRow as $sCol => $sVal) {
+		switch ($sCol) {
 			case 'osm_id':
 				echo '<td>'.osmLink($aRow).'</td>';
 				break;

--- a/website/details.php
+++ b/website/details.php
@@ -1,163 +1,164 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Details');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/output.php');
+@define('CONST_ConnectionBucket_PageType', 'Details');
 
-	$sOutputFormat = 'html';
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/output.php');
 
-	ini_set('memory_limit', '200M');
+$sOutputFormat = 'html';
 
-	$oDB =& getDB();
+ini_set('memory_limit', '200M');
 
-	$aLangPrefOrder = getPreferredLanguages();
-	$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$aLangPrefOrder))."]";
+$oDB =& getDB();
 
-	$sPlaceId = getParamString('place_id');
-	$sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
-	$iOsmId = getParamInt('osmid', -1);
-	if ($sOsmType && $iOsmId > 0)
+$aLangPrefOrder = getPreferredLanguages();
+$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$aLangPrefOrder))."]";
+
+$sPlaceId = getParamString('place_id');
+$sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
+$iOsmId = getParamInt('osmid', -1);
+if ($sOsmType && $iOsmId > 0)
+{
+	$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
+
+	// Be nice about our error messages for broken geometry
+
+	if (!$sPlaceId)
 	{
-		$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
-
-		// Be nice about our error messages for broken geometry
-
-		if (!$sPlaceId)
-		{
-			$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
-			if (!PEAR::isError($aPointDetails) && $aPointDetails) {
-				if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches))
-				{
-					$aPointDetails['error_x'] = $aMatches[1];
-					$aPointDetails['error_y'] = $aMatches[2];
-				}
-				else
-				{
-					$aPointDetails['error_x'] = 0;
-					$aPointDetails['error_y'] = 0;
-				}
-				include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
-				exit;
+		$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
+		if (!PEAR::isError($aPointDetails) && $aPointDetails) {
+			if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches))
+			{
+				$aPointDetails['error_x'] = $aMatches[1];
+				$aPointDetails['error_y'] = $aMatches[2];
 			}
+			else
+			{
+				$aPointDetails['error_x'] = 0;
+				$aPointDetails['error_y'] = 0;
+			}
+			include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
+			exit;
 		}
 	}
+}
 
 
-	if (!$sPlaceId) userError("Please select a place id");
+if (!$sPlaceId) userError("Please select a place id");
 
-	$iPlaceID = (int)$sPlaceId;
+$iPlaceID = (int)$sPlaceId;
 
-	if (CONST_Use_US_Tiger_Data)
+if (CONST_Use_US_Tiger_Data)
+{
+	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
+	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+}
+
+if (CONST_Use_Aux_Location_data)
+{
+	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_aux where place_id = '.$iPlaceID));
+	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+}
+
+$hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
+
+// Get the details for this point
+$sSQL = "select place_id, osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, calculated_country_code as country_code, importance, wikipedia,";
+$sSQL .= " to_char(indexed_date, 'YYYY-MM-DD HH24:MI') as indexed_date, parent_place_id, rank_address, rank_search, get_searchrank_label(rank_search) as rank_search_label, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ";
+$sSQL .= " ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ";
+//$sSQL .= " ST_Area(geometry::geography) as area, ";
+$sSQL .= " ST_y(centroid) as lat, ST_x(centroid) as lon,";
+$sSQL .= " case when importance = 0 OR importance IS NULL then 0.75-(rank_search::float/40) else importance end as calculated_importance, ";
+$sSQL .= " ST_AsText(CASE WHEN ST_NPoints(geometry) > 5000 THEN ST_SimplifyPreserveTopology(geometry, 0.0001) ELSE geometry END) as outlinestring";
+$sSQL .= " from placex where place_id = $iPlaceID";
+$aPointDetails = chksql($oDB->getRow($sSQL),
+                        "Could not get details of place object.");
+$aPointDetails['localname'] = $aPointDetails['localname']?$aPointDetails['localname']:$aPointDetails['housenumber'];
+
+$aClassType = getClassTypesWithImportance();
+$aPointDetails['icon'] = $aClassType[$aPointDetails['class'].':'.$aPointDetails['type']]['icon'];
+
+// Get all alternative names (languages, etc)
+$sSQL = "select (each(name)).key,(each(name)).value from placex where place_id = $iPlaceID order by (each(name)).key";
+$aPointDetails['aNames'] = $oDB->getAssoc($sSQL);
+if (PEAR::isError($aPointDetails['aNames'])) // possible timeout
+{
+	$aPointDetails['aNames'] = [];
+}
+
+// Extra tags
+$sSQL = "select (each(extratags)).key,(each(extratags)).value from placex where place_id = $iPlaceID order by (each(extratags)).key";
+$aPointDetails['aExtraTags'] = $oDB->getAssoc($sSQL);
+if (PEAR::isError($aPointDetails['aExtraTags'])) // possible timeout
+{
+	$aPointDetails['aExtraTags'] = [];
+}
+
+// Address
+$aAddressLines = getAddressDetails($oDB, $sLanguagePrefArraySQL, $iPlaceID, $aPointDetails['country_code'], -1, true);
+
+// Linked places
+$sSQL = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
+$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
+$sSQL .= " from placex, (select centroid as placegeometry from placex where place_id = $iPlaceID) as x";
+$sSQL .= " where linked_place_id = $iPlaceID";
+$sSQL .= " order by rank_address asc,rank_search asc,get_name_by_language(name,$sLanguagePrefArraySQL),housenumber";
+$aLinkedLines = $oDB->getAll($sSQL);
+if (PEAR::isError($aLinkedLines)) // possible timeout
+{
+	$aLinkedLines = [];
+}
+
+// All places this is an imediate parent of
+$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
+$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
+$sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
+$sSQL .= " where parent_place_id = $iPlaceID order by rank_address asc,rank_search asc limit 500) as obj,";
+$sSQL .= " (select centroid as placegeometry from placex where place_id = $iPlaceID) as x";
+$sSQL .= " order by rank_address asc,rank_search asc,localname,housenumber";
+$aParentOfLines = $oDB->getAll($sSQL);
+if (PEAR::isError($aParentOfLines)) // possible timeout
+{
+	$aParentOfLines = [];
+}
+
+$aPlaceSearchNameKeywords = false;
+$aPlaceSearchAddressKeywords = false;
+if (getParamBool('keywords'))
+{
+	$sSQL = "select * from search_name where place_id = $iPlaceID";
+	$aPlaceSearchName = $oDB->getRow($sSQL);
+	if (PEAR::isError($aPlaceSearchName)) // possible timeout
 	{
-		$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
-		if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+		$aPlaceSearchName = [];
 	}
 
-	if (CONST_Use_Aux_Location_data)
+	$sSQL = "select * from word where word_id in (".substr($aPlaceSearchName['name_vector'],1,-1).")";
+	$aPlaceSearchNameKeywords = $oDB->getAll($sSQL);
+	if (PEAR::isError($aPlaceSearchNameKeywords)) // possible timeout
 	{
-		$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_aux where place_id = '.$iPlaceID));
-		if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+		$aPlaceSearchNameKeywords = [];
 	}
 
-	$hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
-	// Get the details for this point
-	$sSQL = "select place_id, osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, calculated_country_code as country_code, importance, wikipedia,";
-	$sSQL .= " to_char(indexed_date, 'YYYY-MM-DD HH24:MI') as indexed_date, parent_place_id, rank_address, rank_search, get_searchrank_label(rank_search) as rank_search_label, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ";
-	$sSQL .= " ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ";
-	//$sSQL .= " ST_Area(geometry::geography) as area, ";
-	$sSQL .= " ST_y(centroid) as lat, ST_x(centroid) as lon,";
-	$sSQL .= " case when importance = 0 OR importance IS NULL then 0.75-(rank_search::float/40) else importance end as calculated_importance, ";
-	$sSQL .= " ST_AsText(CASE WHEN ST_NPoints(geometry) > 5000 THEN ST_SimplifyPreserveTopology(geometry, 0.0001) ELSE geometry END) as outlinestring";
-	$sSQL .= " from placex where place_id = $iPlaceID";
-	$aPointDetails = chksql($oDB->getRow($sSQL),
-	                        "Could not get details of place object.");
-	$aPointDetails['localname'] = $aPointDetails['localname']?$aPointDetails['localname']:$aPointDetails['housenumber'];
-
-	$aClassType = getClassTypesWithImportance();
-	$aPointDetails['icon'] = $aClassType[$aPointDetails['class'].':'.$aPointDetails['type']]['icon'];
-
-	// Get all alternative names (languages, etc)
-	$sSQL = "select (each(name)).key,(each(name)).value from placex where place_id = $iPlaceID order by (each(name)).key";
-	$aPointDetails['aNames'] = $oDB->getAssoc($sSQL);
-	if (PEAR::isError($aPointDetails['aNames'])) // possible timeout
+	$sSQL = "select * from word where word_id in (".substr($aPlaceSearchName['nameaddress_vector'],1,-1).")";
+	$aPlaceSearchAddressKeywords = $oDB->getAll($sSQL);
+	if (PEAR::isError($aPlaceSearchAddressKeywords)) // possible timeout
 	{
-		$aPointDetails['aNames'] = [];
+		$aPlaceSearchAddressKeywords = [];
 	}
 
-	// Extra tags
-	$sSQL = "select (each(extratags)).key,(each(extratags)).value from placex where place_id = $iPlaceID order by (each(extratags)).key";
-	$aPointDetails['aExtraTags'] = $oDB->getAssoc($sSQL);
-	if (PEAR::isError($aPointDetails['aExtraTags'])) // possible timeout
-	{
-		$aPointDetails['aExtraTags'] = [];
-	}
+}
 
-	// Address
-	$aAddressLines = getAddressDetails($oDB, $sLanguagePrefArraySQL, $iPlaceID, $aPointDetails['country_code'], -1, true);
+logEnd($oDB, $hLog, 1);
 
-	// Linked places
-	$sSQL = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
-	$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
-	$sSQL .= " from placex, (select centroid as placegeometry from placex where place_id = $iPlaceID) as x";
-	$sSQL .= " where linked_place_id = $iPlaceID";
-	$sSQL .= " order by rank_address asc,rank_search asc,get_name_by_language(name,$sLanguagePrefArraySQL),housenumber";
-	$aLinkedLines = $oDB->getAll($sSQL);
-	if (PEAR::isError($aLinkedLines)) // possible timeout
-	{
-		$aLinkedLines = [];
-	}
+if ($sOutputFormat=='html')
+{
+	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+	$sTileURL = CONST_Map_Tile_URL;
+	$sTileAttribution = CONST_Map_Tile_Attribution;
+}
 
-	// All places this is an imediate parent of
-	$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
-	$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
-	$sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
-	$sSQL .= " where parent_place_id = $iPlaceID order by rank_address asc,rank_search asc limit 500) as obj,";
-	$sSQL .= " (select centroid as placegeometry from placex where place_id = $iPlaceID) as x";
-	$sSQL .= " order by rank_address asc,rank_search asc,localname,housenumber";
-	$aParentOfLines = $oDB->getAll($sSQL);
-	if (PEAR::isError($aParentOfLines)) // possible timeout
-	{
-		$aParentOfLines = [];
-	}
-
-	$aPlaceSearchNameKeywords = false;
-	$aPlaceSearchAddressKeywords = false;
-	if (getParamBool('keywords'))
-	{
-		$sSQL = "select * from search_name where place_id = $iPlaceID";
-		$aPlaceSearchName = $oDB->getRow($sSQL);
-		if (PEAR::isError($aPlaceSearchName)) // possible timeout
-		{
-			$aPlaceSearchName = [];
-		}
-
-		$sSQL = "select * from word where word_id in (".substr($aPlaceSearchName['name_vector'],1,-1).")";
-		$aPlaceSearchNameKeywords = $oDB->getAll($sSQL);
-		if (PEAR::isError($aPlaceSearchNameKeywords)) // possible timeout
-		{
-			$aPlaceSearchNameKeywords = [];
-		}
-
-
-		$sSQL = "select * from word where word_id in (".substr($aPlaceSearchName['nameaddress_vector'],1,-1).")";
-		$aPlaceSearchAddressKeywords = $oDB->getAll($sSQL);
-		if (PEAR::isError($aPlaceSearchAddressKeywords)) // possible timeout
-		{
-			$aPlaceSearchAddressKeywords = [];
-		}
-
-	}
-
-	logEnd($oDB, $hLog, 1);
-
-	if ($sOutputFormat=='html')
-	{
-		$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
-		$sTileURL = CONST_Map_Tile_URL;
-		$sTileAttribution = CONST_Map_Tile_Attribution;
-	}
-
-	include(CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php');
+include(CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php');

--- a/website/details.php
+++ b/website/details.php
@@ -2,10 +2,10 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Details');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/output.php';
 
 $sOutputFormat = 'html';
 
@@ -18,12 +18,11 @@ $sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $aLangPrefO
 
 $sPlaceId = getParamString('place_id');
 $sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
-$iOsmId = getParamInt('osmid', -1);
+$iOsmId   = getParamInt('osmid', -1);
 if ($sOsmType && $iOsmId > 0) {
 	$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
 
 	// Be nice about our error messages for broken geometry
-
 	if (!$sPlaceId) {
 		$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
 		if (!PEAR::isError($aPointDetails) && $aPointDetails) {
@@ -34,7 +33,8 @@ if ($sOsmType && $iOsmId > 0) {
 				$aPointDetails['error_x'] = 0;
 				$aPointDetails['error_y'] = 0;
 			}
-			include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
+
+			include CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php';
 			exit;
 		}
 	}
@@ -43,7 +43,7 @@ if ($sOsmType && $iOsmId > 0) {
 
 if (!$sPlaceId) userError("Please select a place id");
 
-$iPlaceID = (int)$sPlaceId;
+$iPlaceID = (int) $sPlaceId;
 
 if (CONST_Use_US_Tiger_Data) {
 	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
@@ -58,16 +58,16 @@ if (CONST_Use_Aux_Location_data) {
 $hLog = logStart($oDB, 'details', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
 // Get the details for this point
-$sSQL = "select place_id, osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, calculated_country_code as country_code, importance, wikipedia,";
+$sSQL  = "select place_id, osm_type, osm_id, class, type, name, admin_level, housenumber, street, isin, postcode, calculated_country_code as country_code, importance, wikipedia,";
 $sSQL .= " to_char(indexed_date, 'YYYY-MM-DD HH24:MI') as indexed_date, parent_place_id, rank_address, rank_search, get_searchrank_label(rank_search) as rank_search_label, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ";
 $sSQL .= " ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ";
-//$sSQL .= " ST_Area(geometry::geography) as area, ";
+// $sSQL .= " ST_Area(geometry::geography) as area, ";
 $sSQL .= " ST_y(centroid) as lat, ST_x(centroid) as lon,";
 $sSQL .= " case when importance = 0 OR importance IS NULL then 0.75-(rank_search::float/40) else importance end as calculated_importance, ";
 $sSQL .= " ST_AsText(CASE WHEN ST_NPoints(geometry) > 5000 THEN ST_SimplifyPreserveTopology(geometry, 0.0001) ELSE geometry END) as outlinestring";
 $sSQL .= " from placex where place_id = $iPlaceID";
 $aPointDetails = chksql($oDB->getRow($sSQL), "Could not get details of place object.");
-$aPointDetails['localname'] = $aPointDetails['localname']?$aPointDetails['localname']:$aPointDetails['housenumber'];
+$aPointDetails['localname'] = $aPointDetails['localname'] ? $aPointDetails['localname'] : $aPointDetails['housenumber'];
 
 $aClassType = getClassTypesWithImportance();
 $aPointDetails['icon'] = $aClassType[$aPointDetails['class'].':'.$aPointDetails['type']]['icon'];
@@ -90,7 +90,7 @@ if (PEAR::isError($aPointDetails['aExtraTags'])) { // possible timeout
 $aAddressLines = getAddressDetails($oDB, $sLanguagePrefArraySQL, $iPlaceID, $aPointDetails['country_code'], -1, true);
 
 // Linked places
-$sSQL = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
+$sSQL  = "select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
 $sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
 $sSQL .= " from placex, (select centroid as placegeometry from placex where place_id = $iPlaceID) as x";
 $sSQL .= " where linked_place_id = $iPlaceID";
@@ -101,7 +101,7 @@ if (PEAR::isError($aLinkedLines)) { // possible timeout
 }
 
 // All places this is an imediate parent of
-$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
+$sSQL  = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea, ST_Distance_Spheroid(geometry, placegeometry, 'SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]]') as distance, ";
 $sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
 $sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
 $sSQL .= " where parent_place_id = $iPlaceID order by rank_address asc,rank_search asc limit 500) as obj,";
@@ -137,10 +137,10 @@ if (getParamBool('keywords')) {
 
 logEnd($oDB, $hLog, 1);
 
-if ($sOutputFormat=='html') {
-	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
-	$sTileURL = CONST_Map_Tile_URL;
+if ($sOutputFormat == 'html') {
+	$sDataDate        = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+	$sTileURL         = CONST_Map_Tile_URL;
 	$sTileAttribution = CONST_Map_Tile_Attribution;
 }
 
-include(CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php');
+require CONST_BasePath.'/lib/template/details-'.$sOutputFormat.'.php';

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -14,22 +14,19 @@ $oDB =& getDB();
 $sOutputFormat = getParamSet('format', array('html', 'json'), 'html');
 
 $aLangPrefOrder = getPreferredLanguages();
-$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$aLangPrefOrder))."]";
+$sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $aLangPrefOrder))."]";
 
 $sPlaceId = getParamString('place_id');
 $sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
 $iOsmId = getParamInt('osmid', -1);
-if ($sOsmType && $iOsmId > 0)
-{
+if ($sOsmType && $iOsmId > 0) {
 	$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
 
 	// Be nice about our error messages for broken geometry
-	if (!$sPlaceId)
-	{
+	if (!$sPlaceId) {
 		$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
 		if ($aPointDetails) {
-			if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches))
-			{
+			if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches)) {
 				$aPointDetails['error_x'] = $aMatches[1];
 				$aPointDetails['error_y'] = $aMatches[2];
 			}
@@ -43,14 +40,12 @@ if (!$sPlaceId) userError("Please select a place id");
 
 $iPlaceID = (int)$sPlaceId;
 
-if (CONST_Use_US_Tiger_Data)
-{
+if (CONST_Use_US_Tiger_Data) {
 	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
 	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
 }
 
-if (CONST_Use_Aux_Location_data)
-{
+if (CONST_Use_Aux_Location_data) {
 	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_aux where place_id = '.$iPlaceID));
 	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
 }
@@ -64,16 +59,14 @@ $aPlaceAddress = array_reverse($oPlaceLookup->getAddressDetails($iPlaceID));
 if (!sizeof($aPlaceAddress)) userError("Unknown place id.");
 
 $aBreadcrums = array();
-foreach($aPlaceAddress as $i => $aPlace)
-{
+foreach ($aPlaceAddress as $i => $aPlace) {
 	if (!$aPlace['place_id']) continue;
 	$aBreadcrums[] = array('placeId'   => $aPlace['place_id'],
 	                       'osmType'   => $aPlace['osm_type'],
 	                       'osmId'     => $aPlace['osm_id'],
 	                       'localName' => $aPlace['localname']);
 
-	if ($sOutputFormat == 'html')
-	{
+	if ($sOutputFormat == 'html') {
 		$sPlaceUrl = 'hierarchy.php?place_id='.$aPlace['place_id'];
 		if ($i) echo " &gt; ";
 		echo '<a href="'.$sPlaceUrl.'">'.$aPlace['localname'].'</a> ('.osmLink($aPlace).')';
@@ -81,8 +74,7 @@ foreach($aPlaceAddress as $i => $aPlace)
 }
 
 
-if ($sOutputFormat == 'json')
-{
+if ($sOutputFormat == 'json') {
 	header("content-type: application/json; charset=UTF-8");
 	$aDetails = array();
 	$aDetails['breadcrumbs'] = $aBreadcrums;
@@ -95,38 +87,32 @@ $aRelatedPlaceIDs = chksql($oDB->getCol($sSQL = "select place_id from placex whe
 $sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea,  st_area(geometry) as area, ";
 $sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
 $sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
-$sSQL .= " where parent_place_id in (".join(',',$aRelatedPlaceIDs).") and name is not null order by rank_address asc,rank_search asc limit 500) as obj";
+$sSQL .= " where parent_place_id in (".join(',', $aRelatedPlaceIDs).") and name is not null order by rank_address asc,rank_search asc limit 500) as obj";
 $sSQL .= " order by rank_address asc,rank_search asc,localname,class, type,housenumber";
 $aParentOfLines = chksql($oDB->getAll($sSQL));
 
-if (sizeof($aParentOfLines))
-{
+if (sizeof($aParentOfLines)) {
 	echo '<h2>Parent Of:</h2>';
 	$aClassType = getClassTypesWithImportance();
 	$aGroupedAddressLines = array();
-	foreach($aParentOfLines as $aAddressLine)
-	{
+	foreach ($aParentOfLines as $aAddressLine) {
 		if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-		      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-		{
+		      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label']) {
 			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
-		}
-		elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-		        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-		{
+		} elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
+		        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label']) {
 			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
+		} else {
+			$aAddressLine['label'] = ucwords($aAddressLine['type']);
 		}
-		else $aAddressLine['label'] = ucwords($aAddressLine['type']);
 
 		if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
-			$aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
+		$aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
 	}
 
-	foreach($aGroupedAddressLines as $sGroupHeading => $aParentOfLines)
-	{
+	foreach ($aGroupedAddressLines as $sGroupHeading => $aParentOfLines) {
 		echo "<h3>$sGroupHeading</h3>";
-		foreach($aParentOfLines as $aAddressLine)
-		{
+		foreach ($aParentOfLines as $aAddressLine) {
 			$aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
 			$sOSMType = formatOSMType($aAddressLine['osm_type'], false);
 

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -1,147 +1,148 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Details');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-	require_once(CONST_BasePath.'/lib/output.php');
-	ini_set('memory_limit', '200M');
+@define('CONST_ConnectionBucket_PageType', 'Details');
 
-	$oDB =& getDB();
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/PlaceLookup.php');
+require_once(CONST_BasePath.'/lib/output.php');
+ini_set('memory_limit', '200M');
 
-	$sOutputFormat = getParamSet('format', array('html', 'json'), 'html');
+$oDB =& getDB();
 
-	$aLangPrefOrder = getPreferredLanguages();
-	$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$aLangPrefOrder))."]";
+$sOutputFormat = getParamSet('format', array('html', 'json'), 'html');
 
-	$sPlaceId = getParamString('place_id');
-	$sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
-	$iOsmId = getParamInt('osmid', -1);
-	if ($sOsmType && $iOsmId > 0)
+$aLangPrefOrder = getPreferredLanguages();
+$sLanguagePrefArraySQL = "ARRAY[".join(',',array_map("getDBQuoted",$aLangPrefOrder))."]";
+
+$sPlaceId = getParamString('place_id');
+$sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
+$iOsmId = getParamInt('osmid', -1);
+if ($sOsmType && $iOsmId > 0)
+{
+	$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
+
+	// Be nice about our error messages for broken geometry
+	if (!$sPlaceId)
 	{
-		$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
-
-		// Be nice about our error messages for broken geometry
-		if (!$sPlaceId)
-		{
-			$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
-			if ($aPointDetails) {
-				if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches))
-				{
-					$aPointDetails['error_x'] = $aMatches[1];
-					$aPointDetails['error_y'] = $aMatches[2];
-				}
-				include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
-				exit;
+		$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
+		if ($aPointDetails) {
+			if (preg_match('/\[(-?\d+\.\d+) (-?\d+\.\d+)\]/', $aPointDetails['errormessage'], $aMatches))
+			{
+				$aPointDetails['error_x'] = $aMatches[1];
+				$aPointDetails['error_y'] = $aMatches[2];
 			}
+			include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
+			exit;
 		}
 	}
+}
 
-	if (!$sPlaceId) userError("Please select a place id");
+if (!$sPlaceId) userError("Please select a place id");
 
-	$iPlaceID = (int)$sPlaceId;
+$iPlaceID = (int)$sPlaceId;
 
-	if (CONST_Use_US_Tiger_Data)
+if (CONST_Use_US_Tiger_Data)
+{
+	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
+	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+}
+
+if (CONST_Use_Aux_Location_data)
+{
+	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_aux where place_id = '.$iPlaceID));
+	if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+}
+
+$oPlaceLookup = new PlaceLookup($oDB);
+$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
+$oPlaceLookup->setIncludeAddressDetails(true);
+
+$aPlaceAddress = array_reverse($oPlaceLookup->getAddressDetails($iPlaceID));
+
+if (!sizeof($aPlaceAddress)) userError("Unknown place id.");
+
+$aBreadcrums = array();
+foreach($aPlaceAddress as $i => $aPlace)
+{
+	if (!$aPlace['place_id']) continue;
+	$aBreadcrums[] = array('placeId'   => $aPlace['place_id'],
+	                       'osmType'   => $aPlace['osm_type'],
+	                       'osmId'     => $aPlace['osm_id'],
+	                       'localName' => $aPlace['localname']);
+
+	if ($sOutputFormat == 'html')
 	{
-		$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
-		if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
+		$sPlaceUrl = 'hierarchy.php?place_id='.$aPlace['place_id'];
+		if ($i) echo " &gt; ";
+		echo '<a href="'.$sPlaceUrl.'">'.$aPlace['localname'].'</a> ('.osmLink($aPlace).')';
 	}
+}
 
-	if (CONST_Use_Aux_Location_data)
+
+if ($sOutputFormat == 'json')
+{
+	header("content-type: application/json; charset=UTF-8");
+	$aDetails = array();
+	$aDetails['breadcrumbs'] = $aBreadcrums;
+	javascript_renderData($aDetails);
+	exit;
+}
+
+$aRelatedPlaceIDs = chksql($oDB->getCol($sSQL = "select place_id from placex where linked_place_id = $iPlaceID or place_id = $iPlaceID"));
+
+$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea,  st_area(geometry) as area, ";
+$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
+$sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
+$sSQL .= " where parent_place_id in (".join(',',$aRelatedPlaceIDs).") and name is not null order by rank_address asc,rank_search asc limit 500) as obj";
+$sSQL .= " order by rank_address asc,rank_search asc,localname,class, type,housenumber";
+$aParentOfLines = chksql($oDB->getAll($sSQL));
+
+if (sizeof($aParentOfLines))
+{
+	echo '<h2>Parent Of:</h2>';
+	$aClassType = getClassTypesWithImportance();
+	$aGroupedAddressLines = array();
+	foreach($aParentOfLines as $aAddressLine)
 	{
-		$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_aux where place_id = '.$iPlaceID));
-		if ($iParentPlaceID) $iPlaceID = $iParentPlaceID;
-	}
-
-	$oPlaceLookup = new PlaceLookup($oDB);
-	$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-	$oPlaceLookup->setIncludeAddressDetails(true);
-
-	$aPlaceAddress = array_reverse($oPlaceLookup->getAddressDetails($iPlaceID));
-
-	if (!sizeof($aPlaceAddress)) userError("Unknown place id.");
-
-	$aBreadcrums = array();
-	foreach($aPlaceAddress as $i => $aPlace)
-	{
-		if (!$aPlace['place_id']) continue;
-		$aBreadcrums[] = array('placeId'   => $aPlace['place_id'],
-		                       'osmType'   => $aPlace['osm_type'],
-		                       'osmId'     => $aPlace['osm_id'],
-		                       'localName' => $aPlace['localname']);
-
-		if ($sOutputFormat == 'html')
+		if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
+		      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
 		{
-			$sPlaceUrl = 'hierarchy.php?place_id='.$aPlace['place_id'];
-			if ($i) echo " &gt; ";
-			echo '<a href="'.$sPlaceUrl.'">'.$aPlace['localname'].'</a> ('.osmLink($aPlace).')';
+			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
 		}
+		elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
+		        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
+		{
+			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
+		}
+		else $aAddressLine['label'] = ucwords($aAddressLine['type']);
+
+		if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
+			$aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
 	}
 
-
-	if ($sOutputFormat == 'json')
+	foreach($aGroupedAddressLines as $sGroupHeading => $aParentOfLines)
 	{
-		header("content-type: application/json; charset=UTF-8");
-		$aDetails = array();
-		$aDetails['breadcrumbs'] = $aBreadcrums;
-		javascript_renderData($aDetails);
-		exit;
-	}
-
-	$aRelatedPlaceIDs = chksql($oDB->getCol($sSQL = "select place_id from placex where linked_place_id = $iPlaceID or place_id = $iPlaceID"));
-
-	$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea,  st_area(geometry) as area, ";
-	$sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
-	$sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
-	$sSQL .= " where parent_place_id in (".join(',',$aRelatedPlaceIDs).") and name is not null order by rank_address asc,rank_search asc limit 500) as obj";
-	$sSQL .= " order by rank_address asc,rank_search asc,localname,class, type,housenumber";
-	$aParentOfLines = chksql($oDB->getAll($sSQL));
-
-	if (sizeof($aParentOfLines))
-	{
-		echo '<h2>Parent Of:</h2>';
-		$aClassType = getClassTypesWithImportance();
-		$aGroupedAddressLines = array();
+		echo "<h3>$sGroupHeading</h3>";
 		foreach($aParentOfLines as $aAddressLine)
 		{
-			if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-			      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-			{
-				$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
-			}
-			elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-			        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-			{
-				$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
-			}
-			else $aAddressLine['label'] = ucwords($aAddressLine['type']);
+			$aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
+			$sOSMType = formatOSMType($aAddressLine['osm_type'], false);
 
-			if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
-				$aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;
+			echo '<div class="line">';
+			echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
+			echo ' (';
+			echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
+			if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' '.osmLink($aAddressLine).'</span>';
+			echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
+			echo ', '.$aAddressLine['area'];
+			echo ')';
+			echo '</div>';
 		}
-
-		foreach($aGroupedAddressLines as $sGroupHeading => $aParentOfLines)
-		{
-			echo "<h3>$sGroupHeading</h3>";
-			foreach($aParentOfLines as $aAddressLine)
-			{
-				$aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
-				$sOSMType = formatOSMType($aAddressLine['osm_type'], false);
-
-				echo '<div class="line">';
-				echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
-				echo ' (';
-				echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
-				if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' '.osmLink($aAddressLine).'</span>';
-				echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
-				echo ', '.$aAddressLine['area'];
-				echo ')';
-				echo '</div>';
-			}
-		}
-		if (sizeof($aParentOfLines) >= 500) {
-			echo '<p>There are more child objects which are not shown.</p>';
-		}
-		echo '</div>';
 	}
+	if (sizeof($aParentOfLines) >= 500) {
+		echo '<p>There are more child objects which are not shown.</p>';
+	}
+	echo '</div>';
+}

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -2,11 +2,11 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Details');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/PlaceLookup.php';
+require_once CONST_BasePath.'/lib/output.php';
 ini_set('memory_limit', '200M');
 
 $oDB =& getDB();
@@ -14,15 +14,17 @@ $oDB =& getDB();
 $sOutputFormat = getParamSet('format', array('html', 'json'), 'html');
 
 $aLangPrefOrder = getPreferredLanguages();
+
 $sLanguagePrefArraySQL = "ARRAY[".join(',', array_map("getDBQuoted", $aLangPrefOrder))."]";
 
 $sPlaceId = getParamString('place_id');
 $sOsmType = getParamSet('osmtype', array('N', 'W', 'R'));
-$iOsmId = getParamInt('osmid', -1);
+$iOsmId   = getParamInt('osmid', -1);
+
 if ($sOsmType && $iOsmId > 0) {
 	$sPlaceId = chksql($oDB->getOne("select place_id from placex where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by type = 'postcode' asc"));
 
-	// Be nice about our error messages for broken geometry
+	// Be nice about our error messages for broken geometry.
 	if (!$sPlaceId) {
 		$aPointDetails = chksql($oDB->getRow("select osm_type, osm_id, errormessage, class, type, get_name_by_language(name,$sLanguagePrefArraySQL) as localname, ST_AsText(prevgeometry) as prevgeom, ST_AsText(newgeometry) as newgeom from import_polygon_error where osm_type = '".$sOsmType."' and osm_id = ".$iOsmId." order by updated desc limit 1"));
 		if ($aPointDetails) {
@@ -30,7 +32,8 @@ if ($sOsmType && $iOsmId > 0) {
 				$aPointDetails['error_x'] = $aMatches[1];
 				$aPointDetails['error_y'] = $aMatches[2];
 			}
-			include(CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php');
+
+			include CONST_BasePath.'/lib/template/details-error-'.$sOutputFormat.'.php';
 			exit;
 		}
 	}
@@ -38,7 +41,7 @@ if ($sOsmType && $iOsmId > 0) {
 
 if (!$sPlaceId) userError("Please select a place id");
 
-$iPlaceID = (int)$sPlaceId;
+$iPlaceID = (int) $sPlaceId;
 
 if (CONST_Use_US_Tiger_Data) {
 	$iParentPlaceID = chksql($oDB->getOne('select parent_place_id from location_property_tiger where place_id = '.$iPlaceID));
@@ -61,10 +64,12 @@ if (!sizeof($aPlaceAddress)) userError("Unknown place id.");
 $aBreadcrums = array();
 foreach ($aPlaceAddress as $i => $aPlace) {
 	if (!$aPlace['place_id']) continue;
-	$aBreadcrums[] = array('placeId'   => $aPlace['place_id'],
-	                       'osmType'   => $aPlace['osm_type'],
-	                       'osmId'     => $aPlace['osm_id'],
-	                       'localName' => $aPlace['localname']);
+	$aBreadcrums[] = array(
+	                  'placeId'   => $aPlace['place_id'],
+	                  'osmType'   => $aPlace['osm_type'],
+	                  'osmId'     => $aPlace['osm_id'],
+	                  'localName' => $aPlace['localname']
+	                 );
 
 	if ($sOutputFormat == 'html') {
 		$sPlaceUrl = 'hierarchy.php?place_id='.$aPlace['place_id'];
@@ -84,23 +89,27 @@ if ($sOutputFormat == 'json') {
 
 $aRelatedPlaceIDs = chksql($oDB->getCol($sSQL = "select place_id from placex where linked_place_id = $iPlaceID or place_id = $iPlaceID"));
 
-$sSQL = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea,  st_area(geometry) as area, ";
+$sSQL  = "select obj.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon') as isarea,  st_area(geometry) as area, ";
 $sSQL .= " get_name_by_language(name,$sLanguagePrefArraySQL) as localname, length(name::text) as namelength ";
 $sSQL .= " from (select placex.place_id, osm_type, osm_id, class, type, housenumber, admin_level, rank_address, rank_search, geometry, name from placex ";
 $sSQL .= " where parent_place_id in (".join(',', $aRelatedPlaceIDs).") and name is not null order by rank_address asc,rank_search asc limit 500) as obj";
 $sSQL .= " order by rank_address asc,rank_search asc,localname,class, type,housenumber";
+
 $aParentOfLines = chksql($oDB->getAll($sSQL));
 
 if (sizeof($aParentOfLines)) {
 	echo '<h2>Parent Of:</h2>';
-	$aClassType = getClassTypesWithImportance();
+	$aClassType           = getClassTypesWithImportance();
 	$aGroupedAddressLines = array();
+
 	foreach ($aParentOfLines as $aAddressLine) {
 		if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'])
-		      && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label']) {
+		    && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label']
+		) {
 			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type'].':'.$aAddressLine['admin_level']]['label'];
-		} elseif (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
-		        && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label']) {
+		} else if (isset($aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'])
+		    && $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label']
+		) {
 			$aAddressLine['label'] = $aClassType[$aAddressLine['class'].':'.$aAddressLine['type']]['label'];
 		} else {
 			$aAddressLine['label'] = ucwords($aAddressLine['type']);
@@ -113,13 +122,13 @@ if (sizeof($aParentOfLines)) {
 	foreach ($aGroupedAddressLines as $sGroupHeading => $aParentOfLines) {
 		echo "<h3>$sGroupHeading</h3>";
 		foreach ($aParentOfLines as $aAddressLine) {
-			$aAddressLine['localname'] = $aAddressLine['localname']?$aAddressLine['localname']:$aAddressLine['housenumber'];
+			$aAddressLine['localname'] = $aAddressLine['localname'] ? $aAddressLine['localname'] : $aAddressLine['housenumber'];
 			$sOSMType = formatOSMType($aAddressLine['osm_type'], false);
 
 			echo '<div class="line">';
-			echo '<span class="name">'.(trim($aAddressLine['localname'])?$aAddressLine['localname']:'<span class="noname">No Name</span>').'</span>';
+			echo '<span class="name">'.(trim($aAddressLine['localname']) ? $aAddressLine['localname'] : '<span class="noname">No Name</span>').'</span>';
 			echo ' (';
-			echo '<span class="area">'.($aAddressLine['isarea']=='t'?'Polygon':'Point').'</span>';
+			echo '<span class="area">'.($aAddressLine['isarea'] == 't' ? 'Polygon' : 'Point').'</span>';
 			if ($sOSMType) echo ', <span class="osm"><span class="label"></span>'.$sOSMType.' '.osmLink($aAddressLine).'</span>';
 			echo ', <a href="hierarchy.php?place_id='.$aAddressLine['place_id'].'">GOTO</a>';
 			echo ', '.$aAddressLine['area'];
@@ -127,8 +136,10 @@ if (sizeof($aParentOfLines)) {
 			echo '</div>';
 		}
 	}
+
 	if (sizeof($aParentOfLines) >= 500) {
 		echo '<p>There are more child objects which are not shown.</p>';
 	}
+
 	echo '</div>';
-}
+}//end if

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -1,73 +1,74 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-	require_once(CONST_BasePath.'/lib/output.php');
+@define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-	$oDB =& getDB();
-	ini_set('memory_limit', '200M');
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/PlaceLookup.php');
+require_once(CONST_BasePath.'/lib/output.php');
 
-	// Format for output
-	$sOutputFormat = getParamSet('format', array('xml', 'json'), 'xml');
+$oDB =& getDB();
+ini_set('memory_limit', '200M');
 
-	// Preferred language
-	$aLangPrefOrder = getPreferredLanguages();
+// Format for output
+$sOutputFormat = getParamSet('format', array('xml', 'json'), 'xml');
 
-	$hLog = logStart($oDB, 'place', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
+// Preferred language
+$aLangPrefOrder = getPreferredLanguages();
 
-	$aSearchResults = array();
-	$aCleanedQueryParts = array();
+$hLog = logStart($oDB, 'place', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
-	$oPlaceLookup = new PlaceLookup($oDB);
-	$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-	$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
-	$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
-	$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
+$aSearchResults = array();
+$aCleanedQueryParts = array();
 
-	$aOsmIds = explode(',', getParamString('osm_ids', ''));
+$oPlaceLookup = new PlaceLookup($oDB);
+$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
+$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
+$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
+$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 
-	if (count($aOsmIds) > CONST_Places_Max_ID_count)
+$aOsmIds = explode(',', getParamString('osm_ids', ''));
+
+if (count($aOsmIds) > CONST_Places_Max_ID_count)
+{
+	userError('Bulk User: Only ' . CONST_Places_Max_ID_count . " ids are allowed in one request.");
+}
+
+foreach ($aOsmIds AS $sItem)
+{
+	// Skip empty sItem
+	if (empty($sItem)) continue;
+	
+	$sType = $sItem[0];
+	$iId = (int) substr($sItem, 1);
+	if ( $iId > 0 && ($sType == 'N' || $sType == 'W' || $sType == 'R') )
 	{
-		userError('Bulk User: Only ' . CONST_Places_Max_ID_count . " ids are allowed in one request.");
-	}
-
-	foreach ($aOsmIds AS $sItem)
-	{
-		// Skip empty sItem
-		if (empty($sItem)) continue;
-		
-		$sType = $sItem[0];
-		$iId = (int) substr($sItem, 1);
-		if ( $iId > 0 && ($sType == 'N' || $sType == 'W' || $sType == 'R') )
-		{
-			$aCleanedQueryParts[] = $sType . $iId;
-			$oPlace = $oPlaceLookup->lookupOSMID($sType, $iId);
-			if ($oPlace){
-				// we want to use the search-* output templates, so we need to fill
-				// $aSearchResults and slightly change the (reverse search) oPlace
-				// key names
-				$oResult = $oPlace;
-				unset($oResult['aAddress']);
-				if (isset($oPlace['aAddress'])) $oResult['address'] = $oPlace['aAddress'];
-				unset($oResult['langaddress']);
-				$oResult['name'] = $oPlace['langaddress'];
-				$aSearchResults[] = $oResult;
-			}
+		$aCleanedQueryParts[] = $sType . $iId;
+		$oPlace = $oPlaceLookup->lookupOSMID($sType, $iId);
+		if ($oPlace){
+			// we want to use the search-* output templates, so we need to fill
+			// $aSearchResults and slightly change the (reverse search) oPlace
+			// key names
+			$oResult = $oPlace;
+			unset($oResult['aAddress']);
+			if (isset($oPlace['aAddress'])) $oResult['address'] = $oPlace['aAddress'];
+			unset($oResult['langaddress']);
+			$oResult['name'] = $oPlace['langaddress'];
+			$aSearchResults[] = $oResult;
 		}
 	}
+}
 
 
-	if (CONST_Debug) exit;
+if (CONST_Debug) exit;
 
-	$sXmlRootTag = 'lookupresults';
-	$sQuery = join(',',$aCleanedQueryParts);
-	// we initialize these to avoid warnings in our logfile
-	$sViewBox = '';
-	$bShowPolygons = '';
-	$aExcludePlaceIDs = [];
-	$sMoreURL = '';
+$sXmlRootTag = 'lookupresults';
+$sQuery = join(',',$aCleanedQueryParts);
+// we initialize these to avoid warnings in our logfile
+$sViewBox = '';
+$bShowPolygons = '';
+$aExcludePlaceIDs = [];
+$sMoreURL = '';
 
-	include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');
+include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -30,23 +30,20 @@ $oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 
 $aOsmIds = explode(',', getParamString('osm_ids', ''));
 
-if (count($aOsmIds) > CONST_Places_Max_ID_count)
-{
+if (count($aOsmIds) > CONST_Places_Max_ID_count) {
 	userError('Bulk User: Only ' . CONST_Places_Max_ID_count . " ids are allowed in one request.");
 }
 
-foreach ($aOsmIds AS $sItem)
-{
+foreach ($aOsmIds as $sItem) {
 	// Skip empty sItem
 	if (empty($sItem)) continue;
 	
 	$sType = $sItem[0];
 	$iId = (int) substr($sItem, 1);
-	if ( $iId > 0 && ($sType == 'N' || $sType == 'W' || $sType == 'R') )
-	{
+	if ($iId > 0 && ($sType == 'N' || $sType == 'W' || $sType == 'R')) {
 		$aCleanedQueryParts[] = $sType . $iId;
 		$oPlace = $oPlaceLookup->lookupOSMID($sType, $iId);
-		if ($oPlace){
+		if ($oPlace) {
 			// we want to use the search-* output templates, so we need to fill
 			// $aSearchResults and slightly change the (reverse search) oPlace
 			// key names
@@ -64,7 +61,7 @@ foreach ($aOsmIds AS $sItem)
 if (CONST_Debug) exit;
 
 $sXmlRootTag = 'lookupresults';
-$sQuery = join(',',$aCleanedQueryParts);
+$sQuery = join(',', $aCleanedQueryParts);
 // we initialize these to avoid warnings in our logfile
 $sViewBox = '';
 $bShowPolygons = '';

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -2,24 +2,24 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/PlaceLookup.php';
+require_once CONST_BasePath.'/lib/output.php';
 
 $oDB =& getDB();
 ini_set('memory_limit', '200M');
 
-// Format for output
+// Format for output.
 $sOutputFormat = getParamSet('format', array('xml', 'json'), 'xml');
 
-// Preferred language
+// Preferred language.
 $aLangPrefOrder = getPreferredLanguages();
 
 $hLog = logStart($oDB, 'place', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
 
-$aSearchResults = array();
+$aSearchResults     = array();
 $aCleanedQueryParts = array();
 
 $oPlaceLookup = new PlaceLookup($oDB);
@@ -31,41 +31,42 @@ $oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 $aOsmIds = explode(',', getParamString('osm_ids', ''));
 
 if (count($aOsmIds) > CONST_Places_Max_ID_count) {
-	userError('Bulk User: Only ' . CONST_Places_Max_ID_count . " ids are allowed in one request.");
+	userError('Bulk User: Only '.CONST_Places_Max_ID_count." ids are allowed in one request.");
 }
 
 foreach ($aOsmIds as $sItem) {
-	// Skip empty sItem
+	// Skip empty sItem.
 	if (empty($sItem)) continue;
-	
+
 	$sType = $sItem[0];
-	$iId = (int) substr($sItem, 1);
+	$iId   = (int) substr($sItem, 1);
+
 	if ($iId > 0 && ($sType == 'N' || $sType == 'W' || $sType == 'R')) {
-		$aCleanedQueryParts[] = $sType . $iId;
+		$aCleanedQueryParts[] = $sType.$iId;
 		$oPlace = $oPlaceLookup->lookupOSMID($sType, $iId);
 		if ($oPlace) {
-			// we want to use the search-* output templates, so we need to fill
+			// We want to use the search-* output templates, so we need to fill
 			// $aSearchResults and slightly change the (reverse search) oPlace
-			// key names
+			// key names.
 			$oResult = $oPlace;
 			unset($oResult['aAddress']);
 			if (isset($oPlace['aAddress'])) $oResult['address'] = $oPlace['aAddress'];
 			unset($oResult['langaddress']);
-			$oResult['name'] = $oPlace['langaddress'];
+			$oResult['name']  = $oPlace['langaddress'];
 			$aSearchResults[] = $oResult;
 		}
 	}
-}
+}//end foreach
 
 
 if (CONST_Debug) exit;
 
 $sXmlRootTag = 'lookupresults';
-$sQuery = join(',', $aCleanedQueryParts);
-// we initialize these to avoid warnings in our logfile
-$sViewBox = '';
-$bShowPolygons = '';
+$sQuery      = join(',', $aCleanedQueryParts);
+// We initialize these to avoid warnings in our logfile.
+$sViewBox         = '';
+$bShowPolygons    = '';
 $aExcludePlaceIDs = [];
-$sMoreURL = '';
+$sMoreURL         = '';
 
-include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');
+require CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php';

--- a/website/polygons.php
+++ b/website/polygons.php
@@ -16,8 +16,7 @@ $sClass = getParamString('class', false);
 $iTotalBroken = (int) chksql($oDB->getOne('select count(*) from import_polygon_error'));
 
 $aPolygons = array();
-while($iTotalBroken && !sizeof($aPolygons))
-{
+while ($iTotalBroken && !sizeof($aPolygons)) {
 	$sSQL = 'select osm_type as "type",osm_id as "id",class as "key",type as "value",name->\'name\' as "name",';
 	$sSQL .= 'country_code as "country",errormessage as "error message",updated';
 	$sSQL .= " from import_polygon_error";
@@ -30,8 +29,7 @@ while($iTotalBroken && !sizeof($aPolygons))
 	$aPolygons = chksql($oDB->getAll($sSQL));
 }
 
-if (CONST_Debug)
-{
+if (CONST_Debug) {
 	var_dump($aPolygons);
 	exit;
 }
@@ -89,51 +87,42 @@ if (!$aPolygons) exit;
 echo "<table>";
 echo "<tr>";
 //var_dump($aPolygons[0]);
-foreach($aPolygons[0] as $sCol => $sVal)
-{
+foreach ($aPolygons[0] as $sCol => $sVal) {
 	echo "<th>".$sCol."</th>";
 }
 echo "<th>&nbsp;</th>";
 echo "<th>&nbsp;</th>";
 echo "</tr>";
 $aSeen = array();
-foreach($aPolygons as $aRow)
-{
+foreach ($aPolygons as $aRow) {
 	if (isset($aSeen[$aRow['type'].$aRow['id']])) continue;
 	$aSeen[$aRow['type'].$aRow['id']] = 1;
 	echo "<tr>";
-	foreach($aRow as $sCol => $sVal)
-	{
-		switch($sCol)
-		{
-		case 'error message':
-			if (preg_match('/Self-intersection\\[([0-9.\\-]+) ([0-9.\\-]+)\\]/',$sVal,$aMatch))
-			{
-				$aRow['lat'] = $aMatch[2];
-				$aRow['lon'] = $aMatch[1];
-				echo "<td><a href=\"http://www.openstreetmap.org/?lat=".$aMatch[2]."&lon=".$aMatch[1]."&zoom=18&layers=M&".$sOSMType."=".$aRow['id']."\">".($sVal?$sVal:'&nbsp;')."</a></td>";
-			}
-			else
-			{
+	foreach ($aRow as $sCol => $sVal) {
+		switch ($sCol) {
+			case 'error message':
+				if (preg_match('/Self-intersection\\[([0-9.\\-]+) ([0-9.\\-]+)\\]/', $sVal, $aMatch)) {
+					$aRow['lat'] = $aMatch[2];
+					$aRow['lon'] = $aMatch[1];
+					echo "<td><a href=\"http://www.openstreetmap.org/?lat=".$aMatch[2]."&lon=".$aMatch[1]."&zoom=18&layers=M&".$sOSMType."=".$aRow['id']."\">".($sVal?$sVal:'&nbsp;')."</a></td>";
+				} else {
+					echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+				}
+				break;
+			case 'id':
+				echo '<td>'.osmLink($aRow).'</td>';
+				break;
+			default:
 				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-			}
-			break;
-		case 'id':
-			echo '<td>'.osmLink($aRow).'</td>';
-			break;
-		default:
-			echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-			break;
+				break;
 		}
 	}
 	echo "<td><a href=\"http://localhost:8111/import?url=http://www.openstreetmap.org/api/0.6/".$sOSMType.'/'.$aRow['id']."/full\" target=\"josm\">josm</a></td>";
-	if (isset($aRow['lat']))
-	{
+	
+	if (isset($aRow['lat'])) {
 		echo "<td><a href=\"http://open.mapquestapi.com/dataedit/index_flash.html?lat=".$aRow['lat']."&lon=".$aRow['lon']."&zoom=18\" target=\"potlatch2\">P2</a></td>";
-	}
-	else
-	{
-		echo "<td>&nbsp;</td>";	
+	} else {
+		echo "<td>&nbsp;</td>";
 	}
 	echo "</tr>";
 }

--- a/website/polygons.php
+++ b/website/polygons.php
@@ -1,39 +1,41 @@
 <?php
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/output.php');
-	ini_set('memory_limit', '200M');
 
-	$oDB =& getDB();
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/output.php');
+ini_set('memory_limit', '200M');
 
-	$sOutputFormat = 'html';
-	$iDays = getParamInt('days', 1);
-	$bReduced = getParamBool('reduced', false);
-	$sClass = getParamString('class', false);
+$oDB =& getDB();
 
-	$iTotalBroken = (int) chksql($oDB->getOne('select count(*) from import_polygon_error'));
+$sOutputFormat = 'html';
+$iDays = getParamInt('days', 1);
+$bReduced = getParamBool('reduced', false);
+$sClass = getParamString('class', false);
 
-	$aPolygons = array();
-	while($iTotalBroken && !sizeof($aPolygons))
-	{
-		$sSQL = 'select osm_type as "type",osm_id as "id",class as "key",type as "value",name->\'name\' as "name",';
-		$sSQL .= 'country_code as "country",errormessage as "error message",updated';
-		$sSQL .= " from import_polygon_error";
-		$sSQL .= " where updated > 'now'::timestamp - '".$iDays." day'::interval";
-		$iDays++;
+$iTotalBroken = (int) chksql($oDB->getOne('select count(*) from import_polygon_error'));
 
-		if ($bReduced) $sSQL .= " and errormessage like 'Area reduced%'";
-		if ($sClass) $sSQL .= " and class = '".pg_escape_string($sClass)."'";
-		$sSQL .= " order by updated desc limit 1000";
-		$aPolygons = chksql($oDB->getAll($sSQL));
-	}
+$aPolygons = array();
+while($iTotalBroken && !sizeof($aPolygons))
+{
+	$sSQL = 'select osm_type as "type",osm_id as "id",class as "key",type as "value",name->\'name\' as "name",';
+	$sSQL .= 'country_code as "country",errormessage as "error message",updated';
+	$sSQL .= " from import_polygon_error";
+	$sSQL .= " where updated > 'now'::timestamp - '".$iDays." day'::interval";
+	$iDays++;
 
-	if (CONST_Debug)
-	{
-		var_dump($aPolygons);
-		exit;
-	}
+	if ($bReduced) $sSQL .= " and errormessage like 'Area reduced%'";
+	if ($sClass) $sSQL .= " and class = '".pg_escape_string($sClass)."'";
+	$sSQL .= " order by updated desc limit 1000";
+	$aPolygons = chksql($oDB->getAll($sSQL));
+}
+
+if (CONST_Debug)
+{
+	var_dump($aPolygons);
+	exit;
+}
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -82,60 +84,61 @@ table td {
 
 <?php
 
-	echo "<p>Total number of broken polygons: $iTotalBroken</p>";
-	if (!$aPolygons) exit;
-	echo "<table>";
-	echo "<tr>";
+echo "<p>Total number of broken polygons: $iTotalBroken</p>";
+if (!$aPolygons) exit;
+echo "<table>";
+echo "<tr>";
 //var_dump($aPolygons[0]);
-	foreach($aPolygons[0] as $sCol => $sVal)
+foreach($aPolygons[0] as $sCol => $sVal)
+{
+	echo "<th>".$sCol."</th>";
+}
+echo "<th>&nbsp;</th>";
+echo "<th>&nbsp;</th>";
+echo "</tr>";
+$aSeen = array();
+foreach($aPolygons as $aRow)
+{
+	if (isset($aSeen[$aRow['type'].$aRow['id']])) continue;
+	$aSeen[$aRow['type'].$aRow['id']] = 1;
+	echo "<tr>";
+	foreach($aRow as $sCol => $sVal)
 	{
-		echo "<th>".$sCol."</th>";
-	}
-	echo "<th>&nbsp;</th>";
-	echo "<th>&nbsp;</th>";
-	echo "</tr>";
-	$aSeen = array();
-	foreach($aPolygons as $aRow)
-	{
-		if (isset($aSeen[$aRow['type'].$aRow['id']])) continue;
-		$aSeen[$aRow['type'].$aRow['id']] = 1;
-		echo "<tr>";
-		foreach($aRow as $sCol => $sVal)
+		switch($sCol)
 		{
-			switch($sCol)
+		case 'error message':
+			if (preg_match('/Self-intersection\\[([0-9.\\-]+) ([0-9.\\-]+)\\]/',$sVal,$aMatch))
 			{
-			case 'error message':
-				if (preg_match('/Self-intersection\\[([0-9.\\-]+) ([0-9.\\-]+)\\]/',$sVal,$aMatch))
-				{
-					$aRow['lat'] = $aMatch[2];
-					$aRow['lon'] = $aMatch[1];
-					echo "<td><a href=\"http://www.openstreetmap.org/?lat=".$aMatch[2]."&lon=".$aMatch[1]."&zoom=18&layers=M&".$sOSMType."=".$aRow['id']."\">".($sVal?$sVal:'&nbsp;')."</a></td>";
-				}
-				else
-				{
-					echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-				}
-				break;
-			case 'id':
-				echo '<td>'.osmLink($aRow).'</td>';
-				break;
-			default:
-				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-				break;
+				$aRow['lat'] = $aMatch[2];
+				$aRow['lon'] = $aMatch[1];
+				echo "<td><a href=\"http://www.openstreetmap.org/?lat=".$aMatch[2]."&lon=".$aMatch[1]."&zoom=18&layers=M&".$sOSMType."=".$aRow['id']."\">".($sVal?$sVal:'&nbsp;')."</a></td>";
 			}
+			else
+			{
+				echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+			}
+			break;
+		case 'id':
+			echo '<td>'.osmLink($aRow).'</td>';
+			break;
+		default:
+			echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+			break;
 		}
-		echo "<td><a href=\"http://localhost:8111/import?url=http://www.openstreetmap.org/api/0.6/".$sOSMType.'/'.$aRow['id']."/full\" target=\"josm\">josm</a></td>";
-		if (isset($aRow['lat']))
-		{
-			echo "<td><a href=\"http://open.mapquestapi.com/dataedit/index_flash.html?lat=".$aRow['lat']."&lon=".$aRow['lon']."&zoom=18\" target=\"potlatch2\">P2</a></td>";
-		}
-		else
-		{
-			echo "<td>&nbsp;</td>";	
-		}
-		echo "</tr>";
 	}
-	echo "</table>";
+	echo "<td><a href=\"http://localhost:8111/import?url=http://www.openstreetmap.org/api/0.6/".$sOSMType.'/'.$aRow['id']."/full\" target=\"josm\">josm</a></td>";
+	if (isset($aRow['lat']))
+	{
+		echo "<td><a href=\"http://open.mapquestapi.com/dataedit/index_flash.html?lat=".$aRow['lat']."&lon=".$aRow['lon']."&zoom=18\" target=\"potlatch2\">P2</a></td>";
+	}
+	else
+	{
+		echo "<td>&nbsp;</td>";	
+	}
+	echo "</tr>";
+}
+echo "</table>";
+
 ?>
 </body>
 </html>

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -14,14 +14,10 @@ $bAsKML = getParamBool('polygon_kml');
 $bAsSVG = getParamBool('polygon_svg');
 $bAsText = getParamBool('polygon_text');
 if ((($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0)
-	+ ($bAsText?1:0)) > CONST_PolygonOutput_MaximumTypes)
-{
-	if (CONST_PolygonOutput_MaximumTypes)
-	{
+	+ ($bAsText?1:0)) > CONST_PolygonOutput_MaximumTypes) {
+	if (CONST_PolygonOutput_MaximumTypes) {
 		userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-	}
-	else
-	{
+	} else {
 		userError("Polygon output is disabled");
 	}
 	exit;
@@ -54,28 +50,25 @@ $sOsmType = getParamSet('osm_type', array('N', 'W', 'R'));
 $iOsmId = getParamInt('osm_id', -1);
 $fLat = getParamFloat('lat');
 $fLon = getParamFloat('lon');
-if ($sOsmType && $iOsmId > 0)
-{
+if ($sOsmType && $iOsmId > 0) {
 	$aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
-}
-else if ($fLat !== false && $fLon !== false)
-{
+} elseif ($fLat !== false && $fLon !== false) {
 	$oReverseGeocode = new ReverseGeocode($oDB);
 	$oReverseGeocode->setZoom(getParamInt('zoom', 18));
 
 	$aLookup = $oReverseGeocode->lookup($fLat, $fLon);
 	if (CONST_Debug) var_dump($aLookup);
 
-	$aPlace = $oPlaceLookup->lookup((int)$aLookup['place_id'],
-	                                $aLookup['type'], $aLookup['fraction']);
-}
-else if ($sOutputFormat != 'html')
-{
+	$aPlace = $oPlaceLookup->lookup(
+		(int)$aLookup['place_id'],
+		$aLookup['type'],
+		$aLookup['fraction']
+	);
+} elseif ($sOutputFormat != 'html') {
 	userError("Need coordinates or OSM object to lookup.");
 }
 
-if ($aPlace)
-{
+if ($aPlace) {
 	$oPlaceLookup->setIncludePolygonAsPoints(false);
 	$oPlaceLookup->setIncludePolygonAsText($bAsText);
 	$oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
@@ -84,25 +77,25 @@ if ($aPlace)
 	$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
 
 	$fRadius = $fDiameter = getResultDiameter($aPlace);
-	$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'],
-	                                             $aPlace['lon'], $aPlace['lat'],
-	                                             $fRadius);
+	$aOutlineResult = $oPlaceLookup->getOutlines(
+		$aPlace['place_id'],
+		$aPlace['lon'],
+		$aPlace['lat'],
+		$fRadius
+	);
 
-	if ($aOutlineResult)
-	{
+	if ($aOutlineResult) {
 		$aPlace = array_merge($aPlace, $aOutlineResult);
 	}
 }
 
 
-if (CONST_Debug)
-{
+if (CONST_Debug) {
 	var_dump($aPlace);
 	exit;
 }
 
-if ($sOutputFormat=='html')
-{
+if ($sOutputFormat=='html') {
 	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
 	$sTileURL = CONST_Map_Tile_URL;
 	$sTileAttribution = CONST_Map_Tile_Attribution;

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -1,109 +1,110 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-	require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
-	require_once(CONST_BasePath.'/lib/output.php');
+@define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-	$bAsGeoJSON = getParamBool('polygon_geojson');
-	$bAsKML = getParamBool('polygon_kml');
-	$bAsSVG = getParamBool('polygon_svg');
-	$bAsText = getParamBool('polygon_text');
-	if ((($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0)
-		+ ($bAsText?1:0)) > CONST_PolygonOutput_MaximumTypes)
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/PlaceLookup.php');
+require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
+require_once(CONST_BasePath.'/lib/output.php');
+
+$bAsGeoJSON = getParamBool('polygon_geojson');
+$bAsKML = getParamBool('polygon_kml');
+$bAsSVG = getParamBool('polygon_svg');
+$bAsText = getParamBool('polygon_text');
+if ((($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0)
+	+ ($bAsText?1:0)) > CONST_PolygonOutput_MaximumTypes)
+{
+	if (CONST_PolygonOutput_MaximumTypes)
 	{
-		if (CONST_PolygonOutput_MaximumTypes)
-		{
-			userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-		}
-		else
-		{
-			userError("Polygon output is disabled");
-		}
-		exit;
+		userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
 	}
-
-
-	// Polygon simplification threshold (optional)
-	$fThreshold = getParamFloat('polygon_threshold', 0.0);
-
-
-	$oDB =& getDB();
-	ini_set('memory_limit', '200M');
-
-	// Format for output
-	$sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'xml');
-
-	// Preferred language
-	$aLangPrefOrder = getPreferredLanguages();
-
-	$hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
-
-
-	$oPlaceLookup = new PlaceLookup($oDB);
-	$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-	$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
-	$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
-	$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
-
-	$sOsmType = getParamSet('osm_type', array('N', 'W', 'R'));
-	$iOsmId = getParamInt('osm_id', -1);
-	$fLat = getParamFloat('lat');
-	$fLon = getParamFloat('lon');
-	if ($sOsmType && $iOsmId > 0)
+	else
 	{
-		$aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
+		userError("Polygon output is disabled");
 	}
-	else if ($fLat !== false && $fLon !== false)
+	exit;
+}
+
+
+// Polygon simplification threshold (optional)
+$fThreshold = getParamFloat('polygon_threshold', 0.0);
+
+
+$oDB =& getDB();
+ini_set('memory_limit', '200M');
+
+// Format for output
+$sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'xml');
+
+// Preferred language
+$aLangPrefOrder = getPreferredLanguages();
+
+$hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
+
+
+$oPlaceLookup = new PlaceLookup($oDB);
+$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
+$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
+$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
+$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
+
+$sOsmType = getParamSet('osm_type', array('N', 'W', 'R'));
+$iOsmId = getParamInt('osm_id', -1);
+$fLat = getParamFloat('lat');
+$fLon = getParamFloat('lon');
+if ($sOsmType && $iOsmId > 0)
+{
+	$aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
+}
+else if ($fLat !== false && $fLon !== false)
+{
+	$oReverseGeocode = new ReverseGeocode($oDB);
+	$oReverseGeocode->setZoom(getParamInt('zoom', 18));
+
+	$aLookup = $oReverseGeocode->lookup($fLat, $fLon);
+	if (CONST_Debug) var_dump($aLookup);
+
+	$aPlace = $oPlaceLookup->lookup((int)$aLookup['place_id'],
+	                                $aLookup['type'], $aLookup['fraction']);
+}
+else if ($sOutputFormat != 'html')
+{
+	userError("Need coordinates or OSM object to lookup.");
+}
+
+if ($aPlace)
+{
+	$oPlaceLookup->setIncludePolygonAsPoints(false);
+	$oPlaceLookup->setIncludePolygonAsText($bAsText);
+	$oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
+	$oPlaceLookup->setIncludePolygonAsKML($bAsKML);
+	$oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
+	$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
+
+	$fRadius = $fDiameter = getResultDiameter($aPlace);
+	$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'],
+	                                             $aPlace['lon'], $aPlace['lat'],
+	                                             $fRadius);
+
+	if ($aOutlineResult)
 	{
-		$oReverseGeocode = new ReverseGeocode($oDB);
-		$oReverseGeocode->setZoom(getParamInt('zoom', 18));
-
-		$aLookup = $oReverseGeocode->lookup($fLat, $fLon);
-		if (CONST_Debug) var_dump($aLookup);
-
-		$aPlace = $oPlaceLookup->lookup((int)$aLookup['place_id'],
-		                                $aLookup['type'], $aLookup['fraction']);
+		$aPlace = array_merge($aPlace, $aOutlineResult);
 	}
-	else if ($sOutputFormat != 'html')
-	{
-		userError("Need coordinates or OSM object to lookup.");
-	}
-
-	if ($aPlace)
-	{
-		$oPlaceLookup->setIncludePolygonAsPoints(false);
-		$oPlaceLookup->setIncludePolygonAsText($bAsText);
-		$oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
-		$oPlaceLookup->setIncludePolygonAsKML($bAsKML);
-		$oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
-		$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
-
-		$fRadius = $fDiameter = getResultDiameter($aPlace);
-		$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'],
-		                                             $aPlace['lon'], $aPlace['lat'],
-		                                             $fRadius);
-
-		if ($aOutlineResult)
-		{
-			$aPlace = array_merge($aPlace, $aOutlineResult);
-		}
-	}
+}
 
 
-	if (CONST_Debug)
-	{
-		var_dump($aPlace);
-		exit;
-	}
+if (CONST_Debug)
+{
+	var_dump($aPlace);
+	exit;
+}
 
-	if ($sOutputFormat=='html')
-	{
-		$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
-		$sTileURL = CONST_Map_Tile_URL;
-		$sTileAttribution = CONST_Map_Tile_Attribution;
-	}
-	include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');
+if ($sOutputFormat=='html')
+{
+	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+	$sTileURL = CONST_Map_Tile_URL;
+	$sTileAttribution = CONST_Map_Tile_Attribution;
+}
+include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -2,39 +2,41 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Reverse');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/PlaceLookup.php');
-require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/PlaceLookup.php';
+require_once CONST_BasePath.'/lib/ReverseGeocode.php';
+require_once CONST_BasePath.'/lib/output.php';
 
 $bAsGeoJSON = getParamBool('polygon_geojson');
-$bAsKML = getParamBool('polygon_kml');
-$bAsSVG = getParamBool('polygon_svg');
-$bAsText = getParamBool('polygon_text');
-if ((($bAsGeoJSON?1:0) + ($bAsKML?1:0) + ($bAsSVG?1:0)
-	+ ($bAsText?1:0)) > CONST_PolygonOutput_MaximumTypes) {
+$bAsKML     = getParamBool('polygon_kml');
+$bAsSVG     = getParamBool('polygon_svg');
+$bAsText    = getParamBool('polygon_text');
+
+$numTypesRequests = (($bAsGeoJSON ? 1 : 0) + ($bAsKML ? 1 : 0) + ($bAsSVG ? 1 : 0) + ($bAsText ? 1 : 0));
+if ($numTypesRequests > CONST_PolygonOutput_MaximumTypes) {
 	if (CONST_PolygonOutput_MaximumTypes) {
 		userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
 	} else {
 		userError("Polygon output is disabled");
 	}
+
 	exit;
 }
 
 
-// Polygon simplification threshold (optional)
+// Polygon simplification threshold (optional).
 $fThreshold = getParamFloat('polygon_threshold', 0.0);
 
 
 $oDB =& getDB();
 ini_set('memory_limit', '200M');
 
-// Format for output
+// Format for output.
 $sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'xml');
 
-// Preferred language
+// Preferred language.
 $aLangPrefOrder = getPreferredLanguages();
 
 $hLog = logStart($oDB, 'reverse', $_SERVER['QUERY_STRING'], $aLangPrefOrder);
@@ -47,12 +49,12 @@ $oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
 $oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 
 $sOsmType = getParamSet('osm_type', array('N', 'W', 'R'));
-$iOsmId = getParamInt('osm_id', -1);
-$fLat = getParamFloat('lat');
-$fLon = getParamFloat('lon');
+$iOsmId   = getParamInt('osm_id', -1);
+$fLat     = getParamFloat('lat');
+$fLon     = getParamFloat('lon');
 if ($sOsmType && $iOsmId > 0) {
 	$aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
-} elseif ($fLat !== false && $fLon !== false) {
+} else if ($fLat !== false && $fLon !== false) {
 	$oReverseGeocode = new ReverseGeocode($oDB);
 	$oReverseGeocode->setZoom(getParamInt('zoom', 18));
 
@@ -60,11 +62,11 @@ if ($sOsmType && $iOsmId > 0) {
 	if (CONST_Debug) var_dump($aLookup);
 
 	$aPlace = $oPlaceLookup->lookup(
-		(int)$aLookup['place_id'],
+		(int) $aLookup['place_id'],
 		$aLookup['type'],
 		$aLookup['fraction']
 	);
-} elseif ($sOutputFormat != 'html') {
+} else if ($sOutputFormat != 'html') {
 	userError("Need coordinates or OSM object to lookup.");
 }
 
@@ -76,7 +78,7 @@ if ($aPlace) {
 	$oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
 	$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
 
-	$fRadius = $fDiameter = getResultDiameter($aPlace);
+	$fRadius        = $fDiameter = getResultDiameter($aPlace);
 	$aOutlineResult = $oPlaceLookup->getOutlines(
 		$aPlace['place_id'],
 		$aPlace['lon'],
@@ -95,9 +97,10 @@ if (CONST_Debug) {
 	exit;
 }
 
-if ($sOutputFormat=='html') {
-	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
-	$sTileURL = CONST_Map_Tile_URL;
+if ($sOutputFormat == 'html') {
+	$sDataDate        = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+	$sTileURL         = CONST_Map_Tile_URL;
 	$sTileAttribution = CONST_Map_Tile_Attribution;
 }
-include(CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php');
+
+require CONST_BasePath.'/lib/template/address-'.$sOutputFormat.'.php';

--- a/website/search.php
+++ b/website/search.php
@@ -1,132 +1,133 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Search');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
-	require_once(CONST_BasePath.'/lib/log.php');
-	require_once(CONST_BasePath.'/lib/Geocode.php');
-	require_once(CONST_BasePath.'/lib/output.php');
+@define('CONST_ConnectionBucket_PageType', 'Search');
 
-	ini_set('memory_limit', '200M');
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/Geocode.php');
+require_once(CONST_BasePath.'/lib/output.php');
 
-	$oDB =& getDB();
+ini_set('memory_limit', '200M');
 
-	$oGeocode = new Geocode($oDB);
+$oDB =& getDB();
 
-	$aLangPrefOrder = getPreferredLanguages();
-	$oGeocode->setLanguagePreference($aLangPrefOrder);
+$oGeocode = new Geocode($oDB);
 
-	if (CONST_Search_ReversePlanForAll
-		|| isset($aLangPrefOrder['name:de'])
-		|| isset($aLangPrefOrder['name:ru'])
-		|| isset($aLangPrefOrder['name:ja'])
-		|| isset($aLangPrefOrder['name:pl']))
+$aLangPrefOrder = getPreferredLanguages();
+$oGeocode->setLanguagePreference($aLangPrefOrder);
+
+if (CONST_Search_ReversePlanForAll
+	|| isset($aLangPrefOrder['name:de'])
+	|| isset($aLangPrefOrder['name:ru'])
+	|| isset($aLangPrefOrder['name:ja'])
+	|| isset($aLangPrefOrder['name:pl']))
+{
+	$oGeocode->setReverseInPlan(true);
+}
+
+// Format for output
+$sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'html');
+
+// Show / use polygons
+if ($sOutputFormat == 'html')
+{
+	$oGeocode->setIncludePolygonAsText(getParamBool('polygon'));
+	$bAsText = false;
+}
+else
+{
+	$bAsPoints = getParamBool('polygon');
+	$bAsGeoJSON = getParamBool('polygon_geojson');
+	$bAsKML = getParamBool('polygon_kml');
+	$bAsSVG = getParamBool('polygon_svg');
+	$bAsText = getParamBool('polygon_text');
+	if ( ( ($bAsGeoJSON?1:0)
+			 + ($bAsKML?1:0)
+			 + ($bAsSVG?1:0)
+			 + ($bAsText?1:0)
+			 + ($bAsPoints?1:0)
+			 ) > CONST_PolygonOutput_MaximumTypes)
 	{
-		$oGeocode->setReverseInPlan(true);
-	}
-
-	// Format for output
-	$sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'html');
-
-	// Show / use polygons
-	if ($sOutputFormat == 'html')
-	{
-		$oGeocode->setIncludePolygonAsText(getParamBool('polygon'));
-		$bAsText = false;
-	}
-	else
-	{
-		$bAsPoints = getParamBool('polygon');
-		$bAsGeoJSON = getParamBool('polygon_geojson');
-		$bAsKML = getParamBool('polygon_kml');
-		$bAsSVG = getParamBool('polygon_svg');
-		$bAsText = getParamBool('polygon_text');
-		if ( ( ($bAsGeoJSON?1:0)
-				 + ($bAsKML?1:0)
-				 + ($bAsSVG?1:0)
-				 + ($bAsText?1:0)
-				 + ($bAsPoints?1:0)
-				 ) > CONST_PolygonOutput_MaximumTypes)
+		if (CONST_PolygonOutput_MaximumTypes)
 		{
-			if (CONST_PolygonOutput_MaximumTypes)
-			{
-				userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-			}
-			else
-			{
-				userError("Polygon output is disabled");
-			}
-			exit;
+			userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
 		}
-		$oGeocode->setIncludePolygonAsPoints($bAsPoints);
-		$oGeocode->setIncludePolygonAsText($bAsText);
-		$oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
-		$oGeocode->setIncludePolygonAsKML($bAsKML);
-		$oGeocode->setIncludePolygonAsSVG($bAsSVG);
-	}
-
-	// Polygon simplification threshold (optional)
-	$oGeocode->setPolygonSimplificationThreshold(getParamFloat('polygon_threshold', 0.0));
-
-	$oGeocode->loadParamArray($_GET);
-
-	if (CONST_Search_BatchMode && isset($_GET['batch']))
-	{
-		$aBatch = json_decode($_GET['batch'], true);
-		$aBatchResults = array();
-		foreach($aBatch as $aBatchParams)
+		else
 		{
-			$oBatchGeocode = clone $oGeocode;
-			$oBatchGeocode->loadParamArray($aBatchParams);
-			$oBatchGeocode->setQueryFromParams($aBatchParams);
-			$aSearchResults = $oBatchGeocode->lookup();
-			$aBatchResults[] = $aSearchResults;
+			userError("Polygon output is disabled");
 		}
-		include(CONST_BasePath.'/lib/template/search-batch-json.php');
 		exit;
 	}
+	$oGeocode->setIncludePolygonAsPoints($bAsPoints);
+	$oGeocode->setIncludePolygonAsText($bAsText);
+	$oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
+	$oGeocode->setIncludePolygonAsKML($bAsKML);
+	$oGeocode->setIncludePolygonAsSVG($bAsSVG);
+}
 
-	if (!getParamString('q') && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
+// Polygon simplification threshold (optional)
+$oGeocode->setPolygonSimplificationThreshold(getParamFloat('polygon_threshold', 0.0));
+
+$oGeocode->loadParamArray($_GET);
+
+if (CONST_Search_BatchMode && isset($_GET['batch']))
+{
+	$aBatch = json_decode($_GET['batch'], true);
+	$aBatchResults = array();
+	foreach($aBatch as $aBatchParams)
 	{
-		$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
-
-		// reverse order of '/' separated string
-		$aPhrases = explode('/', $sQuery);
-		$aPhrases = array_reverse($aPhrases);
-		$sQuery = join(', ',$aPhrases);
-		$oGeocode->setQuery($sQuery);
+		$oBatchGeocode = clone $oGeocode;
+		$oBatchGeocode->loadParamArray($aBatchParams);
+		$oBatchGeocode->setQueryFromParams($aBatchParams);
+		$aSearchResults = $oBatchGeocode->lookup();
+		$aBatchResults[] = $aSearchResults;
 	}
-	else
-	{
-		$oGeocode->setQueryFromParams($_GET);
-	}
+	include(CONST_BasePath.'/lib/template/search-batch-json.php');
+	exit;
+}
 
-	$hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
+if (!getParamString('q') && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
+{
+	$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
 
-	$aSearchResults = $oGeocode->lookup();
-	if ($aSearchResults === false) $aSearchResults = array();
+	// reverse order of '/' separated string
+	$aPhrases = explode('/', $sQuery);
+	$aPhrases = array_reverse($aPhrases);
+	$sQuery = join(', ',$aPhrases);
+	$oGeocode->setQuery($sQuery);
+}
+else
+{
+	$oGeocode->setQueryFromParams($_GET);
+}
 
-	if ($sOutputFormat=='html')
-	{
-		$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
-	}
-	logEnd($oDB, $hLog, sizeof($aSearchResults));
+$hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
 
-	$sQuery = $oGeocode->getQueryString();
-	$sViewBox = $oGeocode->getViewBoxString();
-	$bShowPolygons = (isset($_GET['polygon']) && $_GET['polygon']);
-	$aExcludePlaceIDs = $oGeocode->getExcludedPlaceIDs();
+$aSearchResults = $oGeocode->lookup();
+if ($aSearchResults === false) $aSearchResults = array();
 
-	$sMoreURL = CONST_Website_BaseURL.'search.php?format='.urlencode($sOutputFormat).'&exclude_place_ids='.join(',',$aExcludePlaceIDs);
-	if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) $sMoreURL .= '&accept-language='.$_SERVER["HTTP_ACCEPT_LANGUAGE"];
-	if ($bShowPolygons) $sMoreURL .= '&polygon=1';
-	if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';
-	if ($oGeocode->getIncludeExtraTags()) $sMoreURL .= '&extratags=1';
-	if ($oGeocode->getIncludeNameDetails()) $sMoreURL .= '&namedetails=1';
-	if ($sViewBox) $sMoreURL .= '&viewbox='.urlencode($sViewBox);
-	if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float)$_GET['nearlat'].'&nearlon='.(float)$_GET['nearlon'];
-	$sMoreURL .= '&q='.urlencode($sQuery);
+if ($sOutputFormat=='html')
+{
+	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
+}
+logEnd($oDB, $hLog, sizeof($aSearchResults));
 
-	if (CONST_Debug) exit;
+$sQuery = $oGeocode->getQueryString();
+$sViewBox = $oGeocode->getViewBoxString();
+$bShowPolygons = (isset($_GET['polygon']) && $_GET['polygon']);
+$aExcludePlaceIDs = $oGeocode->getExcludedPlaceIDs();
 
-	include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');
+$sMoreURL = CONST_Website_BaseURL.'search.php?format='.urlencode($sOutputFormat).'&exclude_place_ids='.join(',',$aExcludePlaceIDs);
+if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) $sMoreURL .= '&accept-language='.$_SERVER["HTTP_ACCEPT_LANGUAGE"];
+if ($bShowPolygons) $sMoreURL .= '&polygon=1';
+if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';
+if ($oGeocode->getIncludeExtraTags()) $sMoreURL .= '&extratags=1';
+if ($oGeocode->getIncludeNameDetails()) $sMoreURL .= '&namedetails=1';
+if ($sViewBox) $sMoreURL .= '&viewbox='.urlencode($sViewBox);
+if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float)$_GET['nearlat'].'&nearlon='.(float)$_GET['nearlon'];
+$sMoreURL .= '&q='.urlencode($sQuery);
+
+if (CONST_Debug) exit;
+
+include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');

--- a/website/search.php
+++ b/website/search.php
@@ -2,11 +2,11 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Search');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
-require_once(CONST_BasePath.'/lib/log.php');
-require_once(CONST_BasePath.'/lib/Geocode.php');
-require_once(CONST_BasePath.'/lib/output.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+require_once CONST_BasePath.'/lib/log.php';
+require_once CONST_BasePath.'/lib/Geocode.php';
+require_once CONST_BasePath.'/lib/output.php';
 
 ini_set('memory_limit', '200M');
 
@@ -18,72 +18,73 @@ $aLangPrefOrder = getPreferredLanguages();
 $oGeocode->setLanguagePreference($aLangPrefOrder);
 
 if (CONST_Search_ReversePlanForAll
-	|| isset($aLangPrefOrder['name:de'])
-	|| isset($aLangPrefOrder['name:ru'])
-	|| isset($aLangPrefOrder['name:ja'])
-	|| isset($aLangPrefOrder['name:pl'])) {
+    || isset($aLangPrefOrder['name:de'])
+    || isset($aLangPrefOrder['name:ru'])
+    || isset($aLangPrefOrder['name:ja'])
+    || isset($aLangPrefOrder['name:pl'])
+) {
 	$oGeocode->setReverseInPlan(true);
 }
 
-// Format for output
+// Format for output.
 $sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'html');
 
-// Show / use polygons
+// Show / use polygons.
 if ($sOutputFormat == 'html') {
 	$oGeocode->setIncludePolygonAsText(getParamBool('polygon'));
 	$bAsText = false;
 } else {
-	$bAsPoints = getParamBool('polygon');
+	$bAsPoints  = getParamBool('polygon');
 	$bAsGeoJSON = getParamBool('polygon_geojson');
-	$bAsKML = getParamBool('polygon_kml');
-	$bAsSVG = getParamBool('polygon_svg');
-	$bAsText = getParamBool('polygon_text');
-	if (( ($bAsGeoJSON?1:0)
-			 + ($bAsKML?1:0)
-			 + ($bAsSVG?1:0)
-			 + ($bAsText?1:0)
-			 + ($bAsPoints?1:0)
-			 ) > CONST_PolygonOutput_MaximumTypes) {
+	$bAsKML     = getParamBool('polygon_kml');
+	$bAsSVG     = getParamBool('polygon_svg');
+	$bAsText    = getParamBool('polygon_text');
+
+	$numTypesRequested = (($bAsGeoJSON ? 1 : 0) + ($bAsKML ? 1 : 0) + ($bAsSVG ? 1 : 0) + ($bAsText ? 1 : 0) + ($bAsPoints ? 1 : 0));
+	if ($numTypesRequested > CONST_PolygonOutput_MaximumTypes) {
 		if (CONST_PolygonOutput_MaximumTypes) {
 			userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
 		} else {
 			userError("Polygon output is disabled");
 		}
+
 		exit;
 	}
+
 	$oGeocode->setIncludePolygonAsPoints($bAsPoints);
 	$oGeocode->setIncludePolygonAsText($bAsText);
 	$oGeocode->setIncludePolygonAsGeoJSON($bAsGeoJSON);
 	$oGeocode->setIncludePolygonAsKML($bAsKML);
 	$oGeocode->setIncludePolygonAsSVG($bAsSVG);
-}
+}//end if
 
-// Polygon simplification threshold (optional)
+// Polygon simplification threshold (optional).
 $oGeocode->setPolygonSimplificationThreshold(getParamFloat('polygon_threshold', 0.0));
 
 $oGeocode->loadParamArray($_GET);
 
 if (CONST_Search_BatchMode && isset($_GET['batch'])) {
-	$aBatch = json_decode($_GET['batch'], true);
+	$aBatch        = json_decode($_GET['batch'], true);
 	$aBatchResults = array();
 	foreach ($aBatch as $aBatchParams) {
 		$oBatchGeocode = clone $oGeocode;
 		$oBatchGeocode->loadParamArray($aBatchParams);
 		$oBatchGeocode->setQueryFromParams($aBatchParams);
-		$aSearchResults = $oBatchGeocode->lookup();
+		$aSearchResults  = $oBatchGeocode->lookup();
 		$aBatchResults[] = $aSearchResults;
 	}
-	include(CONST_BasePath.'/lib/template/search-batch-json.php');
+
+	include CONST_BasePath.'/lib/template/search-batch-json.php';
 	exit;
 }
 
 if (!getParamString('q') && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/') {
 	$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
 
-	// reverse order of '/' separated string
+	// Reverse order of '/' separated string.
 	$aPhrases = explode('/', $sQuery);
 	$aPhrases = array_reverse($aPhrases);
-	$sQuery = join(', ', $aPhrases);
+	$sQuery   = join(', ', $aPhrases);
 	$oGeocode->setQuery($sQuery);
 } else {
 	$oGeocode->setQueryFromParams($_GET);
@@ -94,26 +95,27 @@ $hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
 $aSearchResults = $oGeocode->lookup();
 if ($aSearchResults === false) $aSearchResults = array();
 
-if ($sOutputFormat=='html') {
+if ($sOutputFormat == 'html') {
 	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
 }
+
 logEnd($oDB, $hLog, sizeof($aSearchResults));
 
-$sQuery = $oGeocode->getQueryString();
-$sViewBox = $oGeocode->getViewBoxString();
-$bShowPolygons = (isset($_GET['polygon']) && $_GET['polygon']);
+$sQuery           = $oGeocode->getQueryString();
+$sViewBox         = $oGeocode->getViewBoxString();
+$bShowPolygons    = (isset($_GET['polygon']) && $_GET['polygon']);
 $aExcludePlaceIDs = $oGeocode->getExcludedPlaceIDs();
 
 $sMoreURL = CONST_Website_BaseURL.'search.php?format='.urlencode($sOutputFormat).'&exclude_place_ids='.join(',', $aExcludePlaceIDs);
 if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) $sMoreURL .= '&accept-language='.$_SERVER["HTTP_ACCEPT_LANGUAGE"];
 if ($bShowPolygons) $sMoreURL .= '&polygon=1';
 if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';
-if ($oGeocode->getIncludeExtraTags()) $sMoreURL .= '&extratags=1';
-if ($oGeocode->getIncludeNameDetails()) $sMoreURL .= '&namedetails=1';
+if ($oGeocode->getIncludeExtraTags())      $sMoreURL .= '&extratags=1';
+if ($oGeocode->getIncludeNameDetails())    $sMoreURL .= '&namedetails=1';
 if ($sViewBox) $sMoreURL .= '&viewbox='.urlencode($sViewBox);
-if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float)$_GET['nearlat'].'&nearlon='.(float)$_GET['nearlon'];
+if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float) $_GET['nearlat'].'&nearlon='.(float) $_GET['nearlon'];
 $sMoreURL .= '&q='.urlencode($sQuery);
 
 if (CONST_Debug) exit;
 
-include(CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php');
+require CONST_BasePath.'/lib/template/search-'.$sOutputFormat.'.php';

--- a/website/search.php
+++ b/website/search.php
@@ -21,8 +21,7 @@ if (CONST_Search_ReversePlanForAll
 	|| isset($aLangPrefOrder['name:de'])
 	|| isset($aLangPrefOrder['name:ru'])
 	|| isset($aLangPrefOrder['name:ja'])
-	|| isset($aLangPrefOrder['name:pl']))
-{
+	|| isset($aLangPrefOrder['name:pl'])) {
 	$oGeocode->setReverseInPlan(true);
 }
 
@@ -30,31 +29,24 @@ if (CONST_Search_ReversePlanForAll
 $sOutputFormat = getParamSet('format', array('html', 'xml', 'json', 'jsonv2'), 'html');
 
 // Show / use polygons
-if ($sOutputFormat == 'html')
-{
+if ($sOutputFormat == 'html') {
 	$oGeocode->setIncludePolygonAsText(getParamBool('polygon'));
 	$bAsText = false;
-}
-else
-{
+} else {
 	$bAsPoints = getParamBool('polygon');
 	$bAsGeoJSON = getParamBool('polygon_geojson');
 	$bAsKML = getParamBool('polygon_kml');
 	$bAsSVG = getParamBool('polygon_svg');
 	$bAsText = getParamBool('polygon_text');
-	if ( ( ($bAsGeoJSON?1:0)
+	if (( ($bAsGeoJSON?1:0)
 			 + ($bAsKML?1:0)
 			 + ($bAsSVG?1:0)
 			 + ($bAsText?1:0)
 			 + ($bAsPoints?1:0)
-			 ) > CONST_PolygonOutput_MaximumTypes)
-	{
-		if (CONST_PolygonOutput_MaximumTypes)
-		{
+			 ) > CONST_PolygonOutput_MaximumTypes) {
+		if (CONST_PolygonOutput_MaximumTypes) {
 			userError("Select only ".CONST_PolygonOutput_MaximumTypes." polgyon output option");
-		}
-		else
-		{
+		} else {
 			userError("Polygon output is disabled");
 		}
 		exit;
@@ -71,12 +63,10 @@ $oGeocode->setPolygonSimplificationThreshold(getParamFloat('polygon_threshold', 
 
 $oGeocode->loadParamArray($_GET);
 
-if (CONST_Search_BatchMode && isset($_GET['batch']))
-{
+if (CONST_Search_BatchMode && isset($_GET['batch'])) {
 	$aBatch = json_decode($_GET['batch'], true);
 	$aBatchResults = array();
-	foreach($aBatch as $aBatchParams)
-	{
+	foreach ($aBatch as $aBatchParams) {
 		$oBatchGeocode = clone $oGeocode;
 		$oBatchGeocode->loadParamArray($aBatchParams);
 		$oBatchGeocode->setQueryFromParams($aBatchParams);
@@ -87,18 +77,15 @@ if (CONST_Search_BatchMode && isset($_GET['batch']))
 	exit;
 }
 
-if (!getParamString('q') && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/')
-{
+if (!getParamString('q') && isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'][0] == '/') {
 	$sQuery = substr(rawurldecode($_SERVER['PATH_INFO']), 1);
 
 	// reverse order of '/' separated string
 	$aPhrases = explode('/', $sQuery);
 	$aPhrases = array_reverse($aPhrases);
-	$sQuery = join(', ',$aPhrases);
+	$sQuery = join(', ', $aPhrases);
 	$oGeocode->setQuery($sQuery);
-}
-else
-{
+} else {
 	$oGeocode->setQueryFromParams($_GET);
 }
 
@@ -107,8 +94,7 @@ $hLog = logStart($oDB, 'search', $oGeocode->getQueryString(), $aLangPrefOrder);
 $aSearchResults = $oGeocode->lookup();
 if ($aSearchResults === false) $aSearchResults = array();
 
-if ($sOutputFormat=='html')
-{
+if ($sOutputFormat=='html') {
 	$sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
 }
 logEnd($oDB, $hLog, sizeof($aSearchResults));
@@ -118,7 +104,7 @@ $sViewBox = $oGeocode->getViewBoxString();
 $bShowPolygons = (isset($_GET['polygon']) && $_GET['polygon']);
 $aExcludePlaceIDs = $oGeocode->getExcludedPlaceIDs();
 
-$sMoreURL = CONST_Website_BaseURL.'search.php?format='.urlencode($sOutputFormat).'&exclude_place_ids='.join(',',$aExcludePlaceIDs);
+$sMoreURL = CONST_Website_BaseURL.'search.php?format='.urlencode($sOutputFormat).'&exclude_place_ids='.join(',', $aExcludePlaceIDs);
 if (isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) $sMoreURL .= '&accept-language='.$_SERVER["HTTP_ACCEPT_LANGUAGE"];
 if ($bShowPolygons) $sMoreURL .= '&polygon=1';
 if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';

--- a/website/status.php
+++ b/website/status.php
@@ -13,28 +13,25 @@ function statusError($sMsg)
 }
 
 $oDB =& DB::connect(CONST_Database_DSN, false);
-if (!$oDB || PEAR::isError($oDB))
-{
+if (!$oDB || PEAR::isError($oDB)) {
 	statusError("No database");
 }
 
 $sStandardWord = $oDB->getOne("select make_standard_name('a')");
-if (PEAR::isError($sStandardWord))
-{
+if (PEAR::isError($sStandardWord)) {
 	statusError("Module failed");
 }
-if ($sStandardWord != 'a')
-{
+
+if ($sStandardWord != 'a') {
 	statusError("Module call failed");
 }
 
 $iWordID = $oDB->getOne("select word_id,word_token, word, class, type, country_code, operator, search_name_count from word where word_token in (' a')");
-if (PEAR::isError($iWordID))
-{
+if (PEAR::isError($iWordID)) {
 	statusError("Query failed");
 }
-if (!$iWordID)
-{
+
+if (!$iWordID) {
 	statusError("No value");
 }
 

--- a/website/status.php
+++ b/website/status.php
@@ -2,15 +2,19 @@
 
 @define('CONST_ConnectionBucket_PageType', 'Status');
 
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-require_once(CONST_BasePath.'/lib/init-website.php');
+require_once dirname(dirname(__FILE__)).'/settings/settings.php';
+require_once CONST_BasePath.'/lib/init-website.php';
+
 
 function statusError($sMsg)
 {
+
 	header("HTTP/1.0 500 Internal Server Error");
 	echo "ERROR: ".$sMsg;
 	exit;
-}
+
+}//end statusError()
+
 
 $oDB =& DB::connect(CONST_Database_DSN, false);
 if (!$oDB || PEAR::isError($oDB)) {

--- a/website/status.php
+++ b/website/status.php
@@ -1,42 +1,42 @@
 <?php
-	@define('CONST_ConnectionBucket_PageType', 'Status');
 
-	require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-	require_once(CONST_BasePath.'/lib/init-website.php');
+@define('CONST_ConnectionBucket_PageType', 'Status');
 
-	function statusError($sMsg)
-	{
-		header("HTTP/1.0 500 Internal Server Error");
-		echo "ERROR: ".$sMsg;
-		exit;
-	}
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
 
-	$oDB =& DB::connect(CONST_Database_DSN, false);
-	if (!$oDB || PEAR::isError($oDB))
-	{
-		statusError("No database");
-	}
-
-	$sStandardWord = $oDB->getOne("select make_standard_name('a')");
-	if (PEAR::isError($sStandardWord))
-	{
-		statusError("Module failed");
-	}
-	if ($sStandardWord != 'a')
-	{
-		statusError("Module call failed");
-	}
-
-	$iWordID = $oDB->getOne("select word_id,word_token, word, class, type, country_code, operator, search_name_count from word where word_token in (' a')");
-	if (PEAR::isError($iWordID))
-	{
-		statusError("Query failed");
-	}
-	if (!$iWordID)
-	{
-		statusError("No value");
-	}
-
-	echo "OK";
+function statusError($sMsg)
+{
+	header("HTTP/1.0 500 Internal Server Error");
+	echo "ERROR: ".$sMsg;
 	exit;
+}
 
+$oDB =& DB::connect(CONST_Database_DSN, false);
+if (!$oDB || PEAR::isError($oDB))
+{
+	statusError("No database");
+}
+
+$sStandardWord = $oDB->getOne("select make_standard_name('a')");
+if (PEAR::isError($sStandardWord))
+{
+	statusError("Module failed");
+}
+if ($sStandardWord != 'a')
+{
+	statusError("Module call failed");
+}
+
+$iWordID = $oDB->getOne("select word_id,word_token, word, class, type, country_code, operator, search_name_count from word where word_token in (' a')");
+if (PEAR::isError($iWordID))
+{
+	statusError("Query failed");
+}
+if (!$iWordID)
+{
+	statusError("No value");
+}
+
+echo "OK";
+exit;


### PR DESCRIPTION
New `php-link-rules.xml` for [CodeSniffer](http://pear.php.net/package/PHP_CodeSniffer/). Install using `sudo pear install PHP_CodeSniffer`.

A direct code diff is too complex, you'd need to compare revision by revision. The first two only change whitespace.

I started with the `PSR2` ruleset and fixed all errors. The moved to the more strict `PHPCS` ruleset. The `php-link-rules.xml` contains many exceptions because currently they would caused too many warning. In total I fixed about 4000 warnings and errors. (`PSR2` wants `elseif` while `PHPCS` wants `else if` and both don't agree on bracket rules for multiline if).

To run
`phpcs --standard=./php-lint-rules.xml --report-width=120 --tab-width=4 --colors lib/**.php website/**.php`

It still produces about 20 errors:
   * `TODO` statements cause warnings, can we disabled of course
   * Nominatim still uses PHP4 style constructors, worth fixing
   * formatting of Doc style comments on functions. Probably worth adding
   * one function uses snake_case instead of camelCase in its name

In the future it's worth enabling the maximum line limit again and force every class and function to have documentation.