### PR TITLE
fix indentation and misc errors according to PSR2 coding style guide

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -48,6 +48,7 @@ class Geocode
     protected $sQuery = false;
     protected $aStructuredQuery = false;
 
+
     function Geocode(&$oDB)
     {
         $this->oDB =& $oDB;
@@ -131,18 +132,18 @@ class Geocode
     function setFeatureType($sFeatureType)
     {
         switch ($sFeatureType) {
-        case 'country':
-            $this->setRankRange(4, 4);
-            break;
-        case 'state':
-            $this->setRankRange(8, 8);
-            break;
-        case 'city':
-            $this->setRankRange(14, 16);
-            break;
-        case 'settlement':
-            $this->setRankRange(8, 20);
-            break;
+            case 'country':
+                $this->setRankRange(4, 4);
+                break;
+            case 'state':
+                $this->setRankRange(8, 8);
+                break;
+            case 'city':
+                $this->setRankRange(14, 16);
+                break;
+            case 'settlement':
+                $this->setRankRange(8, 20);
+                break;
         }
     }
 
@@ -397,7 +398,7 @@ class Geocode
         $sSQL .= ",extratags->'place' ";
 
         if (30 >= $this->iMinAddressRank && 30 <= $this->iMaxAddressRank) {
-            //only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines 
+            // only Tiger housenumbers and interpolation lines need to be interpolated, because they are saved as lines
             // with start- and endnumber, the common osm housenumbers are usually saved as points
             $sHousenumbers = "";
             $i = 0;
@@ -408,7 +409,7 @@ class Geocode
                 if ($i<$length) $sHousenumbers .= ", ";
             }
             if (CONST_Use_US_Tiger_Data) {
-                //Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
+                // Tiger search only if a housenumber was searched and if it was found (i.e. aPlaceIDs[placeID] = housenumber != -1) (realized through a join)
                 $sSQL .= " union";
                 $sSQL .= " select 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, 30 as rank_search, 30 as rank_address, min(place_id) as place_id, min(parent_place_id) as parent_place_id, 'us' as country_code";
                 $sSQL .= ", get_address_by_language(place_id, housenumber_for_place, $sLanguagePrefArraySQL) as langaddress ";
@@ -421,7 +422,7 @@ class Geocode
                 $sSQL .= ", (select max(p.importance*(p.rank_address+2)) from place_addressline s, placex p where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance ";
                 $sSQL .= ", null as extra_place ";
                 $sSQL .= " from (select place_id";
-                //interpolate the Tiger housenumbers here
+                // interpolate the Tiger housenumbers here
                 $sSQL .= ", ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) as centroid, parent_place_id, housenumber_for_place";
                 $sSQL .= " from (location_property_tiger ";
                 $sSQL .= " join (values ".$sHousenumbers.") as housenumbers(place_id, housenumber_for_place) using(place_id)) ";
@@ -444,7 +445,7 @@ class Geocode
             $sSQL .= " where s.place_id = min(blub.parent_place_id) and p.place_id = s.address_place_id and s.isaddress and p.importance is not null) as addressimportance,";
             $sSQL .= " null as extra_place ";
             $sSQL .= " from (select place_id, calculated_country_code ";
-            //interpolate the housenumbers here
+            // interpolate the housenumbers here
             $sSQL .= ", CASE WHEN startnumber != endnumber THEN ST_LineInterpolatePoint(linegeo, (housenumber_for_place-startnumber::float)/(endnumber-startnumber)::float) ";
             $sSQL .= " ELSE ST_LineInterpolatePoint(linegeo, 0.5) END as centroid";
             $sSQL .= ", parent_place_id, housenumber_for_place ";
@@ -476,7 +477,8 @@ class Geocode
 
         $sSQL .= " order by importance desc";
         if (CONST_Debug) {
-            echo "<hr>"; var_dump($sSQL);
+            echo "<hr>";
+            var_dump($sSQL);
         }
         $aSearchResults = chksql(
             $this->oDB->getAll($sSQL),
@@ -738,6 +740,8 @@ class Geocode
             name: full name (currently the same as langaddress)
             foundorder: secondary ordering for places with same importance
     */
+
+
     function lookup()
     {
         if (!$this->sQuery && !$this->aStructuredQuery) return false;
@@ -939,7 +943,7 @@ class Geocode
                         }
                     } elseif (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
                         // US ZIP+4 codes - if there is no token,
-                        //  merge in the 5-digit ZIP code
+                        // merge in the 5-digit ZIP code
                         if (isset($aValidTokens[$aData[1]])) {
                             foreach ($aValidTokens[$aData[1]] as $aToken) {
                                 if (!$aToken['class']) {
@@ -1413,7 +1417,8 @@ class Geocode
                     }
 
                     if (CONST_Debug) {
-                        echo "<br><b>Place IDs:</b> "; var_Dump($aPlaceIDs);
+                        echo "<br><b>Place IDs:</b> ";
+                        var_Dump($aPlaceIDs);
                     }
 
                     foreach ($aPlaceIDs as $iPlaceID) {
@@ -1495,7 +1500,8 @@ class Geocode
         }
 
         if (CONST_Debug) {
-            echo '<i>Recheck words:<\i>'; var_dump($aRecheckWords);
+            echo '<i>Recheck words:<\i>';
+            var_dump($aRecheckWords);
         }
 
         $oPlaceLookup = new PlaceLookup($this->oDB);
@@ -1577,15 +1583,15 @@ class Geocode
 
             $aResult['name'] = $aResult['langaddress'];
             // secondary ordering (for results with same importance (the smaller the better):
-            //   - approximate importance of address parts
+            // - approximate importance of address parts
             $aResult['foundorder'] = -$aResult['addressimportance']/10;
-            //   - number of exact matches from the query
+            // - number of exact matches from the query
             if (isset($this->exactMatchCache[$aResult['place_id']])) {
                 $aResult['foundorder'] -= $this->exactMatchCache[$aResult['place_id']];
             } elseif (isset($this->exactMatchCache[$aResult['parent_place_id']])) {
                 $aResult['foundorder'] -= $this->exactMatchCache[$aResult['parent_place_id']];
             }
-            //  - importance of the class/type
+            // - importance of the class/type
             if (isset($aClassType[$aResult['class'].':'.$aResult['type']]['importance'])
                 && $aClassType[$aResult['class'].':'.$aResult['type']]['importance']
             ) {
@@ -1625,9 +1631,5 @@ class Geocode
         }
 
         return $aSearchResults;
-
     } // end lookup()
-
-
 } // end class
-

--- a/lib/ParameterParser.php
+++ b/lib/ParameterParser.php
@@ -4,9 +4,10 @@ class ParameterParser
 {
     private $aParams;
 
-    function __construct($aParams = NULL)
+
+    function __construct($aParams = null)
     {
-        $this->aParams = ($aParams === NULL) ? $_GET : $aParams;
+        $this->aParams = ($aParams === null) ? $_GET : $aParams;
     }
 
     function getBool($sName, $bDefault = false)
@@ -77,9 +78,9 @@ class ParameterParser
         return $aDefault;
     }
 
-    function getPreferredLanguages($sFallback = NULL)
+    function getPreferredLanguages($sFallback = null)
     {
-        if ($sFallback === NULL && isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) {
+        if ($sFallback === null && isset($_SERVER["HTTP_ACCEPT_LANGUAGE"])) {
             $sFallback = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
         }
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -237,15 +237,18 @@ class PlaceLookup
 
 
 
-    // returns an array which will contain the keys
-    //   aBoundingBox
-    // and may also contain one or more of the keys
-    //   asgeojson
-    //   askml
-    //   assvg
-    //   astext
-    //   lat
-    //   lon
+    /* returns an array which will contain the keys
+     *   aBoundingBox
+     * and may also contain one or more of the keys
+     *   asgeojson
+     *   askml
+     *   assvg
+     *   astext
+     *   lat
+     *   lon
+     */
+
+
     function getOutlines($iPlaceID, $fLon = null, $fLat = null, $fRadius = null)
     {
 
@@ -301,7 +304,7 @@ class PlaceLookup
                                                    (string)$aPointPolygon['maxlon']
                                                   );
             }
-        } // CONST_Search_AreaPolygons
+        }
 
         // as a fallback we generate a bounding box without knowing the size of the geometry
         if ((!isset($aOutlineResult['aBoundingBox'])) && isset($fLon)) {

--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -5,10 +5,12 @@ class ReverseGeocode
     protected $oDB;
     protected $iMaxRank = 28;
 
+
     function ReverseGeocode(&$oDB)
     {
         $this->oDB =& $oDB;
     }
+
 
     function setZoom($iZoom)
     {
@@ -38,8 +40,13 @@ class ReverseGeocode
         $this->iMaxRank = (isset($iZoom) && isset($aZoomRank[$iZoom]))?$aZoomRank[$iZoom]:28;
     }
 
-    // returns { place_id =>, type => '(osm|tiger)' }
-    // fails if no place was found
+
+    /* lookup()
+     * returns { place_id =>, type => '(osm|tiger)' }
+     * fails if no place was found
+     */
+
+
     function lookup($fLat, $fLon, $bDoInterpolation = true)
     {
         $sPointSQL = 'ST_SetSRID(ST_Point('.$fLon.','.$fLat.'),4326)';
@@ -111,7 +118,7 @@ class ReverseGeocode
             if ($aPlaceLine) {
                 if (CONST_Debug) var_dump('found housenumber in interpolation lines table', $aPlaceLine);
                 if ($aPlace['rank_search'] == 30) {
-                    // if a house was already found in placex, we have to find out, 
+                    // if a house was already found in placex, we have to find out,
                     // if the placex house or the interpolated house are closer to the searched point
                     // distance between point and placex house
                     $sSQL = 'SELECT ST_distance('.$sPointSQL.', house.geometry) as distance FROM placex as house WHERE house.place_id='.$iPlaceID;
@@ -204,5 +211,4 @@ class ReverseGeocode
                 'fraction' => ($bPlaceIsTiger || $bPlaceIsLine) ? $fFraction : -1
                );
     }
-    
 }

--- a/lib/cmd.php
+++ b/lib/cmd.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function getCmdOpt($aArg, $aSpec, &$aResult, $bExitOnError = false, $bExitOnUnknown = false)
 {
     $aQuick = array();

--- a/lib/db.php
+++ b/lib/db.php
@@ -2,6 +2,7 @@
 
 require_once('DB.php');
 
+
 function &getDB($bNew = false, $bPersistent = false)
 {
     // Get the database object

--- a/lib/init-website.php
+++ b/lib/init-website.php
@@ -9,6 +9,7 @@ require_once('ParameterParser.php');
  *
  */
 
+
 function chksql($oSql, $sMsg = "Database request failed")
 {
     if (!PEAR::isError($oSql)) return $oSql;
@@ -95,4 +96,3 @@ if (CONST_NoAccessControl) {
 if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') exit;
 
 if (CONST_Debug) header('Content-type: text/html; charset=utf-8');
-

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function fail($sError, $sUserError = false)
 {
     if (!$sUserError) $sUserError = $sError;
@@ -97,10 +98,6 @@ function getTokensFromSets($aSets)
     return $aTokens;
 }
 
-
-/*
-   GB Postcode functions
- */
 
 function gbPostcodeCalculate($sPostcode, $sPostcodeSector, $sPostcodeEnd, &$oDB)
 {
@@ -599,72 +596,78 @@ function addQuotes($s)
     return "'".$s."'";
 }
 
-// returns boolean
 function validLatLon($fLat, $fLon)
 {
     return ($fLat <= 90.1 && $fLat >= -90.1 && $fLon <= 180.1 && $fLon >= -180.1);
 }
 
-// Do we have anything that looks like a lat/lon pair?
-// returns array(lat,lon,query_with_lat_lon_removed)
-// or null
 function looksLikeLatLonPair($sQuery)
 {
+    // Do we have anything that looks like a lat/lon pair?
+    // returns array(lat,lon,query_with_lat_lon_removed)
+    // or null
     $sFound    = null;
     $fQueryLat = null;
     $fQueryLon = null;
 
     if (preg_match('/\\b([NS])[ ]+([0-9]+[0-9.]*)[° ]+([0-9.]+)?[′\']*[, ]+([EW])[ ]+([0-9]+)[° ]+([0-9]+[0-9.]*)[′\']*?\\b/', $sQuery, $aData)) {
-        //              1         2                   3                  4         5            6
-        // degrees decimal minutes
-        // N 40 26.767, W 79 58.933
-        // N 40°26.767′, W 79°58.933′
+        /*              1         2                   3                  4         5            6
+         * degrees decimal minutes
+         * N 40 26.767, W 79 58.933
+         * N 40°26.767′, W 79°58.933′
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60);
         $fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[5] + $aData[6]/60);
     } elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\']*[ ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+[0-9.]*)?[′\' ]+([EW])\\b/', $sQuery, $aData)) {
-        //                    1             2                      3          4            5                    6
-        // degrees decimal minutes
-        // 40 26.767 N, 79 58.933 W
-        // 40° 26.767′ N 79° 58.933′ W
+        /*                    1             2                      3          4            5                    6
+         * degrees decimal minutes
+         * 40 26.767 N, 79 58.933 W
+         * 40° 26.767′ N 79° 58.933′ W
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[3]=='N'?1:-1) * ($aData[1] + $aData[2]/60);
         $fQueryLon = ($aData[6]=='E'?1:-1) * ($aData[4] + $aData[5]/60);
     } elseif (preg_match('/\\b([NS])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*[, ]+([EW])[ ]([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″"]*\\b/', $sQuery, $aData)) {
-        //                    1        2            3            4                5        6            7            8
-        // degrees decimal seconds
-        // N 40 26 46 W 79 58 56
-        // N 40° 26′ 46″, W 79° 58′ 56″
+        /*                    1        2            3            4                5        6            7            8
+         * degrees decimal seconds
+         * N 40 26 46 W 79 58 56
+         * N 40° 26′ 46″, W 79° 58′ 56″
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2] + $aData[3]/60 + $aData[4]/3600);
         $fQueryLon = ($aData[5]=='E'?1:-1) * ($aData[6] + $aData[7]/60 + $aData[8]/3600);
     } elseif (preg_match('/\\b([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([NS])[, ]+([0-9]+)[° ]+([0-9]+)[′\' ]+([0-9]+)[″" ]+([EW])\\b/', $sQuery, $aData)) {
-        //                    1            2            3            4          5            6            7            8
-        // degrees decimal seconds
-        // 40 26 46 N 79 58 56 W
-        // 40° 26′ 46″ N, 79° 58′ 56″ W
+        /*                    1            2            3            4          5            6            7            8
+         * degrees decimal seconds
+         * 40 26 46 N 79 58 56 W
+         * 40° 26′ 46″ N, 79° 58′ 56″ W
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[4]=='N'?1:-1) * ($aData[1] + $aData[2]/60 + $aData[3]/3600);
         $fQueryLon = ($aData[8]=='E'?1:-1) * ($aData[5] + $aData[6]/60 + $aData[7]/3600);
     } elseif (preg_match('/\\b([NS])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*[, ]+([EW])[ ]([0-9]+[0-9]*\\.[0-9]+)[°]*\\b/', $sQuery, $aData)) {
-        //                    1        2                               3        4
-        // degrees decimal
-        // N 40.446° W 79.982°
+        /*                    1        2                               3        4
+         * degrees decimal
+         * N 40.446° W 79.982°
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[1]=='N'?1:-1) * ($aData[2]);
         $fQueryLon = ($aData[3]=='E'?1:-1) * ($aData[4]);
     } elseif (preg_match('/\\b([0-9]+[0-9]*\\.[0-9]+)[° ]+([NS])[, ]+([0-9]+[0-9]*\\.[0-9]+)[° ]+([EW])\\b/', $sQuery, $aData)) {
-        //                    1                           2          3                           4
-        // degrees decimal
-        // 40.446° N 79.982° W
+        /*                    1                           2          3                           4
+         * degrees decimal
+         * 40.446° N 79.982° W
+         */
         $sFound    = $aData[0];
         $fQueryLat = ($aData[2]=='N'?1:-1) * ($aData[1]);
         $fQueryLon = ($aData[4]=='E'?1:-1) * ($aData[3]);
     } elseif (preg_match('/(\\[|^|\\b)(-?[0-9]+[0-9]*\\.[0-9]+)[, ]+(-?[0-9]+[0-9]*\\.[0-9]+)(\\]|$|\\b)/', $sQuery, $aData)) {
-        //                 1          2                             3                        4
-        // degrees decimal
-        // 12.34, 56.78
-        // [12.456,-78.90]
+        /*                 1          2                             3                        4
+         * degrees decimal
+         * 12.34, 56.78
+         * [12.456,-78.90]
+         */
         $sFound    = $aData[0];
         $fQueryLat = $aData[2];
         $fQueryLon = $aData[3];
@@ -679,7 +682,7 @@ function looksLikeLatLonPair($sQuery)
 
 function geometryText2Points($geometry_as_text, $fRadius)
 {
-    $aPolyPoints = NULL;
+    $aPolyPoints = null;
     if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
         //
         preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);

--- a/lib/log.php
+++ b/lib/log.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function logStart(&$oDB, $sType = '', $sQuery = '', $aLanguageList = array())
 {
     $fStartTime = microtime(true);
@@ -70,5 +71,4 @@ function logEnd(&$oDB, $hLog, $iNumResults)
         );
         file_put_contents(CONST_Log_File, $aOutdata, FILE_APPEND | LOCK_EX);
     }
-
 }

--- a/lib/output.php
+++ b/lib/output.php
@@ -1,5 +1,6 @@
 <?php
 
+
 function formatOSMType($sType, $bIncludeExternal = true)
 {
     if ($sType == 'N') return 'node';
@@ -38,4 +39,3 @@ function detailsLink($aFeature, $sTitle = false)
 
     return '<a href="details.php?place_id='.$aFeature['place_id'].'">'.($sTitle?$sTitle:$aFeature['place_id']).'</a>';
 }
-

--- a/php-lint-rules.xml
+++ b/php-lint-rules.xml
@@ -20,6 +20,15 @@
   </rule>
 
 
+  <!-- "A file should declare new symbols (classes, functions, constants, etc.) and cause no
+    other side effects, or it should execute logic with side effects, but should not do both."
+    ... we have too many script and includes to be able to enforce that.
+     -->
+  <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+    <severity>0</severity>
+  </rule>
+
+
 
   <!-- **************************************************************
        DOCUMENTATION
@@ -42,12 +51,22 @@
        COMMENTS
        ************************************************************** -->
 
+  <!-- any comments in the lines before function() are better than forcing
+       a PHPdoc style right now -->
+  <rule ref="PEAR.Commenting.FunctionComment.WrongStyle">
+    <severity>0</severity>
+  </rule>
+
   <!-- We allow comments after statements -->
   <rule ref="Squiz.Commenting.PostStatementComment.Found">
     <severity>0</severity>
   </rule>
   <!-- ... even without space e.g. //some words -->
   <rule ref="Squiz.Commenting.InlineComment.NoSpaceBefore">
+    <severity>0</severity>
+  </rule>
+  <!-- blank lines after inline comments are fine -->
+  <rule ref="Squiz.Commenting.InlineComment.SpacingAfter">
     <severity>0</severity>
   </rule>
 
@@ -57,6 +76,10 @@
   </rule>
   <!-- Comments don't have to end with one of .!? -->
   <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+    <severity>0</severity>
+  </rule>
+  <!-- Empty comments are fine -->
+  <rule ref="Squiz.Commenting.InlineComment.Empty">
     <severity>0</severity>
   </rule>
 
@@ -84,6 +107,9 @@
 
   <!-- Aligned looks nicer, but causes too many warnings currently -->
   <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSame">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSameWarning">
     <severity>0</severity>
   </rule>
 
@@ -147,25 +173,6 @@
     <severity>0</severity>
   </rule>
 
-  <!-- We allow
-              if (a)
-              {
-  -->
-  <rule ref="PEAR.ControlStructures.MultiLineCondition.NewlineBeforeOpenBrace">
-    <severity>0</severity>
-  </rule>
-  <!-- ... same -->
-  <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.NoLineAfterClose">
-    <severity>0</severity>
-  </rule>
-  <!-- ... same for foreach/while etc -->
-  <rule ref="PEAR.ControlStructures.ControlSignature">
-    <severity>0</severity>
-  </rule>
-  <!-- ... same -->
-  <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace.SpacingBeforeClose">
-    <severity>0</severity>
-  </rule>
 
 
 </ruleset>

--- a/utils/blocks.php
+++ b/utils/blocks.php
@@ -35,9 +35,9 @@ if ($aResult['list']) {
         printf(
             " %-40s | %12s | %7s | %13s | %31s | %8s\n",
             $sKey,
-            $aDetails['totalBlocks'], 
+            $aDetails['totalBlocks'],
             (int)$aDetails['currentBucketSize'],
-            $aDetails['currentlyBlocked']?'Y':'N', 
+            $aDetails['currentlyBlocked']?'Y':'N',
             date("r", $aDetails['lastBlockTimestamp']),
             $aDetails['isSleeping']?'Y':'N'
         );

--- a/utils/importWikipedia.php
+++ b/utils/importWikipedia.php
@@ -90,11 +90,13 @@ EOD;
     $oDB->query($sSQL);
 }
 
+
 function degreesAndMinutesToDecimal($iDegrees, $iMinutes = 0, $fSeconds = 0, $sNSEW = 'N')
 {
     $sNSEW = strtoupper($sNSEW);
     return ($sNSEW == 'S' || $sNSEW == 'W'?-1:1) * ((float)$iDegrees + (float)$iMinutes/60 + (float)$fSeconds/3600);
 }
+
 
 function _parseWikipediaContent($sPageText)
 {
@@ -113,83 +115,83 @@ function _parseWikipediaContent($sPageText)
     $aState = array('body');
     foreach ($aPageText as $i => $sPart) {
         switch ($sPart) {
-        case '{{':
-            array_unshift($aTemplateStack, array('', array()));
-            array_unshift($aState, 'template');
-            break;
-        case '}}':
-            if ($aState[0] == 'template' || $aState[0] == 'templateparam') {
-                $aTemplate = array_shift($aTemplateStack);
-                array_shift($aState);
+            case '{{':
+                array_unshift($aTemplateStack, array('', array()));
+                array_unshift($aState, 'template');
+                break;
+            case '}}':
+                if ($aState[0] == 'template' || $aState[0] == 'templateparam') {
+                    $aTemplate = array_shift($aTemplateStack);
+                    array_shift($aState);
 
-                $aTemplates[] = $aTemplate;
-            }
-            break;
-        case '[[':
-            $sLinkPage = '';
-            $sLinkSyn = '';
-            array_unshift($aState, 'link');
-            break;
-        case ']]':
-            if ($aState[0] == 'link' || $aState[0] == 'linksynonim') {
-                if (!$sLinkSyn) $sLinkSyn = $sLinkPage;
-                if (substr($sLinkPage, 0, 6) == 'Image:') $sLinkSyn = substr($sLinkPage, 6);
-
-                $aLinks[] = array($sLinkPage, $sLinkSyn);
-
-                array_shift($aState);
-                switch ($aState[0]) {
-                case 'template':
-                    $aTemplateStack[0][0] .= trim($sPart);
-                    break;
-                case 'templateparam':
-                    $aTemplateStack[0][1][0] .= $sLinkSyn;
-                    break;
-                case 'link':
-                    $sLinkPage .= trim($sPart);
-                    break;
-                case 'linksynonim':
-                    $sLinkSyn .= $sPart;
-                    break;
-                case 'body':
-                    $sPageBody .= $sLinkSyn;
-                    break;
-                default:
-                    var_dump($aState, $sPageName, $aTemplateStack, $sPart, $aPageText);
-                    fail('unknown state');
+                    $aTemplates[] = $aTemplate;
                 }
-            }
-            break;
-        case '|':
-            if ($aState[0] == 'template' || $aState[0] == 'templateparam') {
-                // Create a new template paramater
-                $aState[0] = 'templateparam';
-                array_unshift($aTemplateStack[0][1], '');
-            }
-            if ($aState[0] == 'link') $aState[0] = 'linksynonim';
-            break;
-        default:
-            switch ($aState[0]) {
-            case 'template':
-                $aTemplateStack[0][0] .= trim($sPart);
                 break;
-            case 'templateparam':
-                $aTemplateStack[0][1][0] .= $sPart;
+            case '[[':
+                $sLinkPage = '';
+                $sLinkSyn = '';
+                array_unshift($aState, 'link');
                 break;
-            case 'link':
-                $sLinkPage .= trim($sPart);
+            case ']]':
+                if ($aState[0] == 'link' || $aState[0] == 'linksynonim') {
+                    if (!$sLinkSyn) $sLinkSyn = $sLinkPage;
+                    if (substr($sLinkPage, 0, 6) == 'Image:') $sLinkSyn = substr($sLinkPage, 6);
+
+                    $aLinks[] = array($sLinkPage, $sLinkSyn);
+
+                    array_shift($aState);
+                    switch ($aState[0]) {
+                        case 'template':
+                            $aTemplateStack[0][0] .= trim($sPart);
+                            break;
+                        case 'templateparam':
+                            $aTemplateStack[0][1][0] .= $sLinkSyn;
+                            break;
+                        case 'link':
+                            $sLinkPage .= trim($sPart);
+                            break;
+                        case 'linksynonim':
+                            $sLinkSyn .= $sPart;
+                            break;
+                        case 'body':
+                            $sPageBody .= $sLinkSyn;
+                            break;
+                        default:
+                            var_dump($aState, $sPageName, $aTemplateStack, $sPart, $aPageText);
+                            fail('unknown state');
+                    }
+                }
                 break;
-            case 'linksynonim':
-                $sLinkSyn .= $sPart;
-                break;
-            case 'body':
-                $sPageBody .= $sPart;
+            case '|':
+                if ($aState[0] == 'template' || $aState[0] == 'templateparam') {
+                    // Create a new template paramater
+                    $aState[0] = 'templateparam';
+                    array_unshift($aTemplateStack[0][1], '');
+                }
+                if ($aState[0] == 'link') $aState[0] = 'linksynonim';
                 break;
             default:
-                var_dump($aState, $aPageText);
-                fail('unknown state');
-            }
-            break;
+                switch ($aState[0]) {
+                    case 'template':
+                        $aTemplateStack[0][0] .= trim($sPart);
+                        break;
+                    case 'templateparam':
+                        $aTemplateStack[0][1][0] .= $sPart;
+                        break;
+                    case 'link':
+                        $sLinkPage .= trim($sPart);
+                        break;
+                    case 'linksynonim':
+                        $sLinkSyn .= $sPart;
+                        break;
+                    case 'body':
+                        $sPageBody .= $sPart;
+                        break;
+                    default:
+                        var_dump($aState, $aPageText);
+                        fail('unknown state');
+                }
+                break;
         }
     }
     return $aTemplates;
@@ -201,7 +203,7 @@ function _templatesToProperties($aTemplates)
     foreach ($aTemplates as $iTemplate => $aTemplate) {
         $aParams = array();
         foreach (array_reverse($aTemplate[1]) as $iParam => $sParam) {
-            if (($iPos = strpos($sParam, '=')) === FALSE) {
+            if (($iPos = strpos($sParam, '=')) === false) {
                 $aParams[] = trim($sParam);
             } else {
                 $aParams[trim(substr($sParam, 0, $iPos))] = trim(substr($sParam, $iPos+1));
@@ -224,7 +226,7 @@ function _templatesToProperties($aTemplates)
         if (!isset($aPageProperties['sWebsite']) && isset($aParams['website']) && $aParams['website']) {
             if (preg_match('#^\\[?([^ \\]]+)[^\\]]*\\]?$#', $aParams['website'], $aMatch)) {
                 $aPageProperties['sWebsite'] = $aMatch[1];
-                if (strpos($aPageProperties['sWebsite'], ':/'.'/') === FALSE) {
+                if (strpos($aPageProperties['sWebsite'], ':/'.'/') === false) {
                     $aPageProperties['sWebsite'] = 'http:/'.'/'.$aPageProperties['sWebsite'];
                 }
             }
@@ -306,7 +308,7 @@ function _templatesToProperties($aTemplates)
 if (isset($aCMDResult['parse-wikipedia'])) {
     $oDB =& getDB();
     $aArticleNames = $oDB->getCol('select page_title from content where page_namespace = 0 and page_id %10 = '.$aCMDResult['parse-wikipedia'].' and (page_content ilike \'%{{Coord%\' or (page_content ilike \'%lat%\' and page_content ilike \'%lon%\'))');
-//      $aArticleNames = $oDB->getCol($sSQL = 'select page_title from content where page_namespace = 0 and (page_content ilike \'%{{Coord%\' or (page_content ilike \'%lat%\' and page_content ilike \'%lon%\')) and page_title in (\'Virginia\')');
+    // $aArticleNames = $oDB->getCol($sSQL = 'select page_title from content where page_namespace = 0 and (page_content ilike \'%{{Coord%\' or (page_content ilike \'%lat%\' and page_content ilike \'%lon%\')) and page_title in (\'Virginia\')');
     foreach ($aArticleNames as $sArticleName) {
         $sPageText = $oDB->getOne('select page_content from content where page_namespace = 0 and page_title = \''.pg_escape_string($sArticleName).'\'');
         $aP = _templatesToProperties(_parseWikipediaContent($sPageText));
@@ -342,15 +344,17 @@ if (isset($aCMDResult['parse-wikipedia'])) {
     }
 }
 
+
 function nominatimXMLStart($hParser, $sName, $aAttr)
 {
-        global $aNominatRecords;
-        switch ($sName) {
+    global $aNominatRecords;
+    switch ($sName) {
         case 'PLACE':
-                $aNominatRecords[] = $aAttr;
-                break;
-        }
+            $aNominatRecords[] = $aAttr;
+            break;
+    }
 }
+
 
 function nominatimXMLEnd($hParser, $sName)
 {
@@ -373,102 +377,104 @@ if (isset($aCMDResult['link'])) {
         $fMaxDist = 0.0000001;
         $bUnknown = false;
         switch (strtolower($aRecord['infobox_type'])) {
-        case 'former country':
-            continue 2;
-        case 'sea':
-            $fMaxDist = 60; // effectively turn it off
-            $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
-            break;
-        case 'country':
-        case 'island':
-        case 'islands':
-        case 'continent':
-            $fMaxDist = 60; // effectively turn it off
-            $sURL .= "&featuretype=country";
-            $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
-            break;
-        case 'prefecture japan':
-            $aRecord['name'] = trim(str_replace(' Prefecture', ' ', $aRecord['name']));
-        case 'state':
-        case '#us state':
-        case 'county':
-        case 'u.s. state':
-        case 'u.s. state symbols':
-        case 'german state':
-        case 'province or territory of canada';
-        case 'indian jurisdiction';
-        case 'province';
-        case 'french region':
-        case 'region of italy':
-        case 'kommune':
-        case '#australia state or territory':
-        case 'russian federal subject':
-            $fMaxDist = 4;
-            $sURL .= "&featuretype=state";
-            $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
-            break;
-        case 'protected area':
-            $fMaxDist = 1;
-            $sURL .= "&nearlat=".$aRecord['lat'];
-            $sURL .= "&nearlon=".$aRecord['lon'];
-            $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
-            break;
-        case 'settlement':
-            $bUnknown = true;
-        case 'french commune':
-        case 'italian comune':
-        case 'uk place':
-        case 'italian comune':
-        case 'australian place':
-        case 'german place':
-        case '#geobox':
-        case 'u.s. county':
-        case 'municipality':
-        case 'city japan':
-        case 'russian inhabited locality':
-        case 'finnish municipality/land area':
-        case 'england county':
-        case 'israel municipality':
-        case 'russian city':
-        case 'city':
-            $fMaxDist = 0.2;
-            $sURL .= "&featuretype=settlement";
-            $sURL .= "&viewbox=".($aRecord['lon']-0.5).",".($aRecord['lat']+0.5).",".($aRecord['lon']+0.5).",".($aRecord['lat']-0.5);
-            break;
-        case 'mountain':
-        case 'mountain pass':
-        case 'river':
-        case 'lake':
-        case 'airport':
-            $fMaxDist = 0.2;
-            $sURL .= "&viewbox=".($aRecord['lon']-0.5).",".($aRecord['lat']+0.5).",".($aRecord['lon']+0.5).",".($aRecord['lat']-0.5);
-
-        case 'ship begin':
-            $fMaxDist = 0.1;
-            $aTypes = array('wreck');
-            $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
-            $sURL .= "&nearlat=".$aRecord['lat'];
-            $sURL .= "&nearlon=".$aRecord['lon'];
-            break;
-        case 'road':
-        case 'university':
-        case 'company':
-        case 'department':
-            $fMaxDist = 0.005;
-            $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
-            $sURL .= "&bounded=1";
-            $sURL .= "&nearlat=".$aRecord['lat'];
-            $sURL .= "&nearlon=".$aRecord['lon'];
-            break;
-        default:
-            $bUnknown = true;
-            $fMaxDist = 0.005;
-            $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
-//              $sURL .= "&bounded=1";
-            $sURL .= "&nearlat=".$aRecord['lat'];
-            $sURL .= "&nearlon=".$aRecord['lon'];
-            echo "-- Unknown: ".$aRecord['infobox_type']."\n";
-            break;
+            case 'former country':
+                continue 2;
+            case 'sea':
+                $fMaxDist = 60; // effectively turn it off
+                $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
+                break;
+            case 'country':
+            case 'island':
+            case 'islands':
+            case 'continent':
+                $fMaxDist = 60; // effectively turn it off
+                $sURL .= "&featuretype=country";
+                $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
+                break;
+            case 'prefecture japan':
+                $aRecord['name'] = trim(str_replace(' Prefecture', ' ', $aRecord['name']));
+                break;
+            case 'state':
+            case '#us state':
+            case 'county':
+            case 'u.s. state':
+            case 'u.s. state symbols':
+            case 'german state':
+            case 'province or territory of canada':
+            case 'indian jurisdiction':
+            case 'province':
+            case 'french region':
+            case 'region of italy':
+            case 'kommune':
+            case '#australia state or territory':
+            case 'russian federal subject':
+                $fMaxDist = 4;
+                $sURL .= "&featuretype=state";
+                $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
+                break;
+            case 'protected area':
+                $fMaxDist = 1;
+                $sURL .= "&nearlat=".$aRecord['lat'];
+                $sURL .= "&nearlon=".$aRecord['lon'];
+                $sURL .= "&viewbox=".($aRecord['lon']-$fMaxDist).",".($aRecord['lat']+$fMaxDist).",".($aRecord['lon']+$fMaxDist).",".($aRecord['lat']-$fMaxDist);
+                break;
+            case 'settlement':
+                $bUnknown = true;
+                break;
+            case 'french commune':
+            case 'italian comune':
+            case 'uk place':
+            case 'italian comune':
+            case 'australian place':
+            case 'german place':
+            case '#geobox':
+            case 'u.s. county':
+            case 'municipality':
+            case 'city japan':
+            case 'russian inhabited locality':
+            case 'finnish municipality/land area':
+            case 'england county':
+            case 'israel municipality':
+            case 'russian city':
+            case 'city':
+                $fMaxDist = 0.2;
+                $sURL .= "&featuretype=settlement";
+                $sURL .= "&viewbox=".($aRecord['lon']-0.5).",".($aRecord['lat']+0.5).",".($aRecord['lon']+0.5).",".($aRecord['lat']-0.5);
+                break;
+            case 'mountain':
+            case 'mountain pass':
+            case 'river':
+            case 'lake':
+            case 'airport':
+                $fMaxDist = 0.2;
+                $sURL .= "&viewbox=".($aRecord['lon']-0.5).",".($aRecord['lat']+0.5).",".($aRecord['lon']+0.5).",".($aRecord['lat']-0.5);
+                break;
+            case 'ship begin':
+                $fMaxDist = 0.1;
+                $aTypes = array('wreck');
+                $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
+                $sURL .= "&nearlat=".$aRecord['lat'];
+                $sURL .= "&nearlon=".$aRecord['lon'];
+                break;
+            case 'road':
+            case 'university':
+            case 'company':
+            case 'department':
+                $fMaxDist = 0.005;
+                $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
+                $sURL .= "&bounded=1";
+                $sURL .= "&nearlat=".$aRecord['lat'];
+                $sURL .= "&nearlon=".$aRecord['lon'];
+                break;
+            default:
+                $bUnknown = true;
+                $fMaxDist = 0.005;
+                $sURL .= "&viewbox=".($aRecord['lon']-0.01).",".($aRecord['lat']+0.01).",".($aRecord['lon']+0.01).",".($aRecord['lat']-0.01);
+                // $sURL .= "&bounded=1";
+                $sURL .= "&nearlat=".$aRecord['lat'];
+                $sURL .= "&nearlon=".$aRecord['lon'];
+                echo "-- Unknown: ".$aRecord['infobox_type']."\n";
+                break;
         }
         $sNameURL = $sURL.'&q='.urlencode($aRecord['name']);
 
@@ -492,7 +498,7 @@ if (isset($aCMDResult['link'])) {
                 $hXMLParser = xml_parser_create();
                 xml_set_element_handler($hXMLParser, 'nominatimXMLStart', 'nominatimXMLEnd');
                 xml_parse($hXMLParser, $sXML, true);
-                xml_parser_free($hXMLParser);#
+                xml_parser_free($hXMLParser);
             }
         }
 
@@ -520,9 +526,15 @@ if (isset($aCMDResult['link'])) {
             } else {
                 $sSQL = "update wikipedia_article set osm_type=";
                 switch ($aNominatRecords[$i]['OSM_TYPE']) {
-                case 'relation': $sSQL .= "'R'"; break;
-                case 'way': $sSQL .= "'W'"; break;
-                case 'node': $sSQL .= "'N'"; break;
+                    case 'relation':
+                        $sSQL .= "'R'";
+                        break;
+                    case 'way':
+                        $sSQL .= "'W'";
+                        break;
+                    case 'node':
+                        $sSQL .= "'N'";
+                        break;
                 }
                 $sSQL .= ", osm_id=".$aNominatRecords[$i]['OSM_ID']." where language = '".pg_escape_string($aRecord['language'])."' and title = '".pg_escape_string($aRecord['title'])."'";
                 $oDB->query($sSQL);

--- a/utils/server_compare.php
+++ b/utils/server_compare.php
@@ -1,8 +1,7 @@
 #!/usr/bin/php -Cq
 <?php
 
-// Apache log file
-$sFile = "sample.log.txt";
+$sFile = "sample.log.txt"; // Apache log file
 $sHost1 = 'http://mq-open-search-lm02.ihost.aol.com:8000/nominatim/v1';
 $sHost2 = 'http://mq-open-search-lm03.ihost.aol.com:8000/nominatim/v1';
 
@@ -50,13 +49,13 @@ while (($sLine = fgets($hFile, 10000)) !== false) {
 
             $sRes = $sURL1.":\n";
             for ($j = 0; $j < strlen($sRes1); $j+=40) {
-                $sRes  .= substr($sRes1, $j, 40)."\n";
+                $sRes .= substr($sRes1, $j, 40)."\n";
             }
             file_put_contents('log/'.$i.'.1', $sRes);
 
             $sRes = $sURL2.":\n";
             for ($j = 0; $j < strlen($sRes2); $j+=40) {
-                $sRes  .= substr($sRes2, $j, 40)."\n";
+                $sRes .= substr($sRes2, $j, 40)."\n";
             }
             file_put_contents('log/'.$i.'.2', $sRes);
         }

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -94,8 +94,9 @@ if ($aCMDResult['create-db'] || $aCMDResult['all']) {
 if ($aCMDResult['setup-db'] || $aCMDResult['all']) {
     echo "Setup DB\n";
     $bDidSomething = true;
-    // TODO: path detection, detection memory, etc.
 
+    // TODO: path detection, detection memory, etc.
+    //
     $oDB =& getDB();
 
     $fPostgresVersion = getPostgresVersion($oDB);
@@ -649,6 +650,7 @@ if (!$bDidSomething) {
     echo "Setup finished.\n";
 }
 
+
 function pgsqlRunScriptFile($sFilename)
 {
     if (!file_exists($sFilename)) fail('unable to find '.$sFilename);
@@ -698,7 +700,6 @@ function pgsqlRunScriptFile($sFilename)
         fclose($ahGzipPipes[1]);
         proc_close($hGzipProcess);
     }
-
 }
 
 function pgsqlRunScript($sScript, $bfatal = true)
@@ -712,7 +713,7 @@ function pgsqlRunScript($sScript, $bfatal = true)
         $sCMD .= ' -v ON_ERROR_STOP=1';
     $aDescriptors = array(
                      0 => array('pipe', 'r'),
-                     1 => STDOUT, 
+                     1 => STDOUT,
                      2 => STDERR
                     );
     $ahPipes = null;
@@ -844,6 +845,4 @@ function create_sql_functions($aCMDResult)
         $sTemplate = str_replace('-- %NOAUXDATA% ', '', $sTemplate);
     }
     pgsqlRunScript($sTemplate);
-
 }
-

--- a/utils/specialphrases.php
+++ b/utils/specialphrases.php
@@ -42,24 +42,24 @@ if ($aCMDResult['wiki-import']) {
                 $sLabel = trim($aMatch[1]);
                 $sClass = trim($aMatch[2]);
                 $sType = trim($aMatch[3]);
-                # hack around a bug where building=yes was imported with
-                # quotes into the wiki
+                // hack around a bug where building=yes was imported with
+                // quotes into the wiki
                 $sType = preg_replace('/&quot;/', '', $sType);
-                # sanity check, in case somebody added garbage in the wiki
+                // sanity check, in case somebody added garbage in the wiki
                 if (preg_match('/^\\w+$/', $sClass) < 1
                     || preg_match('/^\\w+$/', $sType) < 1
                 ) {
                     trigger_error("Bad class/type for language $sLanguage: $sClass=$sType");
                     exit;
                 }
-                # blacklisting: disallow certain class/type combinations
+                // blacklisting: disallow certain class/type combinations
                 if (isset($aTagsBlacklist[$sClass]) && in_array($sType, $aTagsBlacklist[$sClass])) {
-                    # fwrite(STDERR, "Blacklisted: ".$sClass."/".$sType."\n");
+                    // fwrite(STDERR, "Blacklisted: ".$sClass."/".$sType."\n");
                     continue;
                 }
-                # whitelisting: if class is in whitelist, allow only tags in the list
+                // whitelisting: if class is in whitelist, allow only tags in the list
                 if (isset($aTagsWhitelist[$sClass]) && !in_array($sType, $aTagsWhitelist[$sClass])) {
-                    # fwrite(STDERR, "Non-Whitelisted: ".$sClass."/".$sType."\n");
+                    // fwrite(STDERR, "Non-Whitelisted: ".$sClass."/".$sType."\n");
                     continue;
                 }
                 $aPairs[$sClass.'|'.$sType] = array($sClass, $sType);

--- a/utils/update.php
+++ b/utils/update.php
@@ -237,7 +237,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
             // First check if there are new updates published (except for minutelies - there's always new diffs to process)
             if (CONST_Replication_Update_Interval > 60) {
                 unset($aReplicationLag);
-                exec($sCMDCheckReplicationLag, $aReplicationLag, $iErrorLevel); 
+                exec($sCMDCheckReplicationLag, $aReplicationLag, $iErrorLevel);
                 while ($iErrorLevel > 0 || $aReplicationLag[0] < 1) {
                     if ($iErrorLevel) {
                         echo "Error: $iErrorLevel. ";
@@ -247,7 +247,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
                     }
                     sleep(CONST_Replication_Recheck_Interval);
                     unset($aReplicationLag);
-                    exec($sCMDCheckReplicationLag, $aReplicationLag, $iErrorLevel); 
+                    exec($sCMDCheckReplicationLag, $aReplicationLag, $iErrorLevel);
                 }
                 // There are new replication files - use osmosis to download the file
                 echo "\n".date('Y-m-d H:i:s')." Replication Delay is ".$aReplicationLag[0]."\n";
@@ -325,6 +325,7 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
         sleep($iSleep);
     }
 }
+
 
 function getosmosistimestamp($sOsmosisConfigDirectory)
 {

--- a/utils/warm.php
+++ b/utils/warm.php
@@ -67,4 +67,3 @@ if (!$aResult['reverse-only']) {
         else echo ".";
     }
 }
-

--- a/website/deletable.php
+++ b/website/deletable.php
@@ -1,21 +1,23 @@
 <?php
-    require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
-    require_once(CONST_BasePath.'/lib/init-website.php');
-    require_once(CONST_BasePath.'/lib/log.php');
-    require_once(CONST_BasePath.'/lib/output.php');
-    ini_set('memory_limit', '200M');
 
-    $sOutputFormat = 'html';
+require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(CONST_BasePath.'/lib/init-website.php');
+require_once(CONST_BasePath.'/lib/log.php');
+require_once(CONST_BasePath.'/lib/output.php');
+ini_set('memory_limit', '200M');
 
-    $oDB =& getDB();
+$sOutputFormat = 'html';
 
-    $sSQL = "select placex.place_id, calculated_country_code as country_code, name->'name' as name, i.* from placex, import_polygon_delete i where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type and placex.class = i.class and placex.type = i.type";
-    $aPolygons = chksql($oDB->getAll($sSQL), "Could not get list of deleted OSM elements.");
+$oDB =& getDB();
 
-    if (CONST_DEBUG) {
-        var_dump($aPolygons);
-        exit;
-    }
+$sSQL = "select placex.place_id, calculated_country_code as country_code, name->'name' as name, i.* from placex, import_polygon_delete i where placex.osm_id = i.osm_id and placex.osm_type = i.osm_type and placex.class = i.class and placex.type = i.type";
+$aPolygons = chksql($oDB->getAll($sSQL), "Could not get list of deleted OSM elements.");
+
+if (CONST_DEBUG) {
+    var_dump($aPolygons);
+    exit;
+}
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -66,30 +68,32 @@ table td {
 
 <table>
 <?php
-    if (!$aPolygons) exit;
+
+if (!$aPolygons) exit;
+echo "<tr>";
+// var_dump($aPolygons[0]);
+foreach ($aPolygons[0] as $sCol => $sVal) {
+    echo "<th>".$sCol."</th>";
+}
+echo "</tr>";
+foreach ($aPolygons as $aRow) {
     echo "<tr>";
-//var_dump($aPolygons[0]);
-    foreach ($aPolygons[0] as $sCol => $sVal) {
-        echo "<th>".$sCol."</th>";
+    foreach ($aRow as $sCol => $sVal) {
+        switch ($sCol) {
+            case 'osm_id':
+                echo '<td>'.osmLink($aRow).'</td>';
+                break;
+            case 'place_id':
+                echo '<td>'.detailsLink($aRow).'</td>';
+                break;
+            default:
+                echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
+                break;
+        }
     }
     echo "</tr>";
-    foreach ($aPolygons as $aRow) {
-        echo "<tr>";
-        foreach ($aRow as $sCol => $sVal) {
-            switch ($sCol) {
-                case 'osm_id':
-                    echo '<td>'.osmLink($aRow).'</td>';
-                    break;
-                case 'place_id':
-                    echo '<td>'.detailsLink($aRow).'</td>';
-                    break;
-                default:
-                    echo "<td>".($sVal?$sVal:'&nbsp;')."</td>";
-                    break;
-            }
-        }
-        echo "</tr>";
-    }
+}
+
 ?>
 </table>
 

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -35,7 +35,7 @@ if (count($aOsmIds) > CONST_Places_Max_ID_count) {
     userError('Bulk User: Only ' . CONST_Places_Max_ID_count . " ids are allowed in one request.");
 }
 
-foreach ($aOsmIds AS $sItem) {
+foreach ($aOsmIds as $sItem) {
     // Skip empty sItem
     if (empty($sItem)) continue;
     

--- a/website/status.php
+++ b/website/status.php
@@ -4,6 +4,7 @@
 require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
 require_once(CONST_BasePath.'/lib/init-website.php');
 
+
 function statusError($sMsg)
 {
     header("HTTP/1.0 500 Internal Server Error");
@@ -34,4 +35,3 @@ if (!$iWordID) {
 
 echo "OK";
 exit;
-


### PR DESCRIPTION
Fixes most open errors according to the PSR2 standard
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

To be precise
```
* Perl-style comments are not allowed (# instead of //)
* Line indented incorrectly
* Whitespace found at end of line
* Expected 2 blank lines before function
* Expected 1 blank line at end of file
* Expected 1 space before comment text but found 20; use block comment if you need indentation
* Function closing brace must go on the next line following the body
* TRUE, FALSE and NULL must be lowercase
* AS keyword must be lowercase
* Terminating statement must be indented to the same level as the CASE body
```

Tests pass.

I believe it found a couple of bugs this time, "only" in the importWikipedia script though. There were several `case` statements without an explicit `break`. Looking at the logic I added those. Some `case` statements ended in semicolons instead of colons.

In `php-lint-rules.xml` I added ignoring of
```
* Blank comments are not allowed
* Equals sign not aligned with surrounding assignments
* There must be no blank line following an inline comment
* "A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both."
```

We only have three errors remaining, which can be handled in the next PR. 
```
* Method name "Geocode::Geocode" is not in camel caps format
* Each class must be in a namespace of at least one level (a top-level vendor name)
* Visibility must be declared on method
```

After that we can add style checks to the documentation. Maybe to the test suite. Or even a third-party service like https://styleci.io/ (free for open source).
