### PR TITLE
Fix for Russel Way in TIGER 2016 data

### DIFF
--- a/docs/Import_and_update.md
+++ b/docs/Import_and_update.md
@@ -85,11 +85,10 @@ instance by following these steps:
        * Ubuntu: `sudo apt-get install python-gdal`
        * CentOS: `sudo yum install gdal-python`
 
-  2. Get the TIGER 2015 data. You will need the EDGES files
-     (3,234 zip files, 11GB total). Choose one of the two sources:
+  2. Get the TIGER 2016 data. You will need the EDGES files
+     (3,234 zip files, 11GB total)
 
-         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2015/EDGES/
-         wget -r ftp://mirror1.shellbot.com/census/geo/tiger/TIGER2015/EDGES/
+         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2016/EDGES/
 
      The first one is the original source, the second a considerably faster
      mirror.

--- a/utils/tigerAddressImport.py
+++ b/utils/tigerAddressImport.py
@@ -3824,6 +3824,13 @@ def addressways(waylist, nodelist, first_id):
                 ltags.extend(tags)
                 rtags.extend(tags)
 
+                # A typo in the Tiger 2016 data. The 
+                if (name == "Russel Way") and (county == 'Belknap, NH'):
+                    zipl = zipl.replace("83809", "03809")
+                    zipr = zipr.replace("83809", "03809")
+
+
+
 #Write the nodes of the offset ways
                 if right:
                     rlinestring = [];


### PR DESCRIPTION
There's a typo in raw TIGER data putting a road in postcode 83809 instead of the correct 03809. This also affect the nearby road http://nominatim.openstreetmap.org/search.php?q=+27+NEW+DURHAM+RD%2C+ALTON%2C+NH%2C+03809

Since the next release takes 9 months I fixed in the conversion script, manually in my database(s) and added the road to OSM.

sql file before the fix:

`$ grep  'Belknap, NH' *.sql | grep 'Russel Way'`
`33001.sql:select tiger_line_import(ST_GeomFromText('LINESTRING(-71.195306 43.444608,-71.195088 43.444828,-71.194963 43.444997,-71.194760 43.445354,-71.194693 43.445393,-71.194613 43.445414,-71.194528 43.445414,-71.194349 43.445410,-71.194229 43.445384,-71.194223 43.445379)',4326), '1', '99', 'all', 'Russel Way', 'Belknap, NH', '03809');`
`33001.sql:select tiger_line_import(ST_GeomFromText('LINESTRING(-71.193928 43.445342,-71.193543 43.445338)',4326), '1', '99', 'all', 'Russel Way', 'Belknap, NH', '83809');
`