### PR TITLE
fix compilation error (cannot find -lpq)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ unset(PostgreSQL_TYPE_INCLUDE_DIR CACHE)
 set(PostgreSQL_TYPE_INCLUDE_DIR "/usr/include/")
 find_package(PostgreSQL REQUIRED)
 include_directories(${PostgreSQL_INCLUDE_DIRS})
+link_directories(${PostgreSQL_LIBRARY_DIRS})
+
 find_program(OSMOSIS osmosis)
 if (NOT EXISTS "${OSMOSIS}")
         set(OSMOSIS_PATH "/nonexistent")


### PR DESCRIPTION
Hello, 

i had a problem when compiling Nominatim on centos7 with postgresql 9.6 from pgdg repositories.
make failed with:

```
[ 95%] Building C object nominatim/CMakeFiles/nominatim.dir/sprompt.c.o
Linking CXX executable nominatim
/usr/bin/ld: cannot find -lpq
collect2: error: ld returned 1 exit status
make[2]: *** [nominatim/nominatim] Error 1
make[1]: *** [nominatim/CMakeFiles/nominatim.dir/all] Error 2
make: *** [all] Error 2
```
this commit show how i fixed it