### PR TITLE
housenumber interpolation: force calculated housenumber into range

### DIFF
--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -102,6 +102,20 @@ class PlaceLookup
         $bIsTiger = CONST_Use_US_Tiger_Data && $sType == 'tiger';
         $bIsInterpolation = $sType == 'interpolation';
 
+        // The 'greatest(1000,least(1006,someval))' construct makes sure that someval is >= 1000 and <= 1006
+        // Otherwise we'd end up with
+        // interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
+        $sSQLhousenumber  = " GREATEST(startnumber,LEAST(endnumber, ";
+        $sSQLhousenumber .= "   CASE ";
+        $sSQLhousenumber .= "     WHEN interpolationtype='odd' ";
+        $sSQLhousenumber .= "       THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
+        $sSQLhousenumber .= "     WHEN interpolationtype='even' ";
+        $sSQLhousenumber .= "       THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
+        $sSQLhousenumber .= "     WHEN interpolationtype='all' ";
+        $sSQLhousenumber .= "       THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
+        $sSQLhousenumber .= "   END";
+        $sSQLhousenumber .= " )) as housenumber";
+
         if ($bIsTiger) {
             $sSQL = "select place_id,partition, 'T' as osm_type, place_id as osm_id, 'place' as class, 'house' as type, null as admin_level, housenumber, null as street, null as isin, postcode,";
             $sSQL .= " 'us' as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search,";
@@ -113,10 +127,7 @@ class PlaceLookup
             if ($this->bNameDetails) $sSQL .= " null as names,";
             $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
             $sSQL .= " (select *, ";
-            $sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-            $sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-            $sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-            $sSQL .= " END as housenumber";
+            $sSQL .= $sSQLhousenumber;
             $sSQL .= " from location_property_tiger where place_id = ".$iPlaceID.") as blub1) as blub2";
         } elseif ($bIsInterpolation) {
             $sSQL = "select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode,";
@@ -129,14 +140,8 @@ class PlaceLookup
             if ($this->bNameDetails) $sSQL .= " null as names,";
             $sSQL .= " ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from ";
             $sSQL .= " (select *, ";
-            $sSQL .= " CASE WHEN interpolationtype='odd' THEN floor((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2+1";
-            $sSQL .= " WHEN interpolationtype='even' THEN ((".$fInterpolFraction."*(endnumber-startnumber)+startnumber)/2)::int*2";
-            $sSQL .= " WHEN interpolationtype='all' THEN (".$fInterpolFraction."*(endnumber-startnumber)+startnumber)::int";
-            $sSQL .= " END as housenumber";
+            $sSQL .= $sSQLhousenumber;
             $sSQL .= " from location_property_osmline where place_id = ".$iPlaceID.") as blub1) as blub2";
-            // testcase: interpolationtype=odd, startnumber=1000, endnumber=1006, fInterpolFraction=1 => housenumber=1007 => error in st_lineinterpolatepoint
-            // but this will never happen, because if the searched point is that close to the endnumber, the endnumber house will be directly taken from placex (in ReverseGeocode.php line 220)
-            // and not interpolated
         } else {
             $sSQL = "select placex.place_id, partition, osm_type, osm_id, class,";
             $sSQL .= " type, admin_level, housenumber, street, isin, postcode, country_code,";


### PR DESCRIPTION
We collected 50+ unique failures due to housenumber interpolation in reverse search when using the master branch.

Examples of affected coordinates
```
http://localhost:80/nominatim/reverse?format=jsonv2&lat=32.61393&lon=-16.98925
http://localhost:80/nominatim/reverse?format=jsonv2&lat=-23.5445217&lon=-46.5939133
http://localhost:80/nominatim/reverse?format=jsonv2&lat=-27.379749&lon=153.068848
http://localhost:80/nominatim/reverse?format=jsonv2&lat=-33.53406&lon=-70.7664483
http://localhost:80/nominatim/reverse?format=jsonv2&lat=-36.626919&lon=-71.8396
http://localhost:80/nominatim/reverse?format=jsonv2&lat=-5.785943&lon=-35.1996397
http://localhost:80/nominatim/reverse?format=jsonv2&lat=23.015966&lon=120.203583
http://localhost:80/nominatim/reverse?format=jsonv2&lat=48.907551&lon=2.144232
http://localhost:80/nominatim/reverse?format=jsonv2&lat=49.5786024&lon=-123.2247476
http://localhost:80/nominatim/reverse?format=jsonv2&lat=53.6576205&lon=-113.6640007
http://localhost:80/nominatim/reverse?format=jsonv2&lat=55.15658&lon=-118.8447
http://localhost:80/nominatim/reverse?format=jsonv2&lat=55.145117&lon=-118.795183
```

Those produce HTTP error 500. They work fine on nominatim.openstreetmap.org.

`
select place_id, partition, 'W' as osm_type, osm_id, 'place' as class, 'house' as type, null admin_level, housenumber, null as street, null as isin, postcode, calculated_country_code as country_code, parent_place_id, null as linked_place_id, 30 as rank_address, 30 as rank_search, (0.75-(30::float/40)) as importance, null as indexed_status, null as indexed_date, null as wikipedia, calculated_country_code,  get_address_by_language(place_id, housenumber, ARRAY['short_name:en','name:en','short_name','name','brand','official_name:en','official_name','ref','type']) as langaddress, null as placename, null as ref, ST_X(point) as lon, ST_Y(point) as lat from (select *, ST_LineInterpolatePoint(linegeo, (housenumber-startnumber::float)/(endnumber-startnumber)::float) as point from  (select *,  CASE WHEN interpolationtype='odd' THEN floor((1*(endnumber-startnumber)+startnumber)/2)::int*2+1 WHEN interpolationtype='even' THEN ((1*(endnumber-startnumber)+startnumber)/2)::int*2 WHEN interpolationtype='all' THEN (1*(endnumber-startnumber)+startnumber)::int END as housenumber from location_property_osmline where place_id = 11156537) as blub1) as blub2 [nativecode=ERROR:  line_interpolate_point: 2nd arg isn't within [0,1]]
`

Debugging `&lat=53.6576205&lon=-113.6640007` inside `PlaceLookup::lookup` shows the source data is http://www.openstreetmap.org/way/96683981 in Canada.
```
\x
select * from location_property_osmline where place_id=11156537;
-[ RECORD 1 ]-----------+-------------------------------------------------------------------------------------------
linegeo                 | 0102000020E6100000020000006A4DF38E536A5CC01645590927D44A40BB14B24E706A5CC0B698446227D44A40
place_id                | 11156537
partition               | 244
osm_id                  | 96683981
parent_place_id         | 72607367
startnumber             | 23
endnumber               | 36
interpolationtype       | odd
street                  | Doucette Place
addr_place              |
postcode                |
calculated_country_code | ca
geometry_sector         | 244614446
indexed_status          | 0
indexed_date            | 2016-11-28 07:02:17.777198
```

`$bIsInterpolation` is 1, `$bIsTiger` is 0, `$fInterpolFraction` is 1. In the subquery the housenumber gets set to 37 which breaks the main query.

Debugging `&lat=32.61393&lon=-16.98925` uses http://www.openstreetmap.org/way/165529129
in Portugal.

```
linegeo                 | 0102000020E61000000200000002C2E2CB9FF230C0C9E53FA4DF5140405467FF4D39F230C00E034CCFAA514040
osm_id                  | 165529129
startnumber             | 1
endnumber               | 20
interpolationtype       | even
```

`$bIsInterpolation` is 1, `$bIsTiger` is 0, `$fInterpolFraction` is 0. In the subquery the housenumber get set to 0 which breaks the main query.

What's a good approach to testing? I saw the `tests/scenes/bin/osm2wkt.cc` but it seems to ignore tags. Add a separate `*.osm` file or just standard api tests?