### PR TITLE
Drop support for PHP < 5.4

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -38,7 +38,7 @@ For running Nominatim:
 
   * [PostgreSQL](http://www.postgresql.org) (9.1 or later)
   * [PostGIS](http://postgis.refractions.net) (2.0 or later)
-  * [PHP](http://php.net)
+  * [PHP](http://php.net) (5.4 or later)
   * PHP-pgsql
   * [PEAR::DB](http://pear.php.net/package/DB)
   * a webserver (apache or nginx are recommended)


### PR DESCRIPTION
PHP 5.3 has been out of production for two years now, so it should be safe to drop support for it. PHP 5.4 and 5.5 are actually end-of-life as well but CentOS 7 still ships with PHP 5.4. So we are going to be stuck with it for a while.