### PR TITLE
set directoryindex in Apache,nginx configuration

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -104,6 +104,7 @@ directory and create an alias:
     <Directory "/srv/nominatim/build/website">
       Options FollowSymLinks MultiViews
       AddType text/html   .php
+      DirectoryIndex search.php
       Require all granted
     </Directory>
     Alias /nominatim /srv/nominatim/build/website
@@ -134,13 +135,15 @@ follows:
 Tell nginx that php files are special and to fastcgi_pass to the php-fpm
 unix socket by adding the location definition to the default configuration.
 
+    root /srv/nominatim/build/website;
+    index search.php index.html;
     location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+?\.php)(/.*)$;
         if (!-f $document_root$fastcgi_script_name) {
             return 404;
         }
         fastcgi_pass unix:/var/run/php5-fpm.sock;
-        fastcgi_index index.php;
+        fastcgi_index search.php;
         include fastcgi.conf;
     }
 

--- a/vagrant/install-on-centos-7.sh
+++ b/vagrant/install-on-centos-7.sh
@@ -104,6 +104,7 @@ sudo tee /etc/httpd/conf.d/nominatim.conf << EOFAPACHECONF
 <Directory "$USERHOME/build/website"> #DOCS:<Directory "$USERHOME/Nominatim/build/website">
   Options FollowSymLinks MultiViews
   AddType text/html   .php
+  DirectoryIndex search.php
   Require all granted
 </Directory>
 

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -41,6 +41,7 @@ sudo tee /etc/apache2/conf-available/nominatim.conf << EOFAPACHECONF > /dev/null
     <Directory "$TRAVIS_BUILD_DIR/build/website">
       Options FollowSymLinks MultiViews
       AddType text/html   .php
+      DirectoryIndex search.php
       Require all granted
     </Directory>
 

--- a/vagrant/install-on-ubuntu-16.sh
+++ b/vagrant/install-on-ubuntu-16.sh
@@ -104,6 +104,7 @@ sudo tee /etc/apache2/conf-available/nominatim.conf << EOFAPACHECONF
 <Directory "$USERHOME/build/website"> #DOCS:<Directory "$USERHOME/Nominatim/build/website">
   Options FollowSymLinks MultiViews
   AddType text/html   .php
+  DirectoryIndex search.php
   Require all granted
 </Directory>
 


### PR DESCRIPTION
* Apache: easy change, works as expected.

* nginx: I tested the change locally. php-fpm paths are a little different in Ubuntu 16 (php7) and the user will have to change the `CONST_Website_BaseURL` as well because higher up in the instructions we say to set it to `/nominatim`. That said the nginx configuration is more advanced and I can't remember a user asking questions here. 