### PR TITLE
specify ubuntu as primary Vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       checkout = "no"
   end
 
-  config.vm.define "ubuntu" do |sub|
+  config.vm.define "ubuntu", primary: true do |sub|
       sub.vm.box = "bento/ubuntu-16.04"
       sub.vm.provision :shell do |s|
         s.path = "vagrant/install-on-ubuntu-16.sh"


### PR DESCRIPTION
By default if you ran `vagrant up && vagrant ssh` it started both Ubuntu and CentOS. That usually failed because both try to map the same ports. So start just one you had to use `vagrant up ubuntu` or `vagrant up centos`.

With this change the Ubuntu VM is started if no VM is specified. See "SPECIFYING A PRIMARY MACHINE" on https://www.vagrantup.com/docs/multi-machine/
