### PR TITLE
Better search radius for interpolations when reverse geocoding

### DIFF
--- a/test/bdd/api/search/params.feature
+++ b/test/bdd/api/search/params.feature
@@ -68,18 +68,18 @@ Feature: Search queries
     Scenario: Search with bounded viewbox in right area
         When sending json search query "restaurant" with address
           | bounded | viewbox |
-          | 1       | 9.93027,53.61634,10.10073,53.54500 |
+          | 1       | -56.16786,-34.84061,-56.12525,-34.86526 |
         Then result addresses contain
-          | state |
-          | Hamburg |
+          | city |
+          | Montevideo |
 
     Scenario: Search with bounded viewboxlbrt in right area
         When sending json search query "restaurant" with address
           | bounded | viewboxlbrt |
-          | 1       | 9.93027,53.54500,10.10073,53.61634 |
+          | 1       | -56.16786,-34.86526,-56.12525,-34.84061 |
         Then result addresses contain
-          | state |
-          | Hamburg |
+          | city |
+          | Montevideo |
 
     Scenario: No POI search with unbounded viewbox
         When sending json search query "restaurant"


### PR DESCRIPTION
Investigating #545, it turns out that the underlying cause is that reverse uses a larger radius when looking for interpolations than when looking for simple house numbers. So an interpolation may still be found even when the house numbers for the start and end points are outside the search radius. In that case, the end point of the interpolation may well be returned as an result (leading to fraction 1) while later the code assumes that this cannot be the case.

This PR fixes this by searching for interpolations only when $maxRank is larger than 26 (i.e. we are still looking for POIs).

@mtmail I've run the examples #593 and they work all fine with this PR. Would you mind quickly checking also the other 50 cases you have collected?

Fixes #545, supersedes #593.