### PR TITLE
check if query is valid unicode string

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -772,6 +772,9 @@ class Geocode
         }
 
         $sQuery = $this->sQuery;
+        if (!preg_match('//u', $sQuery)) {
+            userError("Query string is not UTF-8 encoded.");
+        }
 
         // Conflicts between US state abreviations and various words for 'the' in different languages
         if (isset($this->aLangPrefOrder['name:en'])) {


### PR DESCRIPTION
There is a surprisingly large number of clients that send queries with some non-UTF-8 encoding. Currently this is caught by postgres during the query normalisation. That's bad because it sends an unnecessary query to postgres and causes a lot of warnings to be written in the postgres logs.

This is an attempt to check for a valid UTF-8 string in the PHP code. There are tons of suggestions in the internet on how to check for invalid UTF-8. This one seems the least hacky and most readable of them all. It assumes that in 2016, UTF-8 is common enough that the PCRE library always comes with unicode support. If there is another 'proper' way for the check, I'm open to suggestions.
