### PR TITLE
Tell users the website will be available at /search.php, not /

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -112,7 +112,7 @@ directory and create an alias:
 build directory.
 
 After making changes in the apache config you need to restart apache.
-The website should now be available on http://localhost/nominatim.
+The website should now be available on http://localhost/nominatim/search.php.
 
 #### Configure for use with Nginx
 
@@ -145,7 +145,7 @@ unix socket by adding the location definition to the default configuration.
     }
 
 Restart the nginx and php5-fpm services and the website should now be available
-on http://localhost/.
+on http://localhost/search.php.
 
 
 Now continue with [importing the database](Import_and_update.md).


### PR DESCRIPTION
Not the first time it got users (including myself) confused, see https://github.com/twain47/Nominatim/issues/591