### PR TITLE
sMoreURL now includes countrycodes values

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -126,6 +126,12 @@ class Geocode
         return $this->aExcludePlaceIDs;
     }
 
+
+    public function getCountryCodes()
+    {
+        return $this->aCountryCodes;
+    }
+
     public function getViewBoxString()
     {
         if (!$this->aViewBox) return null;

--- a/website/search.php
+++ b/website/search.php
@@ -110,6 +110,7 @@ if ($bShowPolygons) $sMoreURL .= '&polygon=1';
 if ($oGeocode->getIncludeAddressDetails()) $sMoreURL .= '&addressdetails=1';
 if ($oGeocode->getIncludeExtraTags()) $sMoreURL .= '&extratags=1';
 if ($oGeocode->getIncludeNameDetails()) $sMoreURL .= '&namedetails=1';
+if ($oGeocode->getCountryCodes()) $sMoreURL .= '&countrycodes='.join(',', $oGeocode->getCountryCodes());
 if ($sViewBox) $sMoreURL .= '&viewbox='.urlencode($sViewBox);
 if (isset($_GET['nearlat']) && isset($_GET['nearlon'])) $sMoreURL .= '&nearlat='.(float)$_GET['nearlat'].'&nearlon='.(float)$_GET['nearlon'];
 $sMoreURL .= '&q='.urlencode($sQuery);


### PR DESCRIPTION
Change needed for https://github.com/twain47/Nominatim/issues/596

Test case:
http://localhost:80/nominatim/search.php?q=berlin&countrycodes=pl,1,,invalid,undefined,%3Cb%3E,bo,,

will have a more URL of 
http://localhost:80/nominatim/search.php?format=html&exclude_place_ids=41070666,40946476,42113413,41144443,41600467,45243901,44663498,25720789,44156375,44647722&accept-language=en-US,en;q=0.8,de;q=0.6&countrycodes=pl,bo&q=berlin