### PR TITLE
fix PHP warnings when reverse search was called without parameters or…

### DIFF
--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -13,12 +13,12 @@
     <form class="form-inline" role="search" accept-charset="UTF-8" action="<?php echo CONST_Website_BaseURL; ?>reverse.php">
         <div class="form-group">
             <input name="format" type="hidden" value="html">
-            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars($_GET['lat']); ?>" >
-            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars($_GET['lon']); ?>" >
+            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars(isset($_GET['lat']) ? $_GET['lat'] : ''); ?>" >
+            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars(isset($_GET['lon']) ? $_GET['lon'] : ''); ?>" >
             max zoom
 
-            <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars($_GET['zoom']); ?>">
-                <option value="" <?php echo $_GET['zoom']==''?'selected':'' ?> >--</option>
+            <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars(isset($_GET['zoom']) ? $_GET['zoom'] : ''); ?>">
+                <option value="" <?php echo (isset($_GET['zoom']) ? $_GET['zoom'] : '') == '' ? 'selected' : '' ?> >--</option>
                 <?php
 
                     $aZoomLevels = array(
@@ -65,7 +65,7 @@
 
     <div id="content">
 
-<?php if ($aPlace) { ?>
+<?php if (isset($aPlace)) { ?>
 
         <div id="searchresults" class="sidebar">
         <?php
@@ -123,7 +123,7 @@
         );
         echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 
-        echo 'var nominatim_results = ' . json_encode([$aPlace], JSON_PRETTY_PRINT) . ';'; 
+        echo 'var nominatim_results = ' . json_encode([isset($aPlace)?$aPlace:[]], JSON_PRETTY_PRINT) . ';'; 
     ?>
     </script>
     <?php include(CONST_BasePath.'/lib/template/includes/html-footer.php'); ?>

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -17,8 +17,8 @@
             <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars(isset($_GET['lon']) && $_GET['lon']); ?>" >
             max zoom
 
-            <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars(isset($_GET['zoom']) ? $_GET['zoom'] : ''); ?>">
-                <option value="" <?php echo (isset($_GET['zoom']) ? $_GET['zoom'] : '') == '' ? 'selected' : '' ?> >--</option>
+            <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars(isset($_GET['zoom']) && $_GET['zoom']); ?>">
+                <option value="" <?php echo (isset($_GET['zoom']) && $_GET['zoom']) == '' && 'selected' ?> >--</option>
                 <?php
 
                     $aZoomLevels = array(

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -13,8 +13,8 @@
     <form class="form-inline" role="search" accept-charset="UTF-8" action="<?php echo CONST_Website_BaseURL; ?>reverse.php">
         <div class="form-group">
             <input name="format" type="hidden" value="html">
-            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars(isset($_GET['lat']) ? $_GET['lat'] : ''); ?>" >
-            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars(isset($_GET['lon']) ? $_GET['lon'] : ''); ?>" >
+            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars(isset($_GET['lat']) && $_GET['lat']); ?>" >
+            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars(isset($_GET['lon']) && $_GET['lon']); ?>" >
             max zoom
 
             <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars(isset($_GET['zoom']) ? $_GET['zoom'] : ''); ?>">

--- a/lib/template/address-html.php
+++ b/lib/template/address-html.php
@@ -13,12 +13,12 @@
     <form class="form-inline" role="search" accept-charset="UTF-8" action="<?php echo CONST_Website_BaseURL; ?>reverse.php">
         <div class="form-group">
             <input name="format" type="hidden" value="html">
-            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude"  value="<?php echo htmlspecialchars(isset($_GET['lat']) && $_GET['lat']); ?>" >
-            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo htmlspecialchars(isset($_GET['lon']) && $_GET['lon']); ?>" >
+            <input name="lat" type="text" class="form-control input-sm" placeholder="latitude" value="<?php echo $fLat; ?>" >
+            <input name="lon" type="text" class="form-control input-sm" placeholder="longitude" value="<?php echo $fLon; ?>" >
             max zoom
 
-            <select name="zoom" class="form-control input-sm" value="<?php echo htmlspecialchars(isset($_GET['zoom']) && $_GET['zoom']); ?>">
-                <option value="" <?php echo (isset($_GET['zoom']) && $_GET['zoom']) == '' && 'selected' ?> >--</option>
+            <select name="zoom" class="form-control input-sm" value="<?php echo $iZoom; ?>">
+                <option value="" <?php echo ($iZoom === 0) && 'selected' ?> >--</option>
                 <?php
 
                     $aZoomLevels = array(
@@ -48,7 +48,7 @@
 
                     foreach($aZoomLevels as $iZoomLevel => $sLabel)
                     {
-                        $bSel = isset($_GET['zoom']) && ($_GET['zoom'] == (string)$iZoomLevel);
+                        $bSel = $iZoom === $iZoomLevel;
                         echo '<option value="'.$iZoomLevel.'"'.($bSel?'selected':'').'>'.$iZoomLevel.' '.$sLabel.'</option>'."\n";
                     }
                 ?>
@@ -65,7 +65,7 @@
 
     <div id="content">
 
-<?php if (isset($aPlace)) { ?>
+<?php if (count($aPlace)>0) { ?>
 
         <div id="searchresults" class="sidebar">
         <?php
@@ -115,15 +115,15 @@
     <?php
 
         $aNominatimMapInit = array(
-            'zoom' => isset($_GET['zoom']) ? htmlspecialchars($_GET['zoom']) : CONST_Default_Zoom,
-            'lat'  => isset($_GET['lat']) ? htmlspecialchars($_GET['lat']) : CONST_Default_Lat,
-            'lon'  => isset($_GET['lon']) ? htmlspecialchars($_GET['lon']) : CONST_Default_Lon,
+            'zoom' => $iZoom !== false ? $iZoom : CONST_Default_Zoom,
+            'lat'  => $fLat !== false ? $fLat : CONST_Default_Lat,
+            'lon'  => $fLon !== false ? $fLon : CONST_Default_Lon,
             'tile_url' => $sTileURL,
             'tile_attribution' => $sTileAttribution
         );
         echo 'var nominatim_map_init = ' . json_encode($aNominatimMapInit, JSON_PRETTY_PRINT) . ';';
 
-        echo 'var nominatim_results = ' . json_encode([isset($aPlace)?$aPlace:[]], JSON_PRETTY_PRINT) . ';'; 
+        echo 'var nominatim_results = ' . json_encode([$aPlace], JSON_PRETTY_PRINT) . ';'; 
     ?>
     </script>
     <?php include(CONST_BasePath.'/lib/template/includes/html-footer.php'); ?>

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -49,11 +49,12 @@ $sOsmType = $oParams->getSet('osm_type', array('N', 'W', 'R'));
 $iOsmId = $oParams->getInt('osm_id', -1);
 $fLat = $oParams->getFloat('lat');
 $fLon = $oParams->getFloat('lon');
+$iZoom = $oParams->getInt('zoom');
 if ($sOsmType && $iOsmId > 0) {
     $aPlace = $oPlaceLookup->lookupOSMID($sOsmType, $iOsmId);
 } elseif ($fLat !== false && $fLon !== false) {
     $oReverseGeocode = new Nominatim\ReverseGeocode($oDB);
-    $oReverseGeocode->setZoom($oParams->getInt('zoom', 18));
+    $oReverseGeocode->setZoom($iZoom !== false ? $iZoom : 18);
 
     $aLookup = $oReverseGeocode->lookup($fLat, $fLon);
     if (CONST_Debug) var_dump($aLookup);
@@ -86,6 +87,8 @@ if (isset($aPlace)) {
     if ($aOutlineResult) {
         $aPlace = array_merge($aPlace, $aOutlineResult);
     }
+} else {
+    $aPlace = [];
 }
 
 
@@ -94,7 +97,7 @@ if (CONST_Debug) {
     exit;
 }
 
-if ($sOutputFormat=='html') {
+if ($sOutputFormat == 'html') {
     $sDataDate = chksql($oDB->getOne("select TO_CHAR(lastimportdate - '2 minutes'::interval,'YYYY/MM/DD HH24:MI')||' GMT' from import_status limit 1"));
     $sTileURL = CONST_Map_Tile_URL;
     $sTileAttribution = CONST_Map_Tile_Attribution;

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -67,7 +67,7 @@ if ($sOsmType && $iOsmId > 0) {
     userError("Need coordinates or OSM object to lookup.");
 }
 
-if ($aPlace) {
+if (isset($aPlace)) {
     $oPlaceLookup->setIncludePolygonAsPoints(false);
     $oPlaceLookup->setIncludePolygonAsText($bAsText);
     $oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);


### PR DESCRIPTION
… empty results

This fixes 7 warnings for https://github.com/twain47/Nominatim/issues/547. I also checked search.php and details.php. Remember to copy `website/*.php` into `build/website/` when testing.
