### PR TITLE
Change on get_addressdata check for matching the condition in placex_…

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -2343,7 +2343,7 @@ BEGIN
 
   IF for_place_id IS NULL THEN
     select parent_place_id, calculated_country_code, housenumber, rank_search, postcode, name, class, type from placex 
-      WHERE place_id = in_place_id and rank_address = 30 
+      WHERE place_id = in_place_id and  rank_search > 27
       INTO for_place_id, searchcountrycode, searchhousenumber, searchrankaddress, searchpostcode, searchhousename, searchclass, searchtype;
   END IF;
 


### PR DESCRIPTION
…update

On placex_update we stop the indexing to the first parent if the rank_search is above 27. We should do the same check in get_adressdata, because place with a rank_address != 30 and a search_rank > 27 will have only 1 parent.
https://github.com/twain47/Nominatim/issues/534