### PR TITLE
Extra headers for compatibility on IE>8

### DIFF
--- a/lib/template/includes/html-header.php
+++ b/lib/template/includes/html-header.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>OpenStreetMap Nominatim: Search</title>
+    <meta content="IE=edge" http-equiv="x-ua-compatible" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <base href="<?php echo CONST_Website_BaseURL;?>" />


### PR DESCRIPTION
I encountered some problems on IE11 with compatibility mode actived (compat with IE7), the search page does not work at all.
We need some extra meta tags to work on all IE versions.
  