### PR TITLE
grub complains about disk unique identifier having changed

### DIFF
--- a/vagrant/install-on-ubuntu-16.sh
+++ b/vagrant/install-on-ubuntu-16.sh
@@ -3,6 +3,7 @@
 # hacks for broken vagrant box      #DOCS:
 sudo rm -f /var/lib/dpkg/lock       #DOCS:
 sudo update-locale LANG=en_US.UTF-8 #DOCS:
+echo "set grub-pc/install_devices /dev/sda" | sudo debconf-communicate #DOCS:
 #
 # *Note:* these installation instructions are also available in executable
 #         form for use with vagrant under vagrant/install-on-ubuntu-16.sh.

--- a/vagrant/install-on-ubuntu-16.sh
+++ b/vagrant/install-on-ubuntu-16.sh
@@ -3,7 +3,9 @@
 # hacks for broken vagrant box      #DOCS:
 sudo rm -f /var/lib/dpkg/lock       #DOCS:
 sudo update-locale LANG=en_US.UTF-8 #DOCS:
-echo "set grub-pc/install_devices /dev/sda" | sudo debconf-communicate #DOCS:
+export APT_LISTCHANGES_FRONTEND=none #DOCS:
+export DEBIAN_FRONTEND=noninteractive #DOCS:
+
 #
 # *Note:* these installation instructions are also available in executable
 #         form for use with vagrant under vagrant/install-on-ubuntu-16.sh.
@@ -17,7 +19,7 @@ echo "set grub-pc/install_devices /dev/sda" | sudo debconf-communicate #DOCS:
 #
 
     sudo apt-get update -qq
-    sudo apt-get upgrade -y
+    apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy dist-upgrade
 
 # Now you can install all packages needed for Nominatim:
 


### PR DESCRIPTION
Recently I get errors when running `vagrant up ubuntu`. Upgrading VirtualBox (to latest = 5.0.26) and the box (`vagrant box update`) didn't help. Same on two host machines. This change helps though.

The error waits for keyboard input and the terminal goes into a non-responsive state.

```
┌──────────────────────────┤ Configuring grub-pc ├──────────────────────────┐
││
│ The GRUB boot loader was previously installed to a disk that is no│
│ longer present, or whose unique identifier has changed for some reason.   │
│ It is important to make sure that the installed GRUB core image stays in  │
│ sync with GRUB modules and grub.cfg. Please check again to make sure│
│ that GRUB is written to the appropriate boot devices.│
││
│ If you're unsure which drive is designated as boot drive by your BIOS,    │
│ it is often a good idea to install GRUB to all of them.│
││
│ Note: it is possible to install GRUB to partition boot records as well,   │
│ and some appropriate partitions are offered here. However, this forces    │
│ GRUB to use the blocklist mechanism, which makes it less reliable, and    │
│ therefore is not recommended.│
││
│<Ok>│
││
└───────────────────────────────────────────────────────────────────────────┘
```