### PR TITLE
Improve markdown of Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Here is a quick summary of the necessary steps.
 
 1. Compile Nominatim:
 
-     mkdir build
-     cd build
-     cmake ..
-     make
+        mkdir build
+        cd build
+        cmake ..
+        make
 
    For more detailed installation instructions see [docs/Installation.md](docs/Installation.md).
    There are also step-by-step instructions for
@@ -36,7 +36,7 @@ Here is a quick summary of the necessary steps.
 
 2. Get OSM data and import:
 
-     ./build/utils/setup.php --osm-file <your planet file> --all
+        ./build/utils/setup.php --osm-file <your planet file> --all
 
    Details can be found in [docs/Import_and_update.md](docs/Import_and_update.md)
 


### PR DESCRIPTION
Due to indentation issues (code within numbered list needs at least 8
spaces instead of 4) the code would not appear as code but as plain text
without a fixed size font and also without newlines appearing in the
HTML.

See the results here:
https://github.com/sebkur/Nominatim/tree/improve-readme-formatting